### PR TITLE
Fix Markdown Formatting for CI Round 2

### DIFF
--- a/docs/book/application-integration/stand-alone.md
+++ b/docs/book/application-integration/stand-alone.md
@@ -1,7 +1,3 @@
-<!-- markdownlint-configure-file {
-    "no-inline-html": false
-} -->
-
 # Stand-Alone
 
 The view and all view-helpers of laminas-view can also be used stand-alone.
@@ -73,7 +69,7 @@ $viewModel->setOption('has_parent', true);
 
 echo $view->render($viewModel); // <h1>Example</h1>
 ```
-
+<!-- markdownlint-disable-next-line no-inline-html -->
 <details><summary>Show full code example</summary>
 
 ```php
@@ -110,6 +106,7 @@ $viewModel->setOption('has_parent', true);
 echo $view->render($viewModel);
 ```
 
+<!-- markdownlint-disable-next-line no-inline-html -->
 </details>
 
 ### Example with Layout
@@ -149,6 +146,7 @@ $layout->addChild($viewModel);
 echo $view->render($layout);
 ```
 
+<!-- markdownlint-disable-next-line no-inline-html -->
 <details><summary>Show full code example</summary>
 
 ```php
@@ -192,6 +190,7 @@ $layout->addChild($viewModel);
 echo $view->render($layout);
 ```
 
+<!-- markdownlint-disable-next-line no-inline-html -->
 </details>
 
 ## View Helpers

--- a/docs/book/application-integration/stand-alone.md
+++ b/docs/book/application-integration/stand-alone.md
@@ -1,3 +1,7 @@
+<!-- markdownlint-configure-file {
+    "no-inline-html": false
+} -->
+
 # Stand-Alone
 
 The view and all view-helpers of laminas-view can also be used stand-alone.

--- a/docs/book/helpers/escape.md
+++ b/docs/book/helpers/escape.md
@@ -14,6 +14,7 @@ More information to the operation and the background of security can be found
 in the
 [documentation of laminas-escaper](https://docs.laminas.dev/laminas-escaper/configuration/).
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### Installation Requirements
 >
 > The escape helpers depends on the laminas-escaper component, so be sure to have

--- a/docs/book/helpers/head-meta.md
+++ b/docs/book/helpers/head-meta.md
@@ -31,6 +31,7 @@ whether or not to autoescape values used in meta tags:
 
 - `setAutoEscape(bool $autoEscape = true)` (enabled by default)
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### AutoEscape
 >
 > **Disable this flag at your own risk.** The one documented case where it is

--- a/docs/book/helpers/head-script.md
+++ b/docs/book/helpers/head-script.md
@@ -20,6 +20,7 @@ script to load; this is usually in the form of a URL or a path. For the
 `*Script()` methods, `$script` is the client-side scripting directives you wish
 to use in the element.
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### Setting Conditional Comments
 >
 > `HeadScript` allows you to wrap the script tag in conditional comments, which

--- a/docs/book/helpers/head-style.md
+++ b/docs/book/helpers/head-style.md
@@ -3,6 +3,7 @@
 The HTML `<style>` element is used to include CSS stylesheets inline in the HTML
 `<head>` element.
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### Use HeadLink to link CSS files
 >
 > [HeadLink](head-link.md) should be used to create `<link>` elements for

--- a/docs/book/helpers/head-title.md
+++ b/docs/book/helpers/head-title.md
@@ -1,3 +1,8 @@
+<!-- markdownlint-configure-file {
+    "no-trailing-spaces": false,
+    "code-block-style": false
+} -->
+
 # HeadTitle
 
 The HTML `<title>` element is used to **provide a title for an HTML document**.

--- a/docs/book/helpers/head-title.md
+++ b/docs/book/helpers/head-title.md
@@ -1,8 +1,3 @@
-<!-- markdownlint-configure-file {
-    "no-trailing-spaces": false,
-    "code-block-style": false
-} -->
-
 # HeadTitle
 
 The HTML `<title>` element is used to **provide a title for an HTML document**.
@@ -77,18 +72,20 @@ To explicitly append content, the second paramater `$setType` or the concrete
 method `append()` of the helper can be used:
 
 === "Invoke Usage"
+<!-- markdownlint-disable-next-line code-block-style -->
     ```php
     $this->headTitle('My albums')
     $this->headTitle('Music', 'APPEND');
-    
+
     echo $this->headTitle(); // <title>My albumsMusic</title>
     ```
 
 === "Setter Usage"
+<!-- markdownlint-disable-next-line code-block-style -->
     ```php
     $this->headTitle('My albums')
     $this->headTitle()->append('Music');
-    
+
     echo $this->headTitle(); // <title>My albumsMusic</title>
     ```
 
@@ -101,18 +98,20 @@ To prepend content, the second paramater `$setType` or the concrete method
 `prepend()` of the helper can be used:
 
 === "Invoke Usage"
+<!-- markdownlint-disable-next-line code-block-style -->
     ```php
     $this->headTitle('My albums')
     $this->headTitle('Music', 'PREPEND');
-    
+
     echo $this->headTitle(); // <title>MusicMy albums</title>
     ```
 
 === "Setter Usage"
+<!-- markdownlint-disable-next-line code-block-style -->
     ```php
     $this->headTitle('My albums')
     $this->headTitle()->prepend('Music');
-    
+
     echo $this->headTitle(); // <title>MusicMy albums</title>
     ```
 
@@ -125,18 +124,20 @@ To overwrite the entire content of title helper, the second parameter `$setType`
 or the concrete method `set()` of the helper can be used:
 
 === "Invoke Usage"
+<!-- markdownlint-disable-next-line code-block-style -->
     ```php
     $this->headTitle('My albums')
     $this->headTitle('Music', 'SET');
-    
+
     echo $this->headTitle(); // <title>Music</title>
     ```
 
 === "Setter Usage"
+<!-- markdownlint-disable-next-line code-block-style -->
     ```php
     $this->headTitle('My albums')
     $this->headTitle()->set('Music');
-    
+
     echo $this->headTitle(); // <title>Music</title>
     ```
 

--- a/docs/book/helpers/html-tag.md
+++ b/docs/book/helpers/html-tag.md
@@ -1,8 +1,3 @@
-<!-- markdownlint-configure-file {
-    "no-trailing-spaces": false,
-    "code-block-style": false
-} -->
-
 # HtmlTag
 
 The `HtmlTag` helper is used to **create the root of an HTML document**, the
@@ -29,32 +24,36 @@ Output:
 ### Set a single Attribute
 
 === "Invoke Usage"
+<!-- markdownlint-disable-next-line code-block-style -->
     ```php
     $this->htmlTag(['lang' => 'en']);
-    
+
     echo $this->htmlTag()->openTag(); // <html lang="en">
     ```
 
 === "Setter Usage"
+<!-- markdownlint-disable-next-line code-block-style -->
     ```php
     $this->htmlTag()->setAttribute('lang', 'en');
-    
+
     echo $this->htmlTag()->openTag(); // <html lang="en">
     ```
 
 ### Set multiple Attributes
 
 === "Invoke Usage"
+<!-- markdownlint-disable-next-line code-block-style -->
     ```php
     $this->htmlTag(['lang' => 'en', 'id' => 'example']);
-    
+
     echo $this->htmlTag()->openTag(); // <html lang="en" id="example">
     ```
 
 === "Setter Usage"
+<!-- markdownlint-disable-next-line code-block-style -->
     ```php
     $this->htmlTag()->setAttributes(['lang' => 'en', 'id' => 'example']);
-    
+
     echo $this->htmlTag()->openTag(); // <html lang="en" id="example">
     ```
 

--- a/docs/book/helpers/html-tag.md
+++ b/docs/book/helpers/html-tag.md
@@ -1,3 +1,8 @@
+<!-- markdownlint-configure-file {
+    "no-trailing-spaces": false,
+    "code-block-style": false
+} -->
+
 # HtmlTag
 
 The `HtmlTag` helper is used to **create the root of an HTML document**, the

--- a/docs/book/helpers/inline-script.md
+++ b/docs/book/helpers/inline-script.md
@@ -6,6 +6,7 @@ code. The `InlineScript` helper allows you to manage both. It is derived from
 [HeadScript](head-script.md), and any method of that helper is available;
 replace the usage of `headScript()` in those examples with `inlineScript()`.
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### Use InlineScript for HTML body scripts
 >
 > `InlineScript` should be used when you wish to include scripts inline in the

--- a/docs/book/helpers/intro.md
+++ b/docs/book/helpers/intro.md
@@ -12,7 +12,7 @@ used to retrieve that instance.  `Laminas\View\Renderer\PhpRenderer` composes a
 method overloading capabilities that allow proxying method calls to helpers.
 
 <!-- markdownlint-disable-next-line header-increment -->
-> ### Callable helpers
+> ### Callable Helpers
 >
 > Starting in version 2.7.0, if your helper does not need access to the view,
 > you can also use any PHP callable as a helper, including arbitrary objects
@@ -78,38 +78,38 @@ for, and rendering, the various HTML `<head>` tags, such as `HeadTitle`,
 - [Placeholder](placeholder.md)
 - [Url](url.md)
 
-> ### Help us document the helpers
+> ### Help Us Document the Helpers
 >
 > Not all helpers are documented! Some that could use documentation include the
 > various escaper helpers, the layout helper, and the `serverUrl` helper. Click
 > the "GitHub" octocat link in the top navbar to go to the repository and start
 > writing documentation!
 
-> ### i18n helpers
+> ### i18n Helpers
 >
 > View helpers related to **Internationalization** are documented in the
 > [I18n View Helpers](https://docs.laminas.dev/laminas-i18n/view-helpers/)
 > documentation.
 
-> ### Form helpers
+> ### Form Helpers
 >
 > View helpers related to **form** are documented in the
 > [Form View Helpers](https://docs.laminas.dev/laminas-form/helper/intro/)
 > documentation.
 
-> ### Navigation helpers
+> ### Navigation Helpers
 >
 > View helpers related to **navigation** are documented in the
 > [Navigation View Helpers](https://docs.laminas.dev/laminas-navigation/helpers/intro/)
 > documentation.
 
-> ### Pagination helpers
+> ### Pagination Helpers
 >
 > View helpers related to **paginator** are documented in the
 > [Paginator Usage](https://docs.laminas.dev/laminas-paginator/usage/#rendering-pages-with-view-scripts)
 > documentation.
 
-> ### Custom helpers
+> ### Custom Helpers
 >
 > For documentation on writing **custom view helpers** see the
 > [Advanced usage](advanced-usage.md) chapter.

--- a/docs/book/helpers/intro.md
+++ b/docs/book/helpers/intro.md
@@ -11,6 +11,7 @@ used to retrieve that instance.  `Laminas\View\Renderer\PhpRenderer` composes a
 *plugin manager*, allowing you to retrieve helpers, and also provides some
 method overloading capabilities that allow proxying method calls to helpers.
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### Callable helpers
 >
 > Starting in version 2.7.0, if your helper does not need access to the view,
@@ -77,7 +78,7 @@ for, and rendering, the various HTML `<head>` tags, such as `HeadTitle`,
 - [Placeholder](placeholder.md)
 - [Url](url.md)
 
-> ### Help document!
+> ### Help us document the helpers
 >
 > Not all helpers are documented! Some that could use documentation include the
 > various escaper helpers, the layout helper, and the `serverUrl` helper. Click

--- a/docs/book/helpers/partial.md
+++ b/docs/book/helpers/partial.md
@@ -7,6 +7,7 @@ you do not need to worry about variable name clashes.
 A sibling to the `Partial`, the `PartialLoop` view helper allows you to pass
 iterable data, and render a partial for each item.
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### PartialLoop Counter
 >
 > The `PartialLoop` view helper gives access to the current position of the

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -1,1 +1,2 @@
+<!-- markdownlint-disable -->
 ../../README.md

--- a/docs/book/quick-start.md
+++ b/docs/book/quick-start.md
@@ -647,6 +647,7 @@ executes prior to the `PhpRendererStrategy`, and thus ensure that a JSON payload
 is created when the controller returns a `JsonModel`.
 
 You could also use the module configuration to add the strategies:
+
 ```php
 namespace Application;
 
@@ -730,6 +731,7 @@ While the above examples detail using the `JsonStrategy`, the same could be done
 for the `FeedStrategy`.
 
 If you successfully registered the Strategy you need to use the appropriate `ViewModel`:
+
 ```php
 namespace Application;
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| QA            | yes

### Description

With reference to #71 and #72, this pull solves formatting errors in Markdown files under the `docs` tree, mostly by using comments for markdownlint.

Calling on @froschdesign for review
