### PR TITLE
Null values in html attribute lists trigger unexpected exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "require": {
         "php": "^7.3 || ~8.0.0 || ~8.1.0",
+        "ext-json": "*",
         "laminas/laminas-eventmanager": "^3.4",
         "laminas/laminas-json": "^2.6.1 || ^3.3",
         "laminas/laminas-stdlib": "^3.6"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "09b3d00b4aa9eaff2d2c39fc03a3e457",
+    "content-hash": "242f3bed2b23c313b8c0bcc3bf1fa9fc",
     "packages": [
         {
             "name": "laminas/laminas-eventmanager",
@@ -2442,16 +2442,16 @@
         },
         {
             "name": "laminas/laminas-i18n",
-            "version": "2.11.2",
+            "version": "2.11.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-i18n.git",
-                "reference": "78adb53ebf6c0bc63f92273fd7809dabc554f786"
+                "reference": "563b1b720ee53f2748473656a250d65911fc4462"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/78adb53ebf6c0bc63f92273fd7809dabc554f786",
-                "reference": "78adb53ebf6c0bc63f92273fd7809dabc554f786",
+                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/563b1b720ee53f2748473656a250d65911fc4462",
+                "reference": "563b1b720ee53f2748473656a250d65911fc4462",
                 "shasum": ""
             },
             "require": {
@@ -2478,12 +2478,12 @@
                 "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "laminas/laminas-cache": "Laminas\\Cache component",
-                "laminas/laminas-config": "Laminas\\Config component",
+                "laminas/laminas-cache": "You should install this package to cache the translations",
+                "laminas/laminas-config": "You should install this package to use the INI translation format",
                 "laminas/laminas-eventmanager": "You should install this package to use the events in the translator",
                 "laminas/laminas-filter": "You should install this package to use the provided filters",
-                "laminas/laminas-i18n-resources": "Translation resources",
-                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component",
+                "laminas/laminas-i18n-resources": "This package provides validator and captcha translations",
+                "laminas/laminas-servicemanager": "You should install this package to use the translator",
                 "laminas/laminas-validator": "You should install this package to use the provided validators",
                 "laminas/laminas-view": "You should install this package to use the provided view helpers"
             },
@@ -2523,7 +2523,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-08-20T08:23:04+00:00"
+            "time": "2021-10-13T08:07:28+00:00"
         },
         {
             "name": "laminas/laminas-loader",
@@ -2583,38 +2583,35 @@
         },
         {
             "name": "laminas/laminas-modulemanager",
-            "version": "2.10.2",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-modulemanager.git",
-                "reference": "2068e0b300e87e139112016a6025be341ceaaf33"
+                "reference": "6acf5991d10b0b38a2edb08729ed48981b2a5dad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-modulemanager/zipball/2068e0b300e87e139112016a6025be341ceaaf33",
-                "reference": "2068e0b300e87e139112016a6025be341ceaaf33",
+                "url": "https://api.github.com/repos/laminas/laminas-modulemanager/zipball/6acf5991d10b0b38a2edb08729ed48981b2a5dad",
+                "reference": "6acf5991d10b0b38a2edb08729ed48981b2a5dad",
                 "shasum": ""
             },
             "require": {
                 "brick/varexporter": "^0.3.2",
-                "laminas/laminas-config": "^3.4",
-                "laminas/laminas-eventmanager": "^3.3",
-                "laminas/laminas-stdlib": "^3.3",
-                "laminas/laminas-zendframework-bridge": "^1.1",
-                "php": "^7.3 || ^8.0",
+                "laminas/laminas-config": "^3.7",
+                "laminas/laminas-eventmanager": "^3.4",
+                "laminas/laminas-stdlib": "^3.6",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0",
                 "webimpress/safe-writer": "^1.0.2 || ^2.1"
             },
-            "replace": {
-                "zendframework/zend-modulemanager": "^2.8.4"
+            "conflict": {
+                "zendframework/zend-modulemanager": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-console": "^2.8",
-                "laminas/laminas-di": "^2.6.1",
-                "laminas/laminas-loader": "^2.6.1",
+                "laminas/laminas-coding-standard": "^2.3",
+                "laminas/laminas-loader": "^2.8",
                 "laminas/laminas-mvc": "^3.1.1",
-                "laminas/laminas-servicemanager": "^3.4.1",
-                "phpunit/phpunit": "^9.3.7"
+                "laminas/laminas-servicemanager": "^3.7",
+                "phpunit/phpunit": "^9.5.5"
             },
             "suggest": {
                 "laminas/laminas-console": "Laminas\\Console component",
@@ -2652,45 +2649,44 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-04-13T20:11:28+00:00"
+            "time": "2021-10-13T17:05:17+00:00"
         },
         {
             "name": "laminas/laminas-mvc",
-            "version": "3.2.0",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-mvc.git",
-                "reference": "88da7200cf8f5a970c35d91717a5c4db94981e5e"
+                "reference": "215d0ff1b504bfbc299346aae20acb362c38d139"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-mvc/zipball/88da7200cf8f5a970c35d91717a5c4db94981e5e",
-                "reference": "88da7200cf8f5a970c35d91717a5c4db94981e5e",
+                "url": "https://api.github.com/repos/laminas/laminas-mvc/zipball/215d0ff1b504bfbc299346aae20acb362c38d139",
+                "reference": "215d0ff1b504bfbc299346aae20acb362c38d139",
                 "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "^1.2",
-                "laminas/laminas-eventmanager": "^3.2",
-                "laminas/laminas-http": "^2.7",
+                "laminas/laminas-eventmanager": "^3.4",
+                "laminas/laminas-http": "^2.15",
                 "laminas/laminas-modulemanager": "^2.8",
-                "laminas/laminas-router": "^3.0.2",
-                "laminas/laminas-servicemanager": "^3.3",
-                "laminas/laminas-stdlib": "^3.2.1",
-                "laminas/laminas-view": "^2.11.3",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "laminas/laminas-router": "^3.5",
+                "laminas/laminas-servicemanager": "^3.7",
+                "laminas/laminas-stdlib": "^3.6",
+                "laminas/laminas-view": "^2.14",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-mvc": "^3.1.1"
+            "conflict": {
+                "zendframework/zend-mvc": "*"
             },
             "require-dev": {
                 "http-interop/http-middleware": "^0.4.1",
                 "laminas/laminas-coding-standard": "^1.0.0",
-                "laminas/laminas-json": "^2.6.1 || ^3.0",
+                "laminas/laminas-json": "^3.3",
                 "laminas/laminas-psr7bridge": "^1.0",
                 "laminas/laminas-stratigility": ">=2.0.1 <2.2",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.4.2"
+                "phpunit/phpunit": "^9.5.5"
             },
             "suggest": {
                 "laminas/laminas-json": "(^2.6.1 || ^3.0) To auto-deserialize JSON body content in AbstractRestfulController extensions, when json_decode is unavailable",
@@ -2735,7 +2731,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-12-14T21:54:40+00:00"
+            "time": "2021-10-13T17:48:28+00:00"
         },
         {
             "name": "laminas/laminas-mvc-i18n",
@@ -3115,30 +3111,34 @@
         },
         {
             "name": "laminas/laminas-router",
-            "version": "3.4.1",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-router.git",
-                "reference": "338e55010c9090d7a79c6e6aed68b886b849801f"
+                "reference": "44759e71620030c93d99e40b394fe9fff8f0beda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-router/zipball/338e55010c9090d7a79c6e6aed68b886b849801f",
-                "reference": "338e55010c9090d7a79c6e6aed68b886b849801f",
+                "url": "https://api.github.com/repos/laminas/laminas-router/zipball/44759e71620030c93d99e40b394fe9fff8f0beda",
+                "reference": "44759e71620030c93d99e40b394fe9fff8f0beda",
                 "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "^1.2",
-                "laminas/laminas-http": "^2.8.1",
-                "laminas/laminas-servicemanager": "^2.7.8 || ^3.3",
-                "laminas/laminas-stdlib": "^3.3",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "laminas/laminas-http": "^2.15",
+                "laminas/laminas-servicemanager": "^3.7",
+                "laminas/laminas-stdlib": "^3.6",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+            },
+            "conflict": {
+                "zendframework/zend-router": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-i18n": "^2.7.4",
-                "phpunit/phpunit": "^9.4"
+                "phpunit/phpunit": "^9.5.5",
+                "psalm/plugin-phpunit": "^0.15.1",
+                "vimeo/psalm": "^4.7"
             },
             "suggest": {
                 "laminas/laminas-i18n": "^2.7.4, if defining translatable HTTP path segments"
@@ -3179,7 +3179,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-11-19T19:42:10+00:00"
+            "time": "2021-10-13T16:02:43+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
@@ -7038,7 +7038,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0"
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
+        "ext-json": "*"
     },
     "platform-dev": {
         "ext-dom": "*"

--- a/src/Helper/HtmlAttributes.php
+++ b/src/Helper/HtmlAttributes.php
@@ -1,14 +1,15 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-view for the canonical source repository
- * @copyright https://github.com/laminas/laminas-view/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-view/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\View\Helper;
 
+use Laminas\Escaper\Escaper;
+use Laminas\View\Helper\Escaper\AbstractHelper as AbstractEscapeHelper;
 use Laminas\View\HtmlAttributesSet;
+use Laminas\View\Renderer\PhpRenderer;
+
+use function assert;
 
 /**
  * Helper for creating HtmlAttributesSet objects
@@ -18,12 +19,20 @@ class HtmlAttributes extends AbstractHelper
     /**
      * Returns a new HtmlAttributesSet object, optionally initializing it with
      * the provided value.
+     *
+     * @param iterable<string, scalar|array|null> $attributes
      */
     public function __invoke(iterable $attributes = []): HtmlAttributesSet
     {
+        $renderer = $this->getView();
+        assert($renderer instanceof PhpRenderer);
+        $escapePlugin = $renderer->plugin('escapeHtml');
+        assert($escapePlugin instanceof AbstractEscapeHelper);
+        $escaper = $escapePlugin->getEscaper();
+        assert($escaper instanceof Escaper);
+
         return new HtmlAttributesSet(
-            $this->getView()->plugin('escapehtml')->getEscaper(),
-            $this->getView()->plugin('escapehtmlattr')->getEscaper(),
+            $escaper,
             $attributes
         );
     }

--- a/src/HtmlAttributesSet.php
+++ b/src/HtmlAttributesSet.php
@@ -22,14 +22,14 @@ use const JSON_THROW_ON_ERROR;
 /**
  * Class for storing and processing HTML tag attributes.
  */
-class HtmlAttributesSet extends ArrayObject
+final class HtmlAttributesSet extends ArrayObject
 {
     /**
      * HTML escaper
      *
      * @var Escaper
      */
-    protected $escaper;
+    private $escaper;
 
     public function __construct(Escaper $escaper, iterable $attributes = [])
     {

--- a/src/HtmlAttributesSet.php
+++ b/src/HtmlAttributesSet.php
@@ -1,15 +1,23 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-view for the canonical source repository
- * @copyright https://github.com/laminas/laminas-view/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-view/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\View;
 
 use ArrayObject;
 use Laminas\Escaper\Escaper;
+use Traversable;
+
+use function in_array;
+use function is_array;
+use function is_scalar;
+use function iterator_to_array;
+
+use const JSON_HEX_AMP;
+use const JSON_HEX_APOS;
+use const JSON_HEX_QUOT;
+use const JSON_HEX_TAG;
+use const JSON_THROW_ON_ERROR;
 
 /**
  * Class for storing and processing HTML tag attributes.
@@ -21,40 +29,26 @@ class HtmlAttributesSet extends ArrayObject
      *
      * @var Escaper
      */
-    protected $htmlEscaper;
+    protected $escaper;
 
-    /**
-     * HTML attribute escaper
-     *
-     * @var Escaper
-     */
-    protected $htmlAttributeEscaper;
-
-    /**
-     * Constructor.
-     *
-     * @param Escaper $htmlEscaper General HTML escaper
-     * @param Escaper $htmlAttributeEscaper Escaper for use with HTML attributes
-     * @param iterable $attributes Attributes to manage
-     */
-    public function __construct(Escaper $htmlEscaper, Escaper $htmlAttributeEscaper, iterable $attributes = [])
+    public function __construct(Escaper $escaper, iterable $attributes = [])
     {
-        parent::__construct();
-        $this->htmlEscaper = $htmlEscaper;
-        $this->htmlAttributeEscaper = $htmlAttributeEscaper;
-        foreach ($attributes as $name => $value) {
-            $this->offsetSet($name, $value);
-        }
+        $attributes = $attributes instanceof Traversable ? iterator_to_array($attributes, true) : $attributes;
+        $this->escaper = $escaper;
+        parent::__construct($attributes);
     }
 
     /**
      * Set several attributes at once.
+     *
+     * @param iterable<string, scalar|array|null> $attributes
      */
     public function set(iterable $attributes): self
     {
         foreach ($attributes as $name => $value) {
-            $this[$name] = $value;
+            $this->offsetSet($name, $value);
         }
+
         return $this;
     }
 
@@ -63,7 +57,7 @@ class HtmlAttributesSet extends ArrayObject
      *
      * Sets the attribute if it does not exist.
      *
-     * @param $value string|array Value
+     * @param scalar|array|null $value
      */
     public function add(string $name, $value): self
     {
@@ -73,32 +67,38 @@ class HtmlAttributesSet extends ArrayObject
                 ? array_merge((array) $this->offsetGet($name), (array) $value)
                 : $value
         );
+
         return $this;
     }
 
     /**
      * Merge attributes with existing attributes.
+     *
+     * @param iterable<string, scalar|array|null> $attributes
      */
     public function merge(iterable $attributes): self
     {
         foreach ($attributes as $name => $value) {
             $this->add($name, $value);
         }
+
         return $this;
     }
 
     /**
-     * Does a specific attribute with a specific value exist?
+     * Whether the named attribute equals or contains the given value
+     *
+     * @param scalar|array|null $value
      */
-    public function hasValue(string $name, string $value): bool
+    public function hasValue(string $name, $value): bool
     {
         if (! $this->offsetExists($name)) {
             return false;
         }
 
         $storeValue = $this->offsetGet($name);
-        if (is_array($storeValue)) {
-            return in_array($value, $storeValue);
+        if (is_array($storeValue) && is_scalar($value)) {
+            return in_array($value, $storeValue, true);
         }
 
         return $value === $storeValue;
@@ -112,12 +112,12 @@ class HtmlAttributesSet extends ArrayObject
         $xhtml = '';
 
         foreach ($this->getArrayCopy() as $key => $value) {
-            $key = $this->htmlEscaper->escapeHtml($key);
+            $key = $this->escaper->escapeHtml((string) $key);
 
             if ((0 === strpos($key, 'on') || ('constraints' === $key)) && ! is_scalar($value)) {
                 // Don't escape event attributes; _do_ substitute double quotes with singles
                 // non-scalar data should be cast to JSON first
-                $value = json_encode($value, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+                $value = json_encode($value, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_THROW_ON_ERROR);
             }
 
             if (0 !== strpos($key, 'on') && 'constraints' !== $key && is_array($value)) {
@@ -126,7 +126,7 @@ class HtmlAttributesSet extends ArrayObject
                 $value = implode(' ', $value);
             }
 
-            $value  = $this->htmlAttributeEscaper->escapeHtmlAttr($value);
+            $value  = $this->escaper->escapeHtmlAttr((string) $value);
             $quote  = strpos($value, '"') !== false ? "'" : '"';
             $xhtml .= sprintf(' %2$s=%1$s%3$s%1$s', $quote, $key, $value);
         }

--- a/src/HtmlAttributesSet.php
+++ b/src/HtmlAttributesSet.php
@@ -117,7 +117,8 @@ class HtmlAttributesSet extends ArrayObject
             if ((0 === strpos($key, 'on') || ('constraints' === $key)) && ! is_scalar($value)) {
                 // Don't escape event attributes; _do_ substitute double quotes with singles
                 // non-scalar data should be cast to JSON first
-                $value = json_encode($value, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_THROW_ON_ERROR);
+                $flags = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_THROW_ON_ERROR;
+                $value = json_encode($value, $flags);
             }
 
             if (0 !== strpos($key, 'on') && 'constraints' !== $key && is_array($value)) {

--- a/test/Helper/AbstractHtmlElementTest.php
+++ b/test/Helper/AbstractHtmlElementTest.php
@@ -1,30 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\View\Helper;
 
-use Laminas\View\Helper\AbstractHtmlElement;
 use Laminas\View\Renderer\PhpRenderer;
+use LaminasTest\View\Helper\TestAsset\ConcreteElementHelper;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Tests for {@see \Laminas\View\Helper\AbstractHtmlElement}
- *
  * @covers \Laminas\View\Helper\AbstractHtmlElement
  */
 class AbstractHtmlElementTest extends TestCase
 {
     /**
-     * @var AbstractHtmlElement|\PHPUnit_Framework_MockObject_MockObject
+     * @var ConcreteElementHelper
      */
     protected $helper;
 
-    /**
-     * {@inheritDoc}
-     */
     protected function setUp(): void
     {
-        $this->helper = $this->getMockForAbstractClass(AbstractHtmlElement::class);
-
+        $this->helper = new ConcreteElementHelper();
         $this->helper->setView(new PhpRenderer());
     }
 
@@ -35,13 +31,15 @@ class AbstractHtmlElementTest extends TestCase
      */
     public function testWillEscapeValueAttributeValuesCorrectly(): void
     {
-        $reflectionMethod = new \ReflectionMethod($this->helper, 'htmlAttribs');
-
-        $reflectionMethod->setAccessible(true);
-
-        $this->assertSame(
+        self::assertEquals(
             ' data-value="breaking&#x20;your&#x20;HTML&#x20;like&#x20;a&#x20;boss&#x21;&#x20;&#x5C;"',
-            $reflectionMethod->invoke($this->helper, ['data-value' => 'breaking your HTML like a boss! \\'])
+            $this->helper->compileAttributes(['data-value' => 'breaking your HTML like a boss! \\'])
         );
+    }
+
+    public function testThatAttributesWithANullValueArePresentedAsAnEmptyString(): void
+    {
+        $expect = 'something=""';
+        self::assertEquals($expect, $this->helper->compileAttributes(['something' => null]));
     }
 }

--- a/test/Helper/AbstractHtmlElementTest.php
+++ b/test/Helper/AbstractHtmlElementTest.php
@@ -8,6 +8,8 @@ use Laminas\View\Renderer\PhpRenderer;
 use LaminasTest\View\Helper\TestAsset\ConcreteElementHelper;
 use PHPUnit\Framework\TestCase;
 
+use function sprintf;
+
 /**
  * @covers \Laminas\View\Helper\AbstractHtmlElement
  */
@@ -41,5 +43,38 @@ class AbstractHtmlElementTest extends TestCase
     {
         $expect = 'something=""';
         self::assertStringContainsString($expect, $this->helper->compileAttributes(['something' => null]));
+    }
+
+    /**
+     * @param scalar|scalar[]|null $attributeValue
+     *
+     * @dataProvider attributeValuesProvider
+     */
+    public function testThatAttributesOfVariousNativeTypesProduceTheExpectedAttributeString(
+        $attributeValue,
+        string $expected,
+        string $expectedEventValue
+    ): void {
+        $expect = sprintf('atr=%s', $expected);
+        self::assertStringContainsString($expect, $this->helper->compileAttributes(['atr' => $attributeValue]));
+
+        $expect = sprintf('onclick=%s', $expectedEventValue);
+        self::assertStringContainsString($expect, $this->helper->compileAttributes(['onclick' => $attributeValue]));
+    }
+
+    /** @return array<string, array{0: scalar|scalar[]|null, 1: string, 2: string}> */
+    public function attributeValuesProvider(): array
+    {
+        return [
+            'Integer' => [1, '"1"', '"1"'],
+            'Float' => [0.5, '"0.5"', '"0.5"'],
+            'String' => ['whatever', '"whatever"', '"whatever"'],
+            'Null' => [null, '""', '"null"'],
+            'Class List' => [
+                ['foo', 'bar', 'baz'],
+                '"foo&#x20;bar&#x20;baz"',
+                '"&#x5B;&quot;foo&quot;,&quot;bar&quot;,&quot;baz&quot;&#x5D;"',
+            ],
+        ];
     }
 }

--- a/test/Helper/AbstractHtmlElementTest.php
+++ b/test/Helper/AbstractHtmlElementTest.php
@@ -40,6 +40,6 @@ class AbstractHtmlElementTest extends TestCase
     public function testThatAttributesWithANullValueArePresentedAsAnEmptyString(): void
     {
         $expect = 'something=""';
-        self::assertEquals($expect, $this->helper->compileAttributes(['something' => null]));
+        self::assertStringContainsString($expect, $this->helper->compileAttributes(['something' => null]));
     }
 }

--- a/test/Helper/HtmlListTest.php
+++ b/test/Helper/HtmlListTest.php
@@ -232,8 +232,8 @@ class HtmlListTest extends TestCase
 
     public function testThatListAttributesHaveTheExpectedValue(): void
     {
-        $result = ($this->helper)(['foo'], false, ['class' => 'jim', 'data-foo' => null, 'data-bar="&"']);
-        $expect = '<ul class="foo" data-foo="" data-bar="&amp;">';
+        $result = ($this->helper)(['foo'], false, ['class' => 'jim', 'data-foo' => null, 'data-bar' => '&']);
+        $expect = '<ul class="jim" data-foo="" data-bar="&amp;">';
         self::assertStringContainsString($expect, $result);
     }
 }

--- a/test/Helper/HtmlListTest.php
+++ b/test/Helper/HtmlListTest.php
@@ -229,4 +229,11 @@ class HtmlListTest extends TestCase
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->helper->__invoke([]);
     }
+
+    public function testThatListAttributesHaveTheExpectedValue(): void
+    {
+        $result = ($this->helper)(['foo'], false, ['class' => 'jim', 'data-foo' => null, 'data-bar="&"']);
+        $expect = '<ul class="foo" data-foo="" data-bar="&amp;">';
+        self::assertStringContainsString($expect, $result);
+    }
 }

--- a/test/Helper/TestAsset/ConcreteElementHelper.php
+++ b/test/Helper/TestAsset/ConcreteElementHelper.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\View\Helper\TestAsset;
+
+use Laminas\View\Helper\AbstractHtmlElement;
+
+final class ConcreteElementHelper extends AbstractHtmlElement
+{
+    /** @return string */
+    public function normalizeElementId(string $id)
+    {
+        return $this->normalizeId($id);
+    }
+
+    /** @return string */
+    public function compileAttributes(array $attributes)
+    {
+        return $this->htmlAttribs($attributes);
+    }
+}

--- a/test/HtmlAttributesSetTest.php
+++ b/test/HtmlAttributesSetTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\View;
+
+use Laminas\Escaper\Escaper;
+use Laminas\View\HtmlAttributesSet;
+use PHPUnit\Framework\TestCase;
+
+class HtmlAttributesSetTest extends TestCase
+{
+    /** @var HtmlAttributesSet */
+    private $helper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->helper = new HtmlAttributesSet(new Escaper());
+    }
+
+    public function testThatTheSetIsInitiallyEmpty(): void
+    {
+        self::assertCount(0, $this->helper);
+    }
+
+    public function testThatAnEmptySetYieldsAnEmptyString(): void
+    {
+        self::assertEquals('', (string) $this->helper);
+    }
+
+    public function testThatSetMutatesTheExistingAttributes(): void
+    {
+        $helper = new HtmlAttributesSet(new Escaper(), ['foo' => 'bar']);
+        self::assertCount(1, $helper);
+        self::assertStringContainsString('foo="bar"', (string) $helper);
+
+        $helper->set(['mushrooms' => 'nice', 'foo' => 'goats']);
+
+        self::assertCount(2, $helper);
+        self::assertStringContainsString('foo="goats" mushrooms="nice"', (string) $helper);
+    }
+
+    public function testThatAClassListWillBeImploded(): void
+    {
+        $this->helper->set(['class' => ['foo', 'bar']]);
+        self::assertStringContainsString('class="foo&#x20;bar"', (string) $this->helper);
+    }
+
+    public function testThatItemsCanBeAddedToAClassList(): void
+    {
+        $this->helper->set(['class' => 'foo']);
+        $this->helper->add('class', 'bar');
+        self::assertStringContainsString('class="foo&#x20;bar"', (string) $this->helper);
+    }
+
+    public function testThatMergingAnArrayIsPossible(): void
+    {
+        $a = new HtmlAttributesSet(new Escaper(), ['foo' => 'foo']);
+        $a->merge(['bar' => 'bar']);
+
+        self::assertStringContainsString('foo="foo" bar="bar"', (string) $a);
+    }
+
+    public function testThatMergingAClassListYieldsExpectedValues(): void
+    {
+        $a = new HtmlAttributesSet(new Escaper(), ['foo' => 'foo']);
+        $a->merge(['foo' => 'bar']);
+
+        self::assertStringContainsString('foo="foo&#x20;bar"', (string) $a);
+    }
+
+    public function testHasValueForScalars(): void
+    {
+        self::assertFalse($this->helper->hasValue('nuts', 'pea'));
+        $this->helper->add('nuts', 'pea');
+        self::assertTrue($this->helper->hasValue('nuts', 'pea'));
+    }
+
+    public function testHasValueForArrays(): void
+    {
+        $this->helper->set(['nuts' => 'walnut']);
+        self::assertFalse($this->helper->hasValue('nuts', 'pea'));
+        self::assertTrue($this->helper->hasValue('nuts', 'walnut'));
+        $this->helper->add('nuts', 'pea');
+        self::assertTrue($this->helper->hasValue('nuts', 'pea'));
+        self::assertTrue($this->helper->hasValue('nuts', 'walnut'));
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| QA            | yes

Prior to 2.13.x, providing an array of attributes such as `['class' => 'whatever', 'data-something' => null]` to a helper that extends from `AbstractHtmlElement` would yield markup along the lines of `class="whatever" data-something=""`

Now, a type error is thrown in `HtmlAttributesSet::__toString()` causing a fatal error because of the the throw in __toString
