### PR TITLE
Update Composer lock file and fix test failures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "phpunit/phpunit": "^9.3"
     },
     "conflict": {
-        "laminas/laminas-servicemanager": "<3.3"
+        "laminas/laminas-servicemanager": "<3.3",
+        "laminas/laminas-router": "<3.0.1"
     },
     "suggest": {
         "laminas/laminas-authentication": "Laminas\\Authentication component",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "laminas/laminas-mvc": "^2.7.14 || ^3.0",
         "laminas/laminas-mvc-i18n": "^1.1",
         "laminas/laminas-mvc-plugin-flashmessenger": "^1.2",
-        "laminas/laminas-navigation": "^2.5",
+        "laminas/laminas-navigation": "^2.8.1",
         "laminas/laminas-paginator": "^2.5",
         "laminas/laminas-permissions-acl": "^2.6",
         "laminas/laminas-router": "^3.0.1",
@@ -50,8 +50,8 @@
         "laminas/laminas-servicemanager": "^3.3",
         "laminas/laminas-session": "^2.8.1",
         "laminas/laminas-uri": "^2.5",
-        "phpspec/prophecy-phpunit": "^2.0",
         "phpspec/prophecy": "^1.12",
+        "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.3"
     },
     "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6df737fff645eed77625bee1f034bc29",
+    "content-hash": "e4dafcda3a5ecc1585516c3011e1f6e5",
     "packages": [
         {
             "name": "laminas/laminas-eventmanager",
@@ -2297,6 +2297,150 @@
                 }
             ],
             "time": "2020-12-14T21:54:40+00:00"
+        },
+        {
+            "name": "laminas/laminas-mvc-i18n",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-mvc-i18n.git",
+                "reference": "4184f6572b5244a5f5781604f1e03d7955e304a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-mvc-i18n/zipball/4184f6572b5244a5f5781604f1e03d7955e304a0",
+                "reference": "4184f6572b5244a5f5781604f1e03d7955e304a0",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "laminas/laminas-i18n": "^2.7",
+                "laminas/laminas-router": "^3.0",
+                "laminas/laminas-servicemanager": "^2.7.10 || ^3.0.3",
+                "laminas/laminas-stdlib": "^2.7.6 || ^3.0",
+                "laminas/laminas-validator": "^2.6",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "conflict": {
+                "laminas/laminas-mvc": "<3.0.0",
+                "phpspec/prophecy": "<1.8.0"
+            },
+            "replace": {
+                "zendframework/zend-mvc-i18n": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-cache": "^2.6.1",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.5"
+            },
+            "suggest": {
+                "laminas/laminas-cache": "To enable caching of translation strings"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev",
+                    "dev-develop": "1.2.x-dev"
+                },
+                "laminas": {
+                    "component": "Laminas\\Mvc\\I18n",
+                    "config-provider": "Laminas\\Mvc\\I18n\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Mvc\\I18n\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Integration between laminas-mvc and laminas-i18n",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "i18n",
+                "laminas",
+                "mvc"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-mvc-i18n/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-mvc-i18n/issues",
+                "rss": "https://github.com/laminas/laminas-mvc-i18n/releases.atom",
+                "source": "https://github.com/laminas/laminas-mvc-i18n"
+            },
+            "time": "2019-12-31T17:33:41+00:00"
+        },
+        {
+            "name": "laminas/laminas-mvc-plugin-flashmessenger",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-mvc-plugin-flashmessenger.git",
+                "reference": "f5a522c3aab215a9b89a0630beb91582f4a3f202"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-mvc-plugin-flashmessenger/zipball/f5a522c3aab215a9b89a0630beb91582f4a3f202",
+                "reference": "f5a522c3aab215a9b89a0630beb91582f4a3f202",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-mvc": "^3.0",
+                "laminas/laminas-session": "^2.8.5",
+                "laminas/laminas-stdlib": "^3.2.1",
+                "laminas/laminas-view": "^2.10",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "conflict": {
+                "laminas/laminas-mvc": "<3.0.0"
+            },
+            "replace": {
+                "zendframework/zend-mvc-plugin-flashmessenger": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-i18n": "^2.8",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev",
+                    "dev-develop": "1.3.x-dev"
+                },
+                "laminas": {
+                    "component": "Laminas\\Mvc\\Plugin\\FlashMessenger"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Mvc\\Plugin\\FlashMessenger\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Plugin for creating and exposing flash messages via laminas-mvc controllers",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "mvc"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-mvc-plugin-flashmessenger/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-mvc-plugin-flashmessenger/issues",
+                "rss": "https://github.com/laminas/laminas-mvc-plugin-flashmessenger/releases.atom",
+                "source": "https://github.com/laminas/laminas-mvc-plugin-flashmessenger"
+            },
+            "time": "2019-12-31T17:33:46+00:00"
         },
         {
             "name": "laminas/laminas-navigation",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4dafcda3a5ecc1585516c3011e1f6e5",
+    "content-hash": "617a9b3e2948b76bc82a871747a69841",
     "packages": [
         {
             "name": "laminas/laminas-eventmanager",

--- a/test/Helper/Navigation/AbstractTest.php
+++ b/test/Helper/Navigation/AbstractTest.php
@@ -10,7 +10,6 @@ namespace LaminasTest\View\Helper\Navigation;
 
 use Laminas\Config\Factory as ConfigFactory;
 use Laminas\I18n\Translator\Translator;
-use Laminas\Mvc\Router\RouteMatch as V2RouteMatch;
 use Laminas\Mvc\Service\ServiceManagerConfig;
 use Laminas\Navigation\Navigation;
 use Laminas\Navigation\Service\DefaultNavigationFactory;
@@ -18,7 +17,7 @@ use Laminas\Permissions\Acl\Acl;
 use Laminas\Permissions\Acl\Resource\GenericResource;
 use Laminas\Permissions\Acl\Role\GenericRole;
 use Laminas\Router\ConfigProvider as RouterConfigProvider;
-use Laminas\Router\RouteMatch as V3RouteMatch;
+use Laminas\Router\RouteMatch;
 use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Renderer\PhpRenderer;
@@ -77,8 +76,6 @@ abstract class AbstractTest extends TestCase
      * @var Navigation\Navigation
      */
     protected $_nav3;
-
-    private $_oldControllerDir;
     // @codingStandardsIgnoreEnd
 
     /**
@@ -88,10 +85,6 @@ abstract class AbstractTest extends TestCase
     protected function setUp(): void
     {
         $cwd = __DIR__;
-
-        $this->routeMatchType = class_exists(V2RouteMatch::class)
-            ? V2RouteMatch::class
-            : V3RouteMatch::class;
 
         // read navigation config
         $this->_files = $cwd . '/_files';
@@ -157,7 +150,7 @@ abstract class AbstractTest extends TestCase
         $sm->setAllowOverride(false);
 
         $app = $this->serviceManager->get('Application');
-        $app->getMvcEvent()->setRouteMatch(new $this->routeMatchType([
+        $app->getMvcEvent()->setRouteMatch(new RouteMatch([
             'controller' => 'post',
             'action'     => 'view',
             'id'         => '1337',

--- a/test/Helper/UrlIntegrationTest.php
+++ b/test/Helper/UrlIntegrationTest.php
@@ -9,7 +9,6 @@
 namespace LaminasTest\View\Helper;
 
 use Laminas\Console\Console;
-use Laminas\Console\Request;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Mvc\Service\ServiceListenerFactory;
 use Laminas\Mvc\Service\ServiceManagerConfig;
@@ -17,6 +16,7 @@ use Laminas\Router\ConfigProvider as RouterConfigProvider;
 use Laminas\Router\Http;
 use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\ServiceManager;
+use Laminas\Stdlib\RequestInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -112,7 +112,10 @@ class UrlIntegrationTest extends TestCase
         Console::overrideIsConsole(true);
         $this->serviceManager->get('Application')->bootstrap();
         $request = $this->serviceManager->get('Request');
-        $this->assertInstanceOf(Request::class, $request);
+        /**
+         * Who care what type of request it is? The important thing is that the given path is correct.
+         */
+        $this->assertInstanceOf(RequestInterface::class, $request);
         $viewHelpers = $this->serviceManager->get('ViewHelperManager');
         $urlHelper   = $viewHelpers->get('url');
         $test        = $urlHelper('test');

--- a/test/Helper/UrlIntegrationTest.php
+++ b/test/Helper/UrlIntegrationTest.php
@@ -11,12 +11,10 @@ namespace LaminasTest\View\Helper;
 use Laminas\Console\Console;
 use Laminas\Console\Request;
 use Laminas\Http\Request as HttpRequest;
-use Laminas\Mvc\Console\ConfigProvider as MvcConsoleConfigProvider;
-use Laminas\Mvc\Router\Http as V2HttpRoute;
 use Laminas\Mvc\Service\ServiceListenerFactory;
 use Laminas\Mvc\Service\ServiceManagerConfig;
 use Laminas\Router\ConfigProvider as RouterConfigProvider;
-use Laminas\Router\Http as V3HttpRoute;
+use Laminas\Router\Http;
 use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
@@ -29,16 +27,15 @@ use PHPUnit\Framework\TestCase;
  */
 class UrlIntegrationTest extends TestCase
 {
+    private $serviceManager;
+
     protected function setUp(): void
     {
-        $this->literalRouteType = class_exists(V2HttpRoute\Literal::class)
-            ? V2HttpRoute\Literal::class
-            : V3HttpRoute\Literal::class;
         $config = [
             'router' => [
                 'routes' => [
                     'test' => [
-                        'type' => $this->literalRouteType,
+                        'type' => Http\Literal::class,
                         'options' => [
                             'route' => '/test',
                             'defaults' => [
@@ -74,15 +71,8 @@ class UrlIntegrationTest extends TestCase
         $this->serviceManager = new ServiceManager();
         (new ServiceManagerConfig($serviceConfig))->configureServiceManager($this->serviceManager);
 
-        if (! class_exists(V2HttpRoute\Literal::class) && class_exists(RouterConfigProvider::class)) {
-            $routerConfig = new Config((new RouterConfigProvider())->getDependencyConfig());
-            $routerConfig->configureServiceManager($this->serviceManager);
-        }
-
-        if (class_exists(MvcConsoleConfigProvider::class)) {
-            $mvcConsoleConfig = new Config((new MvcConsoleConfigProvider())->getDependencyConfig());
-            $mvcConsoleConfig->configureServiceManager($this->serviceManager);
-        }
+        $routerConfig = new Config((new RouterConfigProvider())->getDependencyConfig());
+        $routerConfig->configureServiceManager($this->serviceManager);
 
         $this->serviceManager->setAllowOverride(true);
         $this->serviceManager->setService('config', $config);

--- a/test/Helper/UrlIntegrationTest.php
+++ b/test/Helper/UrlIntegrationTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\View\Helper;
 
 use Laminas\Console\Console;
+use Laminas\Console\Request as ConsoleRequest;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Mvc\Service\ServiceListenerFactory;
 use Laminas\Mvc\Service\ServiceManagerConfig;
@@ -16,7 +17,6 @@ use Laminas\Router\ConfigProvider as RouterConfigProvider;
 use Laminas\Router\Http;
 use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\ServiceManager;
-use Laminas\Stdlib\RequestInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -27,6 +27,7 @@ use PHPUnit\Framework\TestCase;
  */
 class UrlIntegrationTest extends TestCase
 {
+    /** @var ServiceManager */
     private $serviceManager;
 
     protected function setUp(): void
@@ -110,12 +111,11 @@ class UrlIntegrationTest extends TestCase
     public function testUrlHelperUnderConsoleParadigmShouldReturnHttpRoutes()
     {
         Console::overrideIsConsole(true);
+        $this->serviceManager->setAllowOverride(true);
+        $this->serviceManager->setService('Request', new ConsoleRequest());
         $this->serviceManager->get('Application')->bootstrap();
         $request = $this->serviceManager->get('Request');
-        /**
-         * Who care what type of request it is? The important thing is that the given path is correct.
-         */
-        $this->assertInstanceOf(RequestInterface::class, $request);
+        $this->assertInstanceOf(ConsoleRequest::class, $request);
         $viewHelpers = $this->serviceManager->get('ViewHelperManager');
         $urlHelper   = $viewHelpers->get('url');
         $test        = $urlHelper('test');


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Updates the composer lock file with i18n-mvc and flash messenger packages.

* Tests should still fail on lowest because of the namespace rename from `Laminas\Mvc\Router` to `Laminas\Router`
* The `UrlIntegrationTest` should still fail because the request retrieved from the container is not a `ConsoleRequest`
