### PR TITLE
Deprecates `ConsoleModel` and `ConsoleRenderer` for removal in `3.0.0`

### DIFF
--- a/src/Model/ConsoleModel.php
+++ b/src/Model/ConsoleModel.php
@@ -6,6 +6,9 @@ namespace Laminas\View\Model;
 
 use function array_key_exists;
 
+/**
+ * @deprecated
+ */
 class ConsoleModel extends ViewModel
 {
     public const RESULT = 'result';

--- a/src/Renderer/ConsoleRenderer.php
+++ b/src/Renderer/ConsoleRenderer.php
@@ -17,6 +17,8 @@ use function method_exists;
  * Note: all private variables in this class are prefixed with "__". This is to
  * mark them as part of the internal implementation, and thus prevent conflict
  * with variables injected into the renderer.
+ *
+ * @deprecated
  */
 class ConsoleRenderer implements RendererInterface, TreeRendererInterface
 {

--- a/test/Model/ConsoleModelTest.php
+++ b/test/Model/ConsoleModelTest.php
@@ -12,6 +12,7 @@ class ConsoleModelTest extends TestCase
 {
     public function testImplementsModelInterface(): void
     {
+        /** @psalm-suppress DeprecatedClass */
         $model = new ConsoleModel();
         $this->assertInstanceOf(ModelInterface::class, $model);
     }
@@ -21,6 +22,7 @@ class ConsoleModelTest extends TestCase
      */
     public function testSetErrorLevelImplementsFluentInterface(): void
     {
+        /** @psalm-suppress DeprecatedClass */
         $model  = new ConsoleModel();
         $actual = $model->setErrorLevel(0);
         $this->assertSame($model, $actual);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no - There does not appear to be any docs related to console in the docs tree
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | yes
| QA            | no

### Description

Considering that laminas-console and mvc-console are both abandoned, this pull deprecates the console model and renderer for removal in 3.0