### PR TITLE
Remove Irrelevant MVC 2 Compat, since only `laminas/laminas-mvc:^3` is now installable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "laminas/laminas-http": "^2.15",
         "laminas/laminas-i18n": "^2.6",
         "laminas/laminas-modulemanager": "^2.7.1",
-        "laminas/laminas-mvc": "^2.7.14 || ^3.0",
+        "laminas/laminas-mvc": "^3.0",
         "laminas/laminas-mvc-i18n": "^1.1",
         "laminas/laminas-mvc-plugin-flashmessenger": "^1.5.0",
         "laminas/laminas-navigation": "^2.13.1",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -198,7 +198,7 @@
       <code>$escapeHtmlHelper</code>
       <code>$pluginFlashMessenger</code>
     </MissingConstructor>
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="2">
       <code>$item</code>
       <code>$messagesToPrint</code>
     </MixedArgument>
@@ -217,9 +217,6 @@
       <code>$messagesToPrint[]</code>
       <code>$this-&gt;escapeHtmlHelper</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>FlashMessenger</code>
-    </MixedInferredReturnType>
     <RedundantCastGivenDocblockType occurrences="4">
       <code>(bool) $autoEscape</code>
       <code>(string) $messageCloseString</code>
@@ -230,17 +227,6 @@
       <code>$this-&gt;escapeHtmlHelper</code>
       <code>$this-&gt;escapeHtmlHelper</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedClass occurrences="1">
-      <code>V2PluginFlashMessenger</code>
-    </UndefinedClass>
-    <UndefinedDocblockClass occurrences="6">
-      <code>$flashMessenger</code>
-      <code>$flashMessenger</code>
-      <code>$flashMessenger</code>
-      <code>V2PluginFlashMessenger|PluginFlashMessenger</code>
-      <code>V2PluginFlashMessenger|PluginFlashMessenger</code>
-      <code>V2PluginFlashMessenger|PluginFlashMessenger</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="src/Helper/Gravatar.php">
     <DocblockTypeContradiction occurrences="1">
@@ -2523,20 +2509,6 @@
       <code>renderCurrent</code>
       <code>renderCurrent</code>
     </PossiblyInvalidMethodCall>
-    <UndefinedClass occurrences="7">
-      <code>$this-&gt;plugin</code>
-      <code>$this-&gt;plugin</code>
-      <code>$this-&gt;plugin</code>
-      <code>$this-&gt;plugin</code>
-      <code>$this-&gt;plugin</code>
-      <code>$this-&gt;plugin</code>
-      <code>$this-&gt;plugin</code>
-    </UndefinedClass>
-    <UndefinedDocblockClass occurrences="3">
-      <code>$this-&gt;plugin</code>
-      <code>$this-&gt;plugin</code>
-      <code>V2PluginFlashMessenger|V3PluginFlashMessenger</code>
-    </UndefinedDocblockClass>
     <UndefinedMethod occurrences="1">
       <code>getMessagesFromNamespace</code>
     </UndefinedMethod>
@@ -3612,13 +3584,7 @@
       <code>$this-&gt;getServiceNotFoundException()</code>
       <code>$this-&gt;getServiceNotFoundException()</code>
     </ArgumentTypeCoercion>
-    <MissingClosureParamType occurrences="3">
-      <code>$name</code>
-      <code>$options</code>
-      <code>$services</code>
-    </MissingClosureParamType>
-    <MixedArgument occurrences="3">
-      <code>$services</code>
+    <MixedArgument occurrences="2">
       <code>$target</code>
       <code>$target</code>
     </MixedArgument>
@@ -3630,13 +3596,6 @@
     <MixedInferredReturnType occurrences="1">
       <code>Generator&lt;mixed, array{0: mixed, 1: mixed}, mixed, void&gt;</code>
     </MixedInferredReturnType>
-    <UndefinedClass occurrences="1">
-      <code>V2FlashMessenger</code>
-    </UndefinedClass>
-    <UnusedClosureParam occurrences="2">
-      <code>$name</code>
-      <code>$options</code>
-    </UnusedClosureParam>
   </file>
   <file src="test/HelperPluginManagerTest.php">
     <MissingClosureParamType occurrences="2">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.18.0.0">
+<files psalm-version="4.18.1@dda05fa913f4dc6eb3386f2f7ce5a45d37a71bcb">
   <file src="bin/templatemap_generator.php">
     <MissingParamType occurrences="1">
       <code>$templatePath</code>
@@ -1768,63 +1768,21 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Helper/Url.php">
-    <DocblockTypeContradiction occurrences="4">
+    <DocblockTypeContradiction occurrences="3">
       <code>3 === func_num_args() &amp;&amp; is_bool($options)</code>
       <code>is_array($params)</code>
       <code>is_bool($options)</code>
-      <code>null === $this-&gt;router</code>
     </DocblockTypeContradiction>
     <InvalidArrayAssignment occurrences="1">
       <code>$options['name']</code>
     </InvalidArrayAssignment>
-    <InvalidDocblock occurrences="1">
-      <code>protected $routeMatch;</code>
-    </InvalidDocblock>
-    <MissingConstructor occurrences="1">
-      <code>$router</code>
-    </MissingConstructor>
-    <MissingPropertyType occurrences="1">
-      <code>$routeMatch</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="1">
-      <code>$routeMatchParams</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="3">
-      <code>$routeMatchParams[ModuleRouteListener::MODULE_NAMESPACE]</code>
-      <code>$routeMatchParams[ModuleRouteListener::ORIGINAL_CONTROLLER]</code>
-      <code>$routeMatchParams[ModuleRouteListener::ORIGINAL_CONTROLLER]</code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="1">
-      <code>$routeMatchParams['controller']</code>
-    </MixedArrayAssignment>
-    <MixedAssignment occurrences="5">
-      <code>$name</code>
-      <code>$options['name']</code>
+    <MixedAssignment occurrences="2">
       <code>$reuseMatchedParams</code>
-      <code>$routeMatchParams</code>
       <code>$routeMatchParams['controller']</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="3">
-      <code>Url</code>
-      <code>Url</code>
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="2">
-      <code>getMatchedRouteName</code>
-      <code>getParams</code>
-    </MixedMethodCall>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;router-&gt;assemble($params, $options)</code>
-    </MixedReturnStatement>
     <PossiblyInvalidArgument occurrences="1">
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <UndefinedDocblockClass occurrences="4">
-      <code>$this-&gt;router</code>
-      <code>LegacyRouteMatch|RouteMatch</code>
-      <code>LegacyRouteStackInterface|RouteStackInterface</code>
-      <code>LegacyRouteStackInterface|RouteStackInterface</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="src/Helper/ViewModel.php">
     <MissingConstructor occurrences="2">

--- a/src/Helper/FlashMessenger.php
+++ b/src/Helper/FlashMessenger.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper;
 
-use Laminas\Mvc\Controller\Plugin\FlashMessenger as V2PluginFlashMessenger;
 use Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger as PluginFlashMessenger;
 use Laminas\View\Exception\InvalidArgumentException;
 
 use function array_walk_recursive;
 use function call_user_func_array;
-use function class_exists;
 use function get_class;
 use function gettype;
 use function implode;
@@ -73,7 +71,7 @@ class FlashMessenger extends AbstractHelper
     /**
      * Flash messenger plugin
      *
-     * @var V2PluginFlashMessenger|PluginFlashMessenger
+     * @var PluginFlashMessenger
      */
     protected $pluginFlashMessenger;
 
@@ -298,20 +296,17 @@ class FlashMessenger extends AbstractHelper
     /**
      * Set the flash messenger plugin
      *
-     * @param  V2PluginFlashMessenger|PluginFlashMessenger $pluginFlashMessenger
+     * @param  PluginFlashMessenger $pluginFlashMessenger
      * @return FlashMessenger
      * @throws InvalidArgumentException For an invalid $pluginFlashMessenger.
+     * @psalm-suppress RedundantConditionGivenDocblockType, DocblockTypeContradiction
      */
     public function setPluginFlashMessenger($pluginFlashMessenger)
     {
-        if (
-            ! $pluginFlashMessenger instanceof V2PluginFlashMessenger
-            && ! $pluginFlashMessenger instanceof PluginFlashMessenger
-        ) {
+        if (! $pluginFlashMessenger instanceof PluginFlashMessenger) {
             throw new InvalidArgumentException(sprintf(
-                '%s expects either a %s or %s instance; received %s',
+                '%s expects a %s instance; received %s',
                 __METHOD__,
-                V2PluginFlashMessenger::class,
                 PluginFlashMessenger::class,
                 is_object($pluginFlashMessenger) ? get_class($pluginFlashMessenger) : gettype($pluginFlashMessenger)
             ));
@@ -324,16 +319,12 @@ class FlashMessenger extends AbstractHelper
     /**
      * Get the flash messenger plugin
      *
-     * @return V2PluginFlashMessenger|PluginFlashMessenger
+     * @return PluginFlashMessenger
      */
     public function getPluginFlashMessenger()
     {
         if (null === $this->pluginFlashMessenger) {
-            $this->setPluginFlashMessenger(
-                class_exists(PluginFlashMessenger::class)
-                ? new PluginFlashMessenger()
-                : new V2PluginFlashMessenger()
-            );
+            $this->setPluginFlashMessenger(new PluginFlashMessenger());
         }
 
         return $this->pluginFlashMessenger;

--- a/src/Helper/Url.php
+++ b/src/Helper/Url.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Laminas\View\Helper;
 
 use Laminas\Mvc\ModuleRouteListener;
-use Laminas\Mvc\Router\RouteMatch as LegacyRouteMatch;
-use Laminas\Mvc\Router\RouteStackInterface as LegacyRouteStackInterface;
 use Laminas\Router\RouteMatch;
 use Laminas\Router\RouteStackInterface;
 use Laminas\View\Exception;
@@ -30,35 +28,31 @@ class Url extends AbstractHelper
     /**
      * Router instance.
      *
-     * @var LegacyRouteStackInterface|RouteStackInterface
+     * @var RouteStackInterface|null
      */
     protected $router;
 
     /**
      * Route matches returned by the router.
      *
-     * @var LegacyRouteMatch|RouteMatch.
+     * @var RouteMatch|null
      */
     protected $routeMatch;
 
     /**
-     * Generates a url given the name of a route.
+     * Generates an url given the name of a route.
      *
-     * @see Laminas\Mvc\Router\RouteInterface::assemble()
-     * @see Laminas\Router\RouteInterface::assemble()
+     * @see \Laminas\Router\RouteInterface::assemble()
      *
-     * @param  string $name Name of the route
+     * @param  string|null $name Name of the route
      * @param  array $params Parameters for the link
      * @param  array|Traversable $options Options for the route
      * @param  bool $reuseMatchedParams Whether to reuse matched parameters
      * @return string Url For the link href attribute
-     * @throws Exception\RuntimeException If no RouteStackInterface was
-     *     provided.
+     * @throws Exception\RuntimeException If no RouteStackInterface was provided.
      * @throws Exception\RuntimeException If no RouteMatch was provided.
-     * @throws Exception\RuntimeException If RouteMatch didn't contain a
-     *     matched route name.
-     * @throws Exception\InvalidArgumentException If the params object was not
-     *     an array or Traversable object.
+     * @throws Exception\RuntimeException If RouteMatch didn't contain a matched route name.
+     * @throws Exception\InvalidArgumentException If the params object was not an array or Traversable object.
      */
     public function __invoke($name = null, $params = [], $options = [], $reuseMatchedParams = false)
     {
@@ -76,9 +70,10 @@ class Url extends AbstractHelper
                 throw new Exception\RuntimeException('No RouteMatch instance provided');
             }
 
-            $name = $this->routeMatch->getMatchedRouteName();
+            /** @psalm-suppress RedundantCastGivenDocblockType */
+            $name = (string) $this->routeMatch->getMatchedRouteName();
 
-            if ($name === null) {
+            if ($name === '') {
                 throw new Exception\RuntimeException('RouteMatch does not contain a matched route name');
             }
         }
@@ -109,27 +104,24 @@ class Url extends AbstractHelper
 
         $options['name'] = $name;
 
-        return $this->router->assemble($params, $options);
+        return (string) $this->router->assemble($params, $options);
     }
 
     /**
      * Set the router to use for assembling.
      *
-     * @param LegacyRouteStackInterface|RouteStackInterface $router
+     * @param RouteStackInterface $router
      * @return Url
      * @throws Exception\InvalidArgumentException For invalid router types.
+     * @psalm-suppress RedundantConditionGivenDocblockType, DocblockTypeContradiction
      */
     public function setRouter($router)
     {
-        if (
-            ! $router instanceof RouteStackInterface
-            && ! $router instanceof LegacyRouteStackInterface
-        ) {
+        if (! $router instanceof RouteStackInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects a %s or %s instance; received %s',
+                '%s expects a %s instance; received %s',
                 __METHOD__,
                 RouteStackInterface::class,
-                LegacyRouteStackInterface::class,
                 is_object($router) ? get_class($router) : gettype($router)
             ));
         }
@@ -141,20 +133,17 @@ class Url extends AbstractHelper
     /**
      * Set route match returned by the router.
      *
-     * @param  LegacyRouteMatch|RouteMatch $routeMatch
+     * @param  RouteMatch $routeMatch
      * @return Url
+     * @psalm-suppress RedundantConditionGivenDocblockType, DocblockTypeContradiction
      */
     public function setRouteMatch($routeMatch)
     {
-        if (
-            ! $routeMatch instanceof RouteMatch
-            && ! $routeMatch instanceof LegacyRouteMatch
-        ) {
+        if (! $routeMatch instanceof RouteMatch) {
             throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects a %s or %s instance; received %s',
+                '%s expects a %s instance; received %s',
                 __METHOD__,
                 RouteMatch::class,
-                LegacyRouteMatch::class,
                 is_object($routeMatch) ? get_class($routeMatch) : gettype($routeMatch)
             ));
         }

--- a/test/Helper/FlashMessengerTest.php
+++ b/test/Helper/FlashMessengerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LaminasTest\View\Helper;
 
 use Laminas\I18n\Translator\Translator;
-use Laminas\Mvc\Controller\Plugin\FlashMessenger as V2PluginFlashMessenger;
 use Laminas\Mvc\Controller\PluginManager;
 use Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger as V3PluginFlashMessenger;
 use Laminas\ServiceManager\Config;
@@ -16,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
-use function class_exists;
 use function get_class;
 
 /**
@@ -33,14 +31,12 @@ class FlashMessengerTest extends TestCase
     private $mvcPluginClass;
     /** @var FlashMessenger */
     private $helper;
-    /** @var V2PluginFlashMessenger|V3PluginFlashMessenger */
+    /** @var V3PluginFlashMessenger */
     private $plugin;
 
     protected function setUp(): void
     {
-        $this->mvcPluginClass = class_exists(V2PluginFlashMessenger::class)
-            ? V2PluginFlashMessenger::class
-            : V3PluginFlashMessenger::class;
+        $this->mvcPluginClass = V3PluginFlashMessenger::class;
         /** @psalm-suppress DeprecatedClass */
         $this->helper = new FlashMessenger();
         $this->plugin = $this->helper->getPluginFlashMessenger();

--- a/test/HelperPluginManagerCompatibilityTest.php
+++ b/test/HelperPluginManagerCompatibilityTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LaminasTest\View;
 
 use Generator;
-use Laminas\Mvc\Controller\Plugin\FlashMessenger as V2FlashMessenger;
 use Laminas\Mvc\Controller\PluginManager as ControllerPluginManager;
 use Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger;
 use Laminas\ServiceManager\Config;
@@ -14,6 +13,7 @@ use Laminas\ServiceManager\Test\CommonPluginManagerTrait;
 use Laminas\View\Exception\InvalidHelperException;
 use Laminas\View\HelperPluginManager;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use ReflectionProperty;
 
 use function class_exists;
@@ -29,12 +29,10 @@ class HelperPluginManagerCompatibilityTest extends TestCase
 
         if (class_exists(ControllerPluginManager::class)) {
             // @codingStandardsIgnoreLine
-            $factories['ControllerPluginManager'] = function ($services, $name, $options): \Laminas\Mvc\Controller\PluginManager {
+            $factories['ControllerPluginManager'] = function (ContainerInterface $services): ControllerPluginManager {
                 return new ControllerPluginManager($services, [
                     'invokables' => [
-                        'flashmessenger' => class_exists(FlashMessenger::class)
-                            ? FlashMessenger::class
-                            : V2FlashMessenger::class,
+                        'flashmessenger' => FlashMessenger::class,
                     ],
                 ]);
             };


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

It's not possible to install view at any version more recent that ^2.16 in MVC versions before 3.x so this pull removes compat for versions prior to 3.x