### PR TITLE
Add support for the nonce script attribute

### DIFF
--- a/src/Helper/HeadScript.php
+++ b/src/Helper/HeadScript.php
@@ -88,6 +88,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
         'language',
         'src',
         'id',
+        'nonce',
     ];
 
     /**

--- a/src/Helper/HeadScript.php
+++ b/src/Helper/HeadScript.php
@@ -11,6 +11,9 @@ namespace Laminas\View\Helper;
 use Laminas\View\Exception;
 use stdClass;
 
+use function in_array;
+use function strtolower;
+
 /**
  * Helper for setting and retrieving script elements for HTML head section
  *
@@ -89,6 +92,19 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
         'src',
         'id',
         'nonce',
+        'nomodule',
+        'referrerpolicy',
+    ];
+
+    /**
+     * Script attributes that behave as booleans
+     *
+     * @var string[]
+     */
+    private $booleanAttributes = [
+        'nomodule',
+        'defer',
+        'async',
     ];
 
     /**
@@ -390,11 +406,8 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
                     || in_array($key, ['conditional', 'noescape'])) {
                     continue;
                 }
-                if ('defer' == $key) {
-                    $value = 'defer';
-                }
-                if ('async' == $key) {
-                    $value = 'async';
+                if (in_array(strtolower($key), $this->booleanAttributes, true)) {
+                    $value = strtolower($key);
                 }
                 $attrString .= sprintf(
                     ' %s="%s"',

--- a/test/Helper/HeadScriptTest.php
+++ b/test/Helper/HeadScriptTest.php
@@ -551,4 +551,18 @@ document.write(bar.strlen());');
         $test = $this->helper->__invoke()->toString();
         $this->assertDoesNotMatchRegularExpression('#type="text/javascript"#i', $test);
     }
+
+    public function testSupportsNonceAttribute(): void
+    {
+        ($this->helper)()->appendScript(
+            '// some js',
+            'text/javascript',
+            ['nonce' => 'random']
+        );
+
+        self::assertStringContainsString(
+            'nonce="random"',
+            (string) ($this->helper)()
+        );
+    }
 }

--- a/test/Helper/HeadScriptTest.php
+++ b/test/Helper/HeadScriptTest.php
@@ -8,9 +8,12 @@
 
 namespace LaminasTest\View\Helper;
 
+use Generator;
 use Laminas\View;
 use Laminas\View\Helper;
 use PHPUnit\Framework\TestCase;
+
+use function sprintf;
 
 /**
  * Test class for Laminas\View\Helper\HeadScript.
@@ -562,6 +565,31 @@ document.write(bar.strlen());');
 
         self::assertStringContainsString(
             'nonce="random"',
+            (string) ($this->helper)()
+        );
+    }
+
+    /** @return Generator<string, array<int, string> */
+    public function booleanAttributeDataProvider(): Generator
+    {
+        $values = ['async', 'defer', 'nomodule'];
+
+        foreach ($values as $name) {
+            yield $name => [$name];
+        }
+    }
+
+    /** @dataProvider booleanAttributeDataProvider */
+    public function testBooleanAttributesUseTheKeyNameAsTheValue(string $attribute): void
+    {
+        ($this->helper)()->appendScript(
+            '// some js',
+            'text/javascript',
+            [$attribute => 'whatever']
+        );
+
+        self::assertStringContainsString(
+            sprintf('%1$s="%1$s"', $attribute),
             (string) ($this->helper)()
         );
     }

--- a/test/Helper/HeadScriptTest.php
+++ b/test/Helper/HeadScriptTest.php
@@ -593,4 +593,24 @@ document.write(bar.strlen());');
             (string) ($this->helper)()
         );
     }
+
+    /** @dataProvider booleanAttributeDataProvider */
+    public function testBooleanAttributesCanBeAppliedToModules(string $attribute): void
+    {
+        ($this->helper)()->appendScript(
+            '// some js',
+            'module',
+            [$attribute => 'whatever']
+        );
+
+        self::assertStringContainsString(
+            sprintf('%1$s="%1$s"', $attribute),
+            (string) ($this->helper)()
+        );
+
+        self::assertStringContainsString(
+            'type="module"',
+            (string) ($this->helper)()
+        );
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | no
| New Feature   | yes

### Description

The [nonce attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce) is useful for implementing a content security policy. Whilst it is possible to allow arbitrary attributes for the helper(s), in order to add a nonce to a <script> you'd have to implement your own delegator or factory to set this flag.


