### PR TITLE
Remove xdebug message on exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "laminas/laminas-escaper": "^2.5",
         "laminas/laminas-feed": "^2.7",
         "laminas/laminas-filter": "^2.6.1",
+        "laminas/laminas-form": "^2.14.5",
         "laminas/laminas-http": "^2.5.4",
         "laminas/laminas-i18n": "^2.6",
         "laminas/laminas-log": "^2.7",

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -10,6 +10,7 @@ namespace Laminas\View\Renderer;
 
 use ArrayAccess;
 use Laminas\Filter\FilterChain;
+use Laminas\Form\Exception\InvalidElementException;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Exception;
 use Laminas\View\Helper\AbstractHelper;
@@ -506,9 +507,15 @@ class PhpRenderer implements Renderer, TreeRendererInterface
                 $this->__content = ob_get_clean();
             } catch (\Throwable $ex) {
                 ob_end_clean();
+                if ($ex instanceof InvalidElementException && isset($ex->xdebug_message)) {
+                    $ex->xdebug_message = null;
+                }
                 throw $ex;
             } catch (\Exception $ex) { // @TODO clean up once PHP 7 requirement is enforced
                 ob_end_clean();
+                if ($ex instanceof InvalidElementException && isset($ex->xdebug_message)) {
+                    $ex->xdebug_message = null;
+                }
                 throw $ex;
             }
             if ($includeReturn === false && empty($this->__content)) {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | yes
| QA            | no

### Description

If a non existing form fieldset/element should be rendered, and xdebug is currently enabled, the exception will contain a public property called `xdebug_message` containing html formatted message.
 
That message will be huge (500+MB in my case) depending on the complexity of the form (see screenshot).

https://imgur.com/a/p90IxRR

For most browser this will result in 
- waiting a long time 
- and finally get a blank page as the amount of data is too big

I you don't look at the network manager you'll have no clue what is going on.