### PR TITLE
Laminas\Json dependency removal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-json": "*",
         "laminas/laminas-eventmanager": "^3.4",
-        "laminas/laminas-json": "^3.3",
         "laminas/laminas-stdlib": "^3.6"
     },
     "require-dev": {

--- a/docs/book/helpers/json.md
+++ b/docs/book/helpers/json.md
@@ -19,29 +19,3 @@ determine how to handle the content.
 ```php
 <?= $this->json($this->data) ?>
 ```
-
-> WARNING: **Deprecated**
->
-> ### Enabling encoding using Laminas\Json\Expr
->
-> **This feature of the Json view helper has been deprecated in version 2.16 and will be removed in version 3.0.**
->
-> The JSON helper accepts an array of options that will be passed to `Laminas\Json\Json::encode()` and
-> used internally to encode data.
-> `Laminas\Json\Json::encode` allows the encoding of native JSON expressions using `Laminas\Json\Expr`
-> objects. This option is disabled by default. To enable this option, pass a boolean `true` to the
-> `enableJsonExprFinder` key of the options array:
->
-> ```php
-> <?= $this->json($this->data, ['enableJsonExprFinder' => true]) ?>
-> ``
->
-> The JSON helper accepts an array of options that will be passed to `Laminas\Json\Json::encode()` and
-> used internally to encode data.
-> `Laminas\Json\Json::encode` allows the encoding of native JSON expressions using `Laminas\Json\Expr`
-> objects. This option is disabled by default. To enable this option, pass a boolean `true` to the
-> `enableJsonExprFinder` key of the options array:
->
-> ```php
-> <?= $this->json($this->data, ['enableJsonExprFinder' => true]) ?>
-> ```

--- a/src/Helper/AbstractHtmlElement.php
+++ b/src/Helper/AbstractHtmlElement.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\View\Helper;
 
 use function assert;
+use function json_encode;
 use function str_replace;
 use function strlen;
 use function strpos;

--- a/src/Helper/AbstractHtmlElement.php
+++ b/src/Helper/AbstractHtmlElement.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Laminas\View\Helper;
 
 use function assert;
-use function json_encode;
 use function str_replace;
 use function strlen;
 use function strpos;

--- a/src/Helper/Json.php
+++ b/src/Helper/Json.php
@@ -7,9 +7,7 @@ namespace Laminas\View\Helper;
 use Laminas\Http\Response;
 
 use function json_encode;
-use function trigger_error;
 
-use const E_USER_DEPRECATED;
 use const JSON_PRETTY_PRINT;
 use const JSON_THROW_ON_ERROR;
 
@@ -18,7 +16,7 @@ use const JSON_THROW_ON_ERROR;
  */
 class Json extends AbstractHelper
 {
-    /** @var Response */
+    /** @var Response|null */
     protected $response;
 
     /**
@@ -26,7 +24,7 @@ class Json extends AbstractHelper
      *
      * @param  mixed $data
      * @param  array $jsonOptions Options to pass to JsonFormatter::encode()
-     * @return string|void
+     * @return string
      */
     public function __invoke($data, array $jsonOptions = [])
     {
@@ -40,15 +38,11 @@ class Json extends AbstractHelper
         return $data;
     }
 
-    private function optionsToFlags(array $options = []) : int
+    private function optionsToFlags(array $options = []): int
     {
         $prettyPrint = $options['prettyPrint'] ?? false;
-        $flags = JSON_THROW_ON_ERROR;
-        $flags |= $prettyPrint ? 0 : JSON_PRETTY_PRINT;
-        $enableExpr = $options['enableJsonExprFinder'] ?? false;
-        if ($enableExpr) {
-            trigger_error('Json Expression Finder options are no longer available', E_USER_DEPRECATED);
-        }
+        $flags       = JSON_THROW_ON_ERROR;
+        $flags      |= $prettyPrint ? 0 : JSON_PRETTY_PRINT;
 
         return $flags;
     }

--- a/src/Helper/Json.php
+++ b/src/Helper/Json.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Laminas\View\Helper;
 
 use Laminas\Http\Response;
-use Laminas\Json\Json as JsonFormatter;
 
+use function json_encode;
 use function trigger_error;
 
 use const E_USER_DEPRECATED;
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
 
 /**
  * Helper for simplifying JSON responses
@@ -28,14 +30,7 @@ class Json extends AbstractHelper
      */
     public function __invoke($data, array $jsonOptions = [])
     {
-        if (isset($jsonOptions['enableJsonExprFinder']) && $jsonOptions['enableJsonExprFinder'] === true) {
-            trigger_error(
-                'Json Expression functionality is deprecated and will be removed in laminas-view 3.0',
-                E_USER_DEPRECATED
-            );
-        }
-
-        $data = JsonFormatter::encode($data, null, $jsonOptions);
+        $data = json_encode($data, $this->optionsToFlags($jsonOptions));
 
         if ($this->response instanceof Response) {
             $headers = $this->response->getHeaders();
@@ -43,6 +38,19 @@ class Json extends AbstractHelper
         }
 
         return $data;
+    }
+
+    private function optionsToFlags(array $options = []) : int
+    {
+        $prettyPrint = $options['prettyPrint'] ?? false;
+        $flags = JSON_THROW_ON_ERROR;
+        $flags |= $prettyPrint ? 0 : JSON_PRETTY_PRINT;
+        $enableExpr = $options['enableJsonExprFinder'] ?? false;
+        if ($enableExpr) {
+            trigger_error('Json Expression Finder options are no longer available', E_USER_DEPRECATED);
+        }
+
+        return $flags;
     }
 
     /**

--- a/src/Model/JsonModel.php
+++ b/src/Model/JsonModel.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace Laminas\View\Model;
 
-use Laminas\Json\Json;
+use JsonException;
 use Laminas\Stdlib\ArrayUtils;
+use Laminas\View\Exception\DomainException;
 use Traversable;
+
+use function json_encode;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
 
 class JsonModel extends ViewModel
 {
@@ -56,13 +62,21 @@ class JsonModel extends ViewModel
             $variables = ArrayUtils::iteratorToArray($variables);
         }
 
-        $options = [
-            'prettyPrint' => $this->getOption('prettyPrint'),
-        ];
+        $options = (bool) $this->getOption('prettyPrint', false) ? JSON_PRETTY_PRINT : 0;
 
         if (null !== $this->jsonpCallback) {
-            return $this->jsonpCallback . '(' . Json::encode($variables, false, $options) . ');';
+            return $this->jsonpCallback.'('.$this->jsonEncode($variables, $options).');';
         }
-        return Json::encode($variables, false, $options);
+        return $this->jsonEncode($variables, $options);
+    }
+
+    /** @param mixed $data */
+    private function jsonEncode($data, int $options): string
+    {
+        try {
+            return json_encode($data, $options | JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new DomainException('Failed to encode Json', $e->getCode(), $e);
+        }
     }
 }

--- a/src/Model/JsonModel.php
+++ b/src/Model/JsonModel.php
@@ -65,7 +65,7 @@ class JsonModel extends ViewModel
         $options = (bool) $this->getOption('prettyPrint', false) ? JSON_PRETTY_PRINT : 0;
 
         if (null !== $this->jsonpCallback) {
-            return $this->jsonpCallback.'('.$this->jsonEncode($variables, $options).');';
+            return $this->jsonpCallback . '(' . $this->jsonEncode($variables, $options) . ');';
         }
         return $this->jsonEncode($variables, $options);
     }

--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -68,6 +68,8 @@ class JsonRenderer implements Renderer, TreeRendererInterface
     public function setResolver(Resolver $resolver)
     {
         $this->resolver = $resolver;
+
+        return $this;
     }
 
     /**

--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Laminas\View\Renderer;
 
 use ArrayAccess;
+use JsonException;
 use JsonSerializable;
-use Laminas\Json\Json;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\View\Exception;
 use Laminas\View\Model\JsonModel;
@@ -18,7 +18,10 @@ use Traversable;
 use function array_replace_recursive;
 use function get_object_vars;
 use function is_object;
+use function json_encode;
 use function sprintf;
+
+use const JSON_THROW_ON_ERROR;
 
 /**
  * JSON renderer
@@ -131,28 +134,27 @@ class JsonRenderer implements Renderer, TreeRendererInterface
             if ($nameOrModel instanceof JsonModel) {
                 $children = $this->recurseModel($nameOrModel, false);
                 $this->injectChildren($nameOrModel, $children);
-                $values = $nameOrModel->serialize();
+                $output = $nameOrModel->serialize();
             } else {
-                $values = $this->recurseModel($nameOrModel);
-                $values = Json::encode($values);
+                $output = $this->recurseModel($nameOrModel);
+                $output = $this->jsonEncode($output);
             }
 
             if ($this->hasJsonpCallback()) {
-                $values = $this->jsonpCallback . '(' . $values . ');';
+                $output = $this->jsonpCallback . '(' . $output . ');';
             }
-            return $values;
+            return $output;
         }
 
         // use case 2: $nameOrModel is populated, $values is not
         // Serialize $nameOrModel
         if (null === $values) {
             if (! is_object($nameOrModel) || $nameOrModel instanceof JsonSerializable) {
-                $return = Json::encode($nameOrModel);
+                $return = $this->jsonEncode($nameOrModel);
             } elseif ($nameOrModel instanceof Traversable) {
-                $nameOrModel = ArrayUtils::iteratorToArray($nameOrModel);
-                $return      = Json::encode($nameOrModel);
+                $return = $this->jsonEncode(ArrayUtils::iteratorToArray($nameOrModel));
             } else {
-                $return = Json::encode(get_object_vars($nameOrModel));
+                $return = $this->jsonEncode(get_object_vars($nameOrModel));
             }
 
             if ($this->hasJsonpCallback()) {
@@ -235,6 +237,15 @@ class JsonRenderer implements Renderer, TreeRendererInterface
         foreach ($children as $child => $value) {
             // TODO detect collisions and decide whether to append and/or aggregate?
             $model->setVariable($child, $value);
+        }
+    }
+
+    private function jsonEncode($data): string
+    {
+        try {
+            return json_encode($data, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new Exception\DomainException('Json encoding failed', $e->getCode(), $e);
         }
     }
 }

--- a/test/Helper/JsonTest.php
+++ b/test/Helper/JsonTest.php
@@ -6,9 +6,12 @@ namespace LaminasTest\View\Helper;
 
 use Laminas\Http\Header\HeaderInterface;
 use Laminas\Http\Response;
-use Laminas\Json\Json as JsonFormatter;
 use Laminas\View\Helper\Json as JsonHelper;
 use PHPUnit\Framework\TestCase;
+
+use function json_encode;
+
+use const JSON_THROW_ON_ERROR;
 
 /**
  * Test class for Laminas\View\Helper\Json
@@ -34,7 +37,7 @@ class JsonTest extends TestCase
         $this->helper->setResponse($this->response);
     }
 
-    public function verifyJsonHeader(): void
+    private function verifyJsonHeader(): void
     {
         $headers = $this->response->getHeaders();
         $this->assertTrue($headers->has('Content-Type'));
@@ -51,9 +54,13 @@ class JsonTest extends TestCase
 
     public function testJsonHelperReturnsJsonEncodedString(): void
     {
-        $data = $this->helper->__invoke('foobar');
-        $this->assertIsString($data);
-        $this->assertEquals('foobar', JsonFormatter::decode($data));
+        $input = [
+            'dory' => 'blue',
+            'nemo' => 'orange',
+        ];
+        $expect = json_encode($input, JSON_THROW_ON_ERROR);
+
+        self::assertJsonStringEqualsJsonString($expect, ($this->helper)($input));
     }
 
     public function testThatADeprecationErrorIsTriggeredWhenExpressionFinderOptionIsUsed(): void

--- a/test/Helper/JsonTest.php
+++ b/test/Helper/JsonTest.php
@@ -54,24 +54,12 @@ class JsonTest extends TestCase
 
     public function testJsonHelperReturnsJsonEncodedString(): void
     {
-        $input = [
+        $input  = [
             'dory' => 'blue',
             'nemo' => 'orange',
         ];
         $expect = json_encode($input, JSON_THROW_ON_ERROR);
 
         self::assertJsonStringEqualsJsonString($expect, ($this->helper)($input));
-    }
-
-    public function testThatADeprecationErrorIsTriggeredWhenExpressionFinderOptionIsUsed(): void
-    {
-        $this->expectDeprecation();
-        $this->helper->__invoke(['foo'], ['enableJsonExprFinder' => true]);
-    }
-
-    public function testThatADeprecationErrorIsNotTriggeredWhenExpressionFinderOptionIsNotUsed(): void
-    {
-        $this->expectNotToPerformAssertions();
-        $this->helper->__invoke(['foo'], ['enableJsonExprFinder' => 'anything other than true']);
     }
 }

--- a/test/Model/JsonModelTest.php
+++ b/test/Model/JsonModelTest.php
@@ -10,6 +10,7 @@ use Laminas\View\Variables;
 use PHPUnit\Framework\TestCase;
 
 use function json_encode;
+use function sprintf;
 
 use const JSON_PRETTY_PRINT;
 use const JSON_THROW_ON_ERROR;
@@ -45,7 +46,7 @@ class JsonModelTest extends TestCase
 
     public function testPrettyPrint(): void
     {
-        $array = [
+        $array  = [
             'simple'              => 'simple test string',
             'stringwithjsonchars' => '\"[1,2]',
             'complex'             => [
@@ -53,7 +54,7 @@ class JsonModelTest extends TestCase
                 'far' => 'boo',
             ],
         ];
-        $model = new JsonModel($array, ['prettyPrint' => true]);
+        $model  = new JsonModel($array, ['prettyPrint' => true]);
         $expect = json_encode($array, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
         $this->assertEquals($expect, $model->serialize());
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

As per [TSC #68](https://github.com/laminas/technical-steering-committee/issues/68), this pull removes the dev dependency on Laminas\Json.

- Removes Laminas\Json from deps
- Replaces encoding using built-in `json_encode` with `JSON_THROW_ON_ERROR`. Mostly, Json exceptions are wrapped to throw a Zend\View\Exception, which I guess is a BC break?
- c6537c1 Fixes missing fluent return
- The Json view helper no longer does the Json\Expr stuff, so if the option to turn this thing on is present, a deprecation warning is issued - perhaps this is not the best way to deal with that scenario.
- Fixes #33