### PR TITLE
Doctype ViewHelper Factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /laminas-mkdoc-theme/
 /phpunit.xml
 /vendor/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ matrix:
     - php: 7.4
       env:
         - DEPS=latest
-    - php: nightly
+    - php: 8.0
       env:
         - DEPS=lowest
         - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
-    - php: nightly
+    - php: 8.0
       env:
         - DEPS=latest
         - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ## 2.12.0 - TBD
 
+### Added
+
+- [#59](https://github.com/laminas/laminas-view/pull/59) Adds a `Doctype` factory which applies configuration provided via the `view_helper_config` config key in **non Laminas MVC projects**.
+
 - [#58](https://github.com/laminas/laminas-view/pull/58) Adds PHP 8.0 support
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,6 @@
     "config": {
         "sort-packages": true
     },
-    "extra": {
-    },
     "require": {
         "php": "^7.3 || ~8.0.0",
         "laminas/laminas-eventmanager": "^3.0",
@@ -47,12 +45,15 @@
         "laminas/laminas-permissions-acl": "^2.6",
         "laminas/laminas-router": "^3.0.1",
         "laminas/laminas-serializer": "^2.6.1",
-        "laminas/laminas-servicemanager": "^3.0.3",
+        "laminas/laminas-servicemanager": "^3.3",
         "laminas/laminas-session": "^2.8.1",
         "laminas/laminas-uri": "^2.5",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpspec/prophecy": "^1.12",
         "phpunit/phpunit": "^9.3"
+    },
+    "conflict": {
+        "laminas/laminas-servicemanager": "<3.3"
     },
     "suggest": {
         "laminas/laminas-authentication": "Laminas\\Authentication component",

--- a/docs/book/helpers/doctype.md
+++ b/docs/book/helpers/doctype.md
@@ -45,11 +45,31 @@ And then print it out on top of your layout script:
 <?php echo $this->doctype() ?>
 ```
 
-Within an application based off the [laminas-mvc-skeleton](https://github.com/laminas/laminas-mvc-skeleton),
-you can specify the doctype via configuration:
+## Usage in a Mezzio Application
+
+The factory `Laminas\View\Helper\Service\DoctypeFactory` checks the application configuration, making it possible to
+define the doctype through your configuration, e.g. `config/autoload/mezzio.global.php`
+or a `ConfigProvider.php` in a module.
+
+For example, add the following lines to your `config/autoload/mezzio.global.php` file to set the `Doctype` to HTML5:
 
 ```php
-// module/Application/config/module.config.php:
+return [
+    /* ... */
+    'view_helper_config' => [
+        'doctype' => \Laminas\View\Helper\Doctype::HTML5,
+    ],
+];
+```
+
+## Usage in a laminas-mvc Application
+
+If you're running a [laminas-mvc](https://docs.laminas.dev/laminas-mvc/) application, you should specify doctype via the
+[ViewManager](https://docs.laminas.dev/laminas-mvc/services/#viewmanager) service.
+
+Add the following lines to your `config/autoload/global.php` file to set the `Doctype` to HTML5:
+
+```php
 return [
     /* ... */
     'view_manager' => [
@@ -128,8 +148,3 @@ Here is how you check if the doctype is set to `XHTML1_RDFA`:
     <?php endif; ?>
 >
 ```
-
-## Laminas MVC View Manager
-
-If you're running a LaminasMvc application, you should specify doctype via the
-[ViewManager](https://docs.laminas.dev/laminas-mvc/services/#viewmanager) service.

--- a/docs/book/helpers/doctype.md
+++ b/docs/book/helpers/doctype.md
@@ -73,7 +73,7 @@ Add the following lines to your `config/autoload/global.php` file to set the `Do
 return [
     /* ... */
     'view_manager' => [
-        'doctype' => 'html5',
+        'doctype' => \Laminas\View\Helper\Doctype::HTML5,
         /* ... */
     ],
 ];

--- a/src/Helper/Service/DoctypeFactory.php
+++ b/src/Helper/Service/DoctypeFactory.php
@@ -8,23 +8,12 @@
 
 namespace Laminas\View\Helper\Service;
 
-use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\Factory\FactoryInterface;
-use Laminas\View\Exception;
 use Laminas\View\Helper\Doctype;
+use Psr\Container\ContainerInterface;
 
-class DoctypeFactory implements FactoryInterface
+final class DoctypeFactory
 {
-    /**
-     * {@inheritDoc}
-     *
-     * @param ContainerInterface $container
-     * @param string             $name
-     * @param null|array         $options
-     * @return Doctype
-     * @throws Exception\RuntimeException
-     */
-    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    public function __invoke(ContainerInterface $container): Doctype
     {
         $helper = new Doctype();
 

--- a/src/Helper/Service/DoctypeFactory.php
+++ b/src/Helper/Service/DoctypeFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-view for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-view/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-view/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\View\Helper\Service;
+
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\View\Exception;
+use Laminas\View\Helper\Doctype;
+
+class DoctypeFactory implements FactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @param ContainerInterface $container
+     * @param string             $name
+     * @param null|array         $options
+     * @return Doctype
+     * @throws Exception\RuntimeException
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        $helper = new Doctype();
+
+        if (! $container->has('config')) {
+            return $helper;
+        }
+        $config = $container->get('config');
+        if (isset($config['view_helper_config']['doctype'])) {
+            $helper->setDoctype($config['view_helper_config']['doctype']);
+        }
+
+        return $helper;
+    }
+}

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -231,7 +231,8 @@ class HelperPluginManager extends AbstractPluginManager
         Helper\BasePath::class            => InvokableFactory::class,
         Helper\Cycle::class               => InvokableFactory::class,
         Helper\DeclareVars::class         => InvokableFactory::class,
-        Helper\Doctype::class             => InvokableFactory::class, // overridden in ViewHelperManagerFactory
+        // overridden in ViewHelperManagerFactory
+        Helper\Doctype::class             => Helper\Service\DoctypeFactory::class,
         Helper\EscapeHtml::class          => InvokableFactory::class,
         Helper\EscapeHtmlAttr::class      => InvokableFactory::class,
         Helper\EscapeJs::class            => InvokableFactory::class,

--- a/test/Helper/DoctypeTest.php
+++ b/test/Helper/DoctypeTest.php
@@ -209,4 +209,9 @@ class DoctypeTest extends TestCase
         $this->assertEquals('<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">', $string);
         // @codingStandardsIgnoreEnd
     }
+
+    public function testDoctypeDefaultsToHtml4Loose()
+    {
+        self::assertSame(Helper\Doctype::HTML4_LOOSE, $this->helper->getDoctype());
+    }
 }

--- a/test/Helper/Service/DoctypeFactoryTest.php
+++ b/test/Helper/Service/DoctypeFactoryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-view for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-view/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-view/blob/master/LICENSE.md New BSD License
+ */
+
+namespace LaminasTest\View\Helper\Service;
+
+use Interop\Container\ContainerInterface;
+use Laminas\View\Helper\Doctype;
+use Laminas\View\Helper\Service\DoctypeFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class DoctypeFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Doctype::unsetDoctypeRegistry();
+    }
+
+    public function testServiceIsCreatedOnInvocation(): void
+    {
+        $container = $this->createContainer();
+
+        $factory = new DoctypeFactory();
+        $service = $factory($container, '');
+
+        self::assertInstanceOf(Doctype::class, $service);
+    }
+
+    public function testFactorySetsDoctypeBasedOnConfig(): void
+    {
+        $config    = ['view_helper_config' => ['doctype' => Doctype::XHTML1_STRICT]];
+        $container = $this->createContainer($config);
+
+        $factory = new DoctypeFactory();
+        $service = $factory($container, '');
+
+        self::assertSame(Doctype::XHTML1_STRICT, $service->getDoctype());
+    }
+
+    public function testDefaultDoctypeIsUsedIfConfigIsMissing(): void
+    {
+        $config    = ['view_helper_config' => []];
+        $container = $this->createContainer($config);
+
+        $factory = new DoctypeFactory();
+        $service = $factory($container, '');
+
+        self::assertSame(Doctype::HTML4_LOOSE, $service->getDoctype());
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return ContainerInterface & MockObject
+     */
+    private function createContainer(array $config = [])
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->willReturn(true);
+        $container->method('get')->with('config')->willReturn($config);
+        return $container;
+    }
+}

--- a/test/HelperPluginManagerTest.php
+++ b/test/HelperPluginManagerTest.php
@@ -16,6 +16,7 @@ use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Exception\InvalidHelperException;
+use Laminas\View\Helper\Doctype;
 use Laminas\View\Helper\HeadTitle;
 use Laminas\View\Helper\HelperInterface;
 use Laminas\View\Helper\Url;
@@ -30,6 +31,9 @@ use Prophecy\PhpUnit\ProphecyTrait;
 class HelperPluginManagerTest extends TestCase
 {
     use ProphecyTrait;
+
+    /** @var HelperPluginManager */
+    private $helpers;
 
     protected function setUp(): void
     {
@@ -243,6 +247,11 @@ class HelperPluginManagerTest extends TestCase
         );
         $config->configureServiceManager($helpers);
         $this->assertSame($helper, $helpers->get('foo'));
+    }
+
+    public function testDoctypeFactoryExists()
+    {
+        self::assertTrue($this->helpers->has(Doctype::class));
     }
 
     private function getServiceNotFoundException(HelperPluginManager $manager)


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

This PR adds a factory for the `Doctype` view helper, to be able to configure the used doctype via configuration.
The factory is registered with the default factories in the `HelperPluginManager`.
Also, a test checks if the default doctype is HTML4_LOOSE.

fixes #50 