### PR TITLE
Fixed segfault in `htmlAttributes` helper used in `AbstractHtmlElement`, due to incorrect helper name reference

### DIFF
--- a/src/Helper/AbstractHtmlElement.php
+++ b/src/Helper/AbstractHtmlElement.php
@@ -64,7 +64,7 @@ abstract class AbstractHtmlElement extends AbstractHelper
             }
         }
 
-        $attribs = $this->getView()->plugin('htmlAttributes')($attribs);
+        $attribs = $this->getView()->plugin(HtmlAttributes::class)($attribs);
 
         return (string) $attribs;
     }

--- a/test/Helper/HtmlAttributesTest.php
+++ b/test/Helper/HtmlAttributesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\View\Helper;
+
+use Laminas\View\Helper\HtmlAttributes;
+use Laminas\View\Renderer\PhpRenderer;
+use PHPUnit\Framework\TestCase;
+
+class HtmlAttributesTest extends TestCase
+{
+    /** @var HtmlAttributes */
+    private $helper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->helper = new HtmlAttributes();
+        $this->helper->setView(new PhpRenderer());
+    }
+
+    public function testThatInvokeWillReturnAttributeSetWithTheExpectedValues(): void
+    {
+        $set = ($this->helper)([
+            'some' => 'value'
+        ]);
+
+        self::assertEquals(['some' => 'value'], $set->getArrayCopy());
+    }
+
+    public function testThatAttributeValuesWillBeEscaped(): void
+    {
+        $result = (string) ($this->helper)(['attribute' => '1&2']);
+        self::assertStringContainsString('attribute="1&amp;2"', $result);
+    }
+
+    public function testThatAttributeKeysWillBeEscaped(): void
+    {
+        $result = (string) ($this->helper)(['donkeys&goats' => 'value']);
+        self::assertStringContainsString('donkeys&amp;goats="value"', $result);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| QA            | yes

### Description

With the introduction of `$this->htmlAttributes()` a kind-of BC break was introduced… For ages, I've been implementing `HtmlAttributes` helpers in my projects to basically expose the method in `AbstractHtmlElement::htmlAttribs()` which is a protected method. Because, the htmlAttribs() method was updated to call the plugin by alias `htmlAttributes`, this would cause an infinite loop and segfault in consumer code with an existing helper aliased to `htmlAttributes`.

The fix here just uses the FQCN of the expected helper instead of the alias.

I also added a quick test case for the helper itself whilst I was hunting down the cause of the segfault in my own code.

Also - the introduced [HtmlAttributesSet](https://github.com/laminas/laminas-view/blob/3.0.x/src/HtmlAttributesSet.php) class is untested and has several public methods - would it be worth doing some QA on that?
