### PR TITLE
Update locked deps, refine types in `TemplatePathStack`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -135,16 +135,16 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.6.4",
+            "version": "3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "830a36d93aeaf06e540e90ec031babb3c6eafadb"
+                "reference": "cba75fad2053bb5dc8d3e7f5e62b61d75eecfaf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/830a36d93aeaf06e540e90ec031babb3c6eafadb",
-                "reference": "830a36d93aeaf06e540e90ec031babb3c6eafadb",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/cba75fad2053bb5dc8d3e7f5e62b61d75eecfaf1",
+                "reference": "cba75fad2053bb5dc8d3e7f5e62b61d75eecfaf1",
                 "shasum": ""
             },
             "require": {
@@ -155,8 +155,8 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.3.0",
-                "phpbench/phpbench": "^0.17.1",
-                "phpunit/phpunit": "~9.3.7",
+                "phpbench/phpbench": "^1.0",
+                "phpunit/phpunit": "^9.3.7",
                 "psalm/plugin-phpunit": "^0.16.0",
                 "vimeo/psalm": "^4.7"
             },
@@ -190,7 +190,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-12-29T14:33:01+00:00"
+            "time": "2022-01-10T11:18:55+00:00"
         }
     ],
     "packages-dev": [
@@ -1924,33 +1924,35 @@
         },
         {
             "name": "laminas/laminas-mvc-plugin-flashmessenger",
-            "version": "1.5.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-mvc-plugin-flashmessenger.git",
-                "reference": "178339e7eb0e34e220e2fe543832f4eed7fb5705"
+                "reference": "420a99df81432140d78799a2e7cb34931fcdd619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-mvc-plugin-flashmessenger/zipball/178339e7eb0e34e220e2fe543832f4eed7fb5705",
-                "reference": "178339e7eb0e34e220e2fe543832f4eed7fb5705",
+                "url": "https://api.github.com/repos/laminas/laminas-mvc-plugin-flashmessenger/zipball/420a99df81432140d78799a2e7cb34931fcdd619",
+                "reference": "420a99df81432140d78799a2e7cb34931fcdd619",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-mvc": "^3.0",
-                "laminas/laminas-session": "^2.8.5",
-                "laminas/laminas-stdlib": "^3.2.1",
-                "laminas/laminas-view": "^2.12",
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "laminas/laminas-mvc": "^3.3",
+                "laminas/laminas-session": "^2.12.0",
+                "laminas/laminas-stdlib": "^3.6.4",
+                "laminas/laminas-view": "^2.13.1",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
                 "laminas/laminas-mvc": "<3.0.0",
                 "zendframework/zend-mvc-plugin-flashmessenger": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-i18n": "^2.8",
-                "phpunit/phpunit": "^9.3"
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-i18n": "^2.13.0",
+                "phpunit/phpunit": "^9.5.4",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.18"
             },
             "type": "library",
             "extra": {
@@ -1987,7 +1989,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-12-08T07:02:11+00:00"
+            "time": "2022-01-10T11:32:19+00:00"
         },
         {
             "name": "laminas/laminas-navigation",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.18.0.0">
+<files psalm-version="4.18.1@dda05fa913f4dc6eb3386f2f7ce5a45d37a71bcb">
   <file src="bin/templatemap_generator.php">
     <MissingParamType occurrences="1">
       <code>$templatePath</code>
@@ -2208,35 +2208,24 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Resolver/TemplatePathStack.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>gettype($options)</code>
+    <DocblockTypeContradiction occurrences="1">
       <code>is_string($path)</code>
     </DocblockTypeContradiction>
     <FalsableReturnStatement occurrences="2">
       <code>false</code>
       <code>false</code>
     </FalsableReturnStatement>
-    <MixedArgument occurrences="7">
-      <code>$key</code>
-      <code>$path</code>
-      <code>$path</code>
+    <MixedArgument occurrences="4">
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedAssignment occurrences="6">
-      <code>$key</code>
-      <code>$path</code>
-      <code>$path</code>
+    <MixedAssignment occurrences="3">
       <code>$this-&gt;lastLookupFailure</code>
       <code>$this-&gt;lastLookupFailure</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedOperand occurrences="2">
-      <code>$path</code>
-      <code>$path</code>
-    </MixedOperand>
     <NullArgument occurrences="1">
       <code>$this-&gt;paths</code>
     </NullArgument>
@@ -2245,10 +2234,6 @@
       <code>(bool) $flag</code>
       <code>(string) $defaultSuffix</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="2">
-      <code>is_array($paths)</code>
-      <code>is_object($options)</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Strategy/FeedStrategy.php">
     <MixedAssignment occurrences="1">

--- a/src/Resolver/TemplatePathStack.php
+++ b/src/Resolver/TemplatePathStack.php
@@ -35,6 +35,8 @@ use const PATHINFO_EXTENSION;
 
 /**
  * Resolves view scripts based on a stack of paths
+ *
+ * @psalm-type PathStack = SplStack<string>
  */
 class TemplatePathStack implements ResolverInterface
 {
@@ -50,7 +52,7 @@ class TemplatePathStack implements ResolverInterface
      */
     protected $defaultSuffix = 'phtml';
 
-    /** @var SplStack */
+    /** @var PathStack */
     protected $paths;
 
     /**
@@ -81,7 +83,7 @@ class TemplatePathStack implements ResolverInterface
     /**
      * Constructor
      *
-     * @param  null|array|Traversable $options
+     * @param  null|array<string, mixed>|Traversable<string, mixed> $options
      */
     public function __construct($options = null)
     {
@@ -93,7 +95,9 @@ class TemplatePathStack implements ResolverInterface
             }
         }
 
-        $this->paths = new SplStack();
+        /** @psalm-var PathStack $paths */
+        $paths       = new SplStack();
+        $this->paths = $paths;
         if (null !== $options) {
             $this->setOptions($options);
         }
@@ -102,12 +106,13 @@ class TemplatePathStack implements ResolverInterface
     /**
      * Configure object
      *
-     * @param  array|Traversable $options
+     * @param  array<string, mixed>|Traversable<string, mixed> $options
      * @return void
      * @throws Exception\InvalidArgumentException
      */
     public function setOptions($options)
     {
+        /** @psalm-suppress DocblockTypeContradiction */
         if (! is_array($options) && ! $options instanceof Traversable) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Expected array or Traversable object; received "%s"',
@@ -162,7 +167,7 @@ class TemplatePathStack implements ResolverInterface
     /**
      * Add many paths to the stack at once
      *
-     * @param  array $paths
+     * @param  list<string> $paths
      * @return TemplatePathStack
      */
     public function addPaths(array $paths)
@@ -176,7 +181,7 @@ class TemplatePathStack implements ResolverInterface
     /**
      * Rest the path stack to the paths provided
      *
-     * @param  SplStack|array $paths
+     * @param  PathStack|list<string> $paths
      * @return TemplatePathStack
      * @throws Exception\InvalidArgumentException
      */
@@ -184,16 +189,21 @@ class TemplatePathStack implements ResolverInterface
     {
         if ($paths instanceof SplStack) {
             $this->paths = $paths;
-        } elseif (is_array($paths)) {
-            $this->clearPaths();
-            $this->addPaths($paths);
-        } else {
-            throw new Exception\InvalidArgumentException(
-                "Invalid argument provided for \$paths, expecting either an array or SplStack object"
-            );
+
+            return $this;
         }
 
-        return $this;
+        /** @psalm-suppress RedundantConditionGivenDocblockType */
+        if (is_array($paths)) {
+            $this->clearPaths();
+            $this->addPaths($paths);
+
+            return $this;
+        }
+
+        throw new Exception\InvalidArgumentException(
+            "Invalid argument provided for \$paths, expecting either an array or SplStack object"
+        );
     }
 
     /**
@@ -236,13 +246,15 @@ class TemplatePathStack implements ResolverInterface
      */
     public function clearPaths()
     {
-        $this->paths = new SplStack();
+        /** @psalm-var PathStack $paths */
+        $paths       = new SplStack();
+        $this->paths = $paths;
     }
 
     /**
      * Returns stack of paths
      *
-     * @return SplStack
+     * @return PathStack
      */
     public function getPaths()
     {

--- a/test/Resolver/TemplatePathStackTest.php
+++ b/test/Resolver/TemplatePathStackTest.php
@@ -204,7 +204,7 @@ class TemplatePathStackTest extends TestCase
     }
 
     /**
-     * @return array<array-key, array{0: mixed[]|ArrayObject}>
+     * @return array<array-key, array{0: array<string, mixed>|ArrayObject<string, mixed>}>
      */
     public function validOptions(): array
     {
@@ -220,7 +220,7 @@ class TemplatePathStackTest extends TestCase
     }
 
     /**
-     * @param array|ArrayObject $options
+     * @param array<string, mixed>|ArrayObject<string, mixed> $options
      * @dataProvider validOptions
      */
     public function testAllowsSettingOptions($options): void
@@ -239,7 +239,7 @@ class TemplatePathStackTest extends TestCase
     }
 
     /**
-     * @param array|ArrayObject $options
+     * @param array<string, mixed>|ArrayObject<string, mixed> $options
      * @dataProvider validOptions
      */
     public function testAllowsPassingOptionsToConstructor($options): void


### PR DESCRIPTION
### Description

Updates locked versions of stdlib and flash messenger solving psalm errors introduced by type improvements therein. This will make further pulls to ^2 slightly less noisy.
