### PR TITLE
Add note about using RendererInterface::render()

### DIFF
--- a/docs/book/helpers/partial.md
+++ b/docs/book/helpers/partial.md
@@ -4,11 +4,6 @@ The `Partial` view helper is used to render a specified template within its own
 variable scope. The primary use is for reusable template fragments with which
 you do not need to worry about variable name clashes.
 
-> Note that it is also possible to render a template within its own variable
-> scope by calling `RendererInterface::render()` with a `$values` argument.
-> See the documentation for [`PhpRenderer`](../php-renderer.md#render) for
-> more information.
-
 A sibling to the `Partial`, the `PartialLoop` view helper allows you to pass
 iterable data, and render a partial for each item.
 
@@ -79,6 +74,14 @@ Which would then render:
 > `Laminas\Db\ResultSet\ResultSet`s to `partialLoop()`, as you then have full
 > access to your row objects within the view scripts, allowing you to call
 > methods on them (such as retrieving values from parent or dependent rows).
+
+> ### An alternative to using Partial
+>
+> Note that it is also possible to render a template within its own variable
+> scope by directly calling `RendererInterface::render()` with a `$values`
+> argument. You might prefer to do this if your model is an array, or an
+> object that implements `ArrayAccess`. See the documentation for
+> [`PhpRenderer`](../php-renderer.md#render) for more information.
 
 ## Using PartialLoop to Render Iterable Models
 

--- a/docs/book/helpers/partial.md
+++ b/docs/book/helpers/partial.md
@@ -4,6 +4,11 @@ The `Partial` view helper is used to render a specified template within its own
 variable scope. The primary use is for reusable template fragments with which
 you do not need to worry about variable name clashes.
 
+> Note that it is also possible to render a template within its own variable
+> scope by calling `RendererInterface::render()` with a `$values` argument.
+> See the documentation for [`PhpRenderer`](../php-renderer.md#render) for
+> more information.
+
 A sibling to the `Partial`, the `PartialLoop` view helper allows you to pass
 iterable data, and render a partial for each item.
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Adding a note about the possibility to use `RendererInterface::render()` instead.