### PR TITLE
Use htmlattributes helper alias instead of hardcode class

### DIFF
--- a/src/Helper/AbstractHtmlElement.php
+++ b/src/Helper/AbstractHtmlElement.php
@@ -64,7 +64,7 @@ abstract class AbstractHtmlElement extends AbstractHelper
             }
         }
 
-        $attribs = $this->getView()->plugin(HtmlAttributes::class)($attribs);
+        $attribs = $this->getView()->plugin('htmlattributes')($attribs);
 
         return (string) $attribs;
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Currently AbstractHtmlElement uses hardcoded htmlattributes helper so we cannot use a custom helper by overding it via view_helpers config

This PR uses the helper alias
