### PR TITLE
Deprecate `jsonExpressionFinder` usage in `Json` view helper

### DIFF
--- a/docs/book/helpers/json.md
+++ b/docs/book/helpers/json.md
@@ -20,7 +20,21 @@ determine how to handle the content.
 <?= $this->json($this->data) ?>
 ```
 
-> ### Enabling encoding using Laminas\Json\Expr _(Deprecated)_
+> WARNING: **Deprecated**
+> 
+> ### Enabling encoding using Laminas\Json\Expr
+> 
+> **This feature of the Json view helper has been deprecated in version 2.16 and will be removed in version 3.0.**
+>
+> The JSON helper accepts an array of options that will be passed to `Laminas\Json\Json::encode()` and
+> used internally to encode data.
+> `Laminas\Json\Json::encode` allows the encoding of native JSON expressions using `Laminas\Json\Expr`
+> objects. This option is disabled by default. To enable this option, pass a boolean `true` to the
+> `enableJsonExprFinder` key of the options array:
+>
+> ```php
+> <?= $this->json($this->data, ['enableJsonExprFinder' => true]) ?>
+> ``
 >
 > The JSON helper accepts an array of options that will be passed to `Laminas\Json\Json::encode()` and
 > used internally to encode data.

--- a/docs/book/helpers/json.md
+++ b/docs/book/helpers/json.md
@@ -31,4 +31,5 @@ determine how to handle the content.
 > ```php
 > <?= $this->json($this->data, ['enableJsonExprFinder' => true]) ?>
 > ```
+>
 > **This feature of the Json view helper has been deprecated in 2.16.x and will be removed in 3.x**

--- a/docs/book/helpers/json.md
+++ b/docs/book/helpers/json.md
@@ -20,7 +20,7 @@ determine how to handle the content.
 <?= $this->json($this->data) ?>
 ```
 
-> ### Enabling encoding using Laminas\Json\Expr
+> ### Enabling encoding using Laminas\Json\Expr _(Deprecated)_
 >
 > The JSON helper accepts an array of options that will be passed to `Laminas\Json\Json::encode()` and
 > used internally to encode data.
@@ -31,3 +31,4 @@ determine how to handle the content.
 > ```php
 > <?= $this->json($this->data, ['enableJsonExprFinder' => true]) ?>
 > ```
+> **This feature of the Json view helper has been deprecated in 2.16.x and will be removed in 3.x**

--- a/docs/book/helpers/json.md
+++ b/docs/book/helpers/json.md
@@ -45,5 +45,3 @@ determine how to handle the content.
 > ```php
 > <?= $this->json($this->data, ['enableJsonExprFinder' => true]) ?>
 > ```
->
-> **This feature of the Json view helper has been deprecated in 2.16.x and will be removed in 3.x**

--- a/docs/book/helpers/json.md
+++ b/docs/book/helpers/json.md
@@ -21,9 +21,9 @@ determine how to handle the content.
 ```
 
 > WARNING: **Deprecated**
-> 
+>
 > ### Enabling encoding using Laminas\Json\Expr
-> 
+>
 > **This feature of the Json view helper has been deprecated in version 2.16 and will be removed in version 3.0.**
 >
 > The JSON helper accepts an array of options that will be passed to `Laminas\Json\Json::encode()` and

--- a/src/Helper/Json.php
+++ b/src/Helper/Json.php
@@ -5,6 +5,10 @@ namespace Laminas\View\Helper;
 use Laminas\Http\Response;
 use Laminas\Json\Json as JsonFormatter;
 
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
+
 /**
  * Helper for simplifying JSON responses
  */
@@ -24,6 +28,13 @@ class Json extends AbstractHelper
      */
     public function __invoke($data, array $jsonOptions = [])
     {
+        if (isset($jsonOptions['enableJsonExprFinder']) && $jsonOptions['enableJsonExprFinder'] === true) {
+            trigger_error(
+                'Json Expression functionality is deprecated and will be removed in laminas-view 3.0',
+                E_USER_DEPRECATED
+            );
+        }
+
         $data = JsonFormatter::encode($data, null, $jsonOptions);
 
         if ($this->response instanceof Response) {

--- a/test/Helper/JsonTest.php
+++ b/test/Helper/JsonTest.php
@@ -2,10 +2,13 @@
 
 namespace LaminasTest\View\Helper;
 
+use Laminas\Http\Header\HeaderInterface;
 use Laminas\Http\Response;
 use Laminas\Json\Json as JsonFormatter;
 use Laminas\View\Helper\Json as JsonHelper;
 use PHPUnit\Framework\TestCase;
+
+use function assert;
 
 /**
  * Test class for Laminas\View\Helper\Json
@@ -15,6 +18,11 @@ use PHPUnit\Framework\TestCase;
  */
 class JsonTest extends TestCase
 {
+    /** @var Response */
+    private $response;
+    /** @var JsonHelper */
+    private $helper;
+
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
@@ -31,6 +39,7 @@ class JsonTest extends TestCase
         $headers = $this->response->getHeaders();
         $this->assertTrue($headers->has('Content-Type'));
         $header = $headers->get('Content-Type');
+        self::assertInstanceOf(HeaderInterface::class, $header);
         $this->assertEquals('application/json', $header->getFieldValue());
     }
 
@@ -45,5 +54,17 @@ class JsonTest extends TestCase
         $data = $this->helper->__invoke('foobar');
         $this->assertIsString($data);
         $this->assertEquals('foobar', JsonFormatter::decode($data));
+    }
+
+    public function testThatADeprecationErrorIsTriggeredWhenExpressionFinderOptionIsUsed(): void
+    {
+        $this->expectDeprecation();
+        $this->helper->__invoke(['foo'], ['enableJsonExprFinder' => true]);
+    }
+
+    public function testThatADeprecationErrorIsNotTriggeredWhenExpressionFinderOptionIsNotUsed(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $this->helper->__invoke(['foo'], ['enableJsonExprFinder' => 'anything other than true']);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | no
| New Feature   | kindof

### Description

As per [discussion](https://github.com/laminas/laminas-view/pull/68#issuecomment-789062431) about removing the dependency on `laminas-json` in #68 - This adds a deprecation warning when the relevant option is detected paving the way for removal in 3.0