### PR TITLE
Missing dev dependencies causing tests to fail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,8 @@
         "laminas/laminas-log": "^2.7",
         "laminas/laminas-modulemanager": "^2.7.1",
         "laminas/laminas-mvc": "^2.7.14 || ^3.0",
+        "laminas/laminas-mvc-i18n": "^1.1",
+        "laminas/laminas-mvc-plugin-flashmessenger": "^1.2",
         "laminas/laminas-navigation": "^2.5",
         "laminas/laminas-paginator": "^2.5",
         "laminas/laminas-permissions-acl": "^2.6",


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Documentation |no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Tests fail because of missing dependencies on Laminas MVC Flash Messenger and I18n packages. Both added as dev dependencies.
