### PR TITLE
Remove `laminas/laminas-servicemanager:^2` compatibility: only `^3` supported now

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.18.0.0">
+<files psalm-version="4.18.1@dda05fa913f4dc6eb3386f2f7ce5a45d37a71bcb">
   <file src="bin/templatemap_generator.php">
     <MissingParamType occurrences="1">
       <code>$templatePath</code>
@@ -862,10 +862,9 @@
       <code>$view</code>
       <code>$view</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="5">
+    <RedundantConditionGivenDocblockType occurrences="4">
       <code>$helper</code>
       <code>$helper</code>
-      <code>$this-&gt;getServiceLocator()</code>
       <code>$this-&gt;plugins</code>
       <code>$view &amp;&amp; $this-&gt;plugins</code>
     </RedundantConditionGivenDocblockType>
@@ -875,16 +874,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/Navigation/AbstractHelper.php">
-    <DeprecatedMethod occurrences="2">
-      <code>getServiceLocator</code>
-      <code>getServiceLocator</code>
-    </DeprecatedMethod>
-    <DocblockTypeContradiction occurrences="6">
-      <code>! $services</code>
+    <DocblockTypeContradiction occurrences="3">
       <code>! is_int($this-&gt;minDepth)</code>
       <code>! is_string($message)</code>
-      <code>$services</code>
-      <code>$this-&gt;role === null</code>
       <code>null === $this-&gt;container</code>
     </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch occurrences="2">
@@ -894,7 +886,7 @@
     <InvalidThrow occurrences="1">
       <code>Navigation\Exception\ExceptionInterface</code>
     </InvalidThrow>
-    <MissingConstructor occurrences="29">
+    <MissingConstructor occurrences="19">
       <code>$container</code>
       <code>$container</code>
       <code>$container</code>
@@ -914,28 +906,16 @@
       <code>$minDepth</code>
       <code>$minDepth</code>
       <code>$minDepth</code>
-      <code>$role</code>
-      <code>$role</code>
-      <code>$role</code>
-      <code>$role</code>
-      <code>$role</code>
-      <code>$serviceLocator</code>
-      <code>$serviceLocator</code>
-      <code>$serviceLocator</code>
-      <code>$serviceLocator</code>
-      <code>$serviceLocator</code>
     </MissingConstructor>
     <MixedArgument occurrences="2">
       <code>$page-&gt;getTextDomain()</code>
       <code>$page-&gt;getTextDomain()</code>
     </MixedArgument>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="5">
       <code>$container</code>
       <code>$container</code>
       <code>$container</code>
       <code>$label</code>
-      <code>$serviceLocator</code>
-      <code>$this-&gt;serviceLocator</code>
       <code>$value</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
@@ -962,10 +942,9 @@
     <PossiblyNullArgument occurrences="1">
       <code>$page-&gt;getTitle()</code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="3">
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
       <code>$maxDepth</code>
       <code>$minDepth</code>
-      <code>$role</code>
     </PossiblyNullPropertyAssignmentValue>
     <PossiblyNullReference occurrences="4">
       <code>attach</code>
@@ -978,17 +957,12 @@
       <code>(bool) $useAcl</code>
       <code>(string) $indent</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="11">
-      <code>$serviceLocator-&gt;getServiceLocator()</code>
+    <RedundantConditionGivenDocblockType occurrences="5">
       <code>$this-&gt;acl === null &amp;&amp; static::$defaultAcl !== null</code>
-      <code>$this-&gt;role === null &amp;&amp; static::$defaultRole !== null</code>
       <code>is_int($maxDepth)</code>
       <code>is_int($minDepth)</code>
-      <code>is_string($this-&gt;role)</code>
-      <code>is_string(static::$defaultRole)</code>
       <code>null !== $this-&gt;container</code>
       <code>static::$defaultAcl !== null</code>
-      <code>static::$defaultRole !== null</code>
     </RedundantConditionGivenDocblockType>
     <UndefinedInterfaceMethod occurrences="1">
       <code>plugin</code>
@@ -1664,20 +1638,13 @@
     <MixedArrayAccess occurrences="1">
       <code>$config['view_helper_config']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$config</code>
       <code>$configHelper</code>
-      <code>$container</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
-      <code>get</code>
-    </MixedMethodCall>
     <PossiblyNullArgument occurrences="1">
       <code>$cName</code>
     </PossiblyNullArgument>
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>getServiceLocator</code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/Service/DoctypeFactory.php">
     <MixedArgument occurrences="1">
@@ -1711,14 +1678,13 @@
       <code>$configHelper['message_separator_string']</code>
       <code>$config['view_helper_config']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$config</code>
       <code>$configHelper</code>
-      <code>$container</code>
       <code>$controllerPluginManager</code>
       <code>$flashMessenger</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall occurrences="1">
       <code>get</code>
       <code>get</code>
       <code>get</code>
@@ -1729,20 +1695,11 @@
     <PossiblyNullArgument occurrences="1">
       <code>$requestedName</code>
     </PossiblyNullArgument>
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>getServiceLocator</code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/Service/IdentityFactory.php">
     <DeprecatedInterface occurrences="1">
       <code>IdentityFactory</code>
     </DeprecatedInterface>
-    <MixedArgument occurrences="1">
-      <code>$container</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$container</code>
-    </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
       <code>null|AuthenticationServiceInterface</code>
     </MixedInferredReturnType>
@@ -1753,9 +1710,6 @@
     <PossiblyNullArgument occurrences="1">
       <code>$cName</code>
     </PossiblyNullArgument>
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>getServiceLocator</code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/TranslatorAwareTrait.php">
     <DeprecatedClass occurrences="3">
@@ -3281,12 +3235,6 @@
     <UnusedClosureParam occurrences="1">
       <code>$code</code>
     </UnusedClosureParam>
-  </file>
-  <file src="test/Helper/Navigation/PluginManagerCompatibilityTest.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>$this-&gt;getServiceNotFoundException()</code>
-      <code>$this-&gt;getServiceNotFoundException()</code>
-    </ArgumentTypeCoercion>
   </file>
   <file src="test/Helper/Navigation/SitemapTest.php">
     <MixedArgument occurrences="2">

--- a/src/Helper/Navigation/AbstractHelper.php
+++ b/src/Helper/Navigation/AbstractHelper.php
@@ -14,14 +14,12 @@ use Laminas\Navigation\AbstractContainer;
 use Laminas\Navigation\Page\AbstractPage;
 use Laminas\Permissions\Acl;
 use Laminas\Permissions\Acl\AclInterface;
-use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\View;
 use Laminas\View\Exception;
 use Laminas\View\Helper\Navigation\Listener\AclListener;
 use Laminas\View\Helper\TranslatorAwareTrait;
 use RecursiveIteratorIterator;
 use ReflectionClass;
-use ReflectionProperty;
 
 use function call_user_func_array;
 use function get_class;
@@ -30,7 +28,6 @@ use function in_array;
 use function is_int;
 use function is_object;
 use function is_string;
-use function method_exists;
 use function sprintf;
 use function str_repeat;
 use function strlen;
@@ -101,11 +98,11 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     /**
      * ACL role to use when iterating pages
      *
-     * @var string|Acl\Role\RoleInterface
+     * @var string|Acl\Role\RoleInterface|null
      */
     protected $role;
 
-    /** @var ContainerInterface */
+    /** @var ContainerInterface|null */
     protected $serviceLocator;
 
     /**
@@ -127,7 +124,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      * Default ACL role to use when iterating pages if not explicitly set in the
      * instance by calling {@link setRole()}
      *
-     * @var string|Acl\Role\RoleInterface
+     * @var string|Acl\Role\RoleInterface|null
      */
     protected static $defaultRole;
 
@@ -767,28 +764,6 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      */
     public function setServiceLocator(ContainerInterface $serviceLocator)
     {
-        // If we are provided a plugin manager, we should pull the parent
-        // context from it.
-        // @todo We should update tests and code to ensure that this situation
-        //       doesn't happen in the future.
-        if (
-            $serviceLocator instanceof AbstractPluginManager
-            && ! method_exists($serviceLocator, 'configure')
-            && $serviceLocator->getServiceLocator()
-        ) {
-            $serviceLocator = $serviceLocator->getServiceLocator();
-        }
-
-        // v3 variant; likely won't be needed.
-        if (
-            $serviceLocator instanceof AbstractPluginManager
-            && method_exists($serviceLocator, 'configure')
-        ) {
-            $r = new ReflectionProperty($serviceLocator, 'creationContext');
-            $r->setAccessible(true);
-            $serviceLocator = $r->getValue($serviceLocator);
-        }
-
         $this->serviceLocator = $serviceLocator;
         return $this;
     }
@@ -798,7 +773,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      *
      * Used internally to pull named navigation containers to render.
      *
-     * @return ContainerInterface
+     * @return ContainerInterface|null
      */
     public function getServiceLocator()
     {

--- a/src/Helper/Navigation/PluginManager.php
+++ b/src/Helper/Navigation/PluginManager.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Laminas\View\Helper\Navigation;
 
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\HelperPluginManager;
@@ -67,20 +66,19 @@ class PluginManager extends HelperPluginManager
     ];
 
     /**
-     * @param null|ConfigInterface|ContainerInterface $configOrContainerInstance
-     * @param array $v3config If $configOrContainerInstance is a container, this
-     *     value will be passed to the parent constructor.
+     * @param ContainerInterface $configOrContainerInstance
+     * @param array $v3config
      * @psalm-param ServiceManagerConfiguration $v3config
      */
     public function __construct($configOrContainerInstance = null, array $v3config = [])
     {
-        /** @psalm-suppress MissingClosureParamType */
+        /** @psalm-suppress UnusedClosureParam, MissingClosureParamType */
         $this->initializers[] = function (ContainerInterface $container, $instance): void {
             if (! $instance instanceof AbstractHelper) {
                 return;
             }
 
-            $instance->setServiceLocator($container);
+            $instance->setServiceLocator($this->creationContext);
         };
 
         parent::__construct($configOrContainerInstance, $v3config);

--- a/src/Helper/Service/AssetFactory.php
+++ b/src/Helper/Service/AssetFactory.php
@@ -11,7 +11,6 @@ use Laminas\View\Exception;
 use Laminas\View\Helper\Asset;
 
 use function is_array;
-use function method_exists;
 
 class AssetFactory implements FactoryInterface
 {
@@ -23,10 +22,6 @@ class AssetFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, ?array $options = null)
     {
-        // test if we are using Laminas\ServiceManager v2 or v3
-        if (! method_exists($container, 'configure')) {
-            $container = $container->getServiceLocator();
-        }
         $helper = new Asset();
 
         $config = $container->get('config');

--- a/src/Helper/Service/FlashMessengerFactory.php
+++ b/src/Helper/Service/FlashMessengerFactory.php
@@ -9,8 +9,6 @@ use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\View\Helper\FlashMessenger;
 
-use function method_exists;
-
 class FlashMessengerFactory implements FactoryInterface
 {
     /**
@@ -22,10 +20,6 @@ class FlashMessengerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, ?array $options = null)
     {
-        // test if we are using Laminas\ServiceManager v2 or v3
-        if (! method_exists($container, 'configure')) {
-            $container = $container->getServiceLocator();
-        }
         $helper                  = new FlashMessenger();
         $controllerPluginManager = $container->get('ControllerPluginManager');
         $flashMessenger          = $controllerPluginManager->get('flashmessenger');

--- a/src/Helper/Service/IdentityFactory.php
+++ b/src/Helper/Service/IdentityFactory.php
@@ -11,8 +11,6 @@ use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\View\Helper\Identity;
 
-use function method_exists;
-
 class IdentityFactory implements FactoryInterface
 {
     /**
@@ -22,11 +20,6 @@ class IdentityFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, ?array $options = null)
     {
-        // test if we are using Laminas\ServiceManager v2 or v3
-        if (! method_exists($container, 'configure')) {
-            $container = $container->getServiceLocator();
-        }
-
         $helper = new Identity();
 
         if (null !== ($authenticationService = $this->discoverAuthenticationService($container))) {

--- a/test/Helper/Navigation/BreadcrumbsTest.php
+++ b/test/Helper/Navigation/BreadcrumbsTest.php
@@ -7,7 +7,6 @@ namespace LaminasTest\View\Helper\Navigation;
 use Laminas\Navigation\Navigation;
 use Laminas\View\Exception\InvalidArgumentException;
 use Laminas\View\Helper\Navigation\Breadcrumbs;
-use Laminas\View\HelperPluginManager;
 
 use function extension_loaded;
 use function strlen;
@@ -69,8 +68,7 @@ class BreadcrumbsTest extends AbstractTest
 
     public function testHelperEntryPointWithContainerStringParam(): void
     {
-        $pm = new HelperPluginManager($this->serviceManager);
-        $this->_helper->setServiceLocator($pm);
+        $this->_helper->setServiceLocator($this->serviceManager);
 
         $returned = $this->_helper->__invoke('nav1');
         $this->assertEquals($this->_helper, $returned);

--- a/test/Helper/Navigation/LinksTest.php
+++ b/test/Helper/Navigation/LinksTest.php
@@ -66,8 +66,7 @@ class LinksTest extends AbstractTest
 
     public function testCanRenderFromServiceAlias(): void
     {
-        $sm = $this->serviceManager;
-        $this->_helper->setServiceLocator($sm);
+        $this->_helper->setServiceLocator($this->serviceManager);
 
         $returned = $this->_helper->render('Navigation');
         $this->assertEquals($returned, $this->getExpectedFileContents('links/default.html'));

--- a/test/Helper/Navigation/PluginManagerCompatibilityTest.php
+++ b/test/Helper/Navigation/PluginManagerCompatibilityTest.php
@@ -13,8 +13,6 @@ use Laminas\View\Helper\Navigation\Breadcrumbs;
 use Laminas\View\Helper\Navigation\PluginManager;
 use PHPUnit\Framework\TestCase;
 
-use function method_exists;
-
 /**
  * @group      Laminas_View
  */
@@ -37,34 +35,6 @@ class PluginManagerCompatibilityTest extends TestCase
         return AbstractHelper::class;
     }
 
-    /**
-     * @group 43
-     */
-    public function testConstructorArgumentsAreOptionalUnderV2(): void
-    {
-        $helpers = $this->getPluginManager();
-        if (method_exists($helpers, 'configure')) {
-            $this->markTestSkipped('laminas-servicemanager v3 plugin managers require a container argument');
-        }
-
-        $helpers = new PluginManager();
-        $this->assertInstanceOf(PluginManager::class, $helpers);
-    }
-
-    /**
-     * @group 43
-     */
-    public function testConstructorAllowsConfigInstanceAsFirstArgumentUnderV2(): void
-    {
-        $helpers = $this->getPluginManager();
-        if (method_exists($helpers, 'configure')) {
-            $this->markTestSkipped('laminas-servicemanager v3 plugin managers require a container argument');
-        }
-
-        $helpers = new PluginManager(new Config([]));
-        $this->assertInstanceOf(PluginManager::class, $helpers);
-    }
-
     public function testInjectsParentContainerIntoHelpers(): void
     {
         $config = new Config([
@@ -80,25 +50,5 @@ class PluginManagerCompatibilityTest extends TestCase
         $helper = $helpers->get('breadcrumbs');
         $this->assertInstanceOf(Breadcrumbs::class, $helper);
         $this->assertSame($services, $helper->getServiceLocator());
-    }
-
-    /**
-     * @todo remove this test once we set the minimum laminas-servicemanager version to 3
-     */
-    public function testRegisteringInvalidElementRaisesException(): void
-    {
-        $this->expectException($this->getServiceNotFoundException());
-        $this->getPluginManager()->setService('test', $this);
-    }
-
-    /**
-     * @todo remove this test once we set the minimum laminas-servicemanager version to 3
-     */
-    public function testLoadingInvalidElementRaisesException(): void
-    {
-        $manager = $this->getPluginManager();
-        $manager->setInvokableClass('test', static::class);
-        $this->expectException($this->getServiceNotFoundException());
-        $manager->get('test');
     }
 }

--- a/test/HelperPluginManagerTest.php
+++ b/test/HelperPluginManagerTest.php
@@ -30,38 +30,11 @@ class HelperPluginManagerTest extends TestCase
 {
     use ProphecyTrait;
 
-    /** @var HelperPluginManager */
-    private $helpers;
+    private HelperPluginManager $helpers;
 
     protected function setUp(): void
     {
         $this->helpers = new HelperPluginManager(new ServiceManager());
-    }
-
-    /**
-     * @group 43
-     */
-    public function testConstructorArgumentsAreOptionalUnderV2(): void
-    {
-        if (method_exists($this->helpers, 'configure')) {
-            $this->markTestSkipped('laminas-servicemanager v3 plugin managers require a container argument');
-        }
-
-        $helpers = new HelperPluginManager();
-        $this->assertInstanceOf(HelperPluginManager::class, $helpers);
-    }
-
-    /**
-     * @group 43
-     */
-    public function testConstructorAllowsConfigInstanceAsFirstArgumentUnderV2(): void
-    {
-        if (method_exists($this->helpers, 'configure')) {
-            $this->markTestSkipped('laminas-servicemanager v3 plugin managers require a container argument');
-        }
-
-        $helpers = new HelperPluginManager(new Config([]));
-        $this->assertInstanceOf(HelperPluginManager::class, $helpers);
     }
 
     public function testViewIsNullByDefault(): void
@@ -183,23 +156,6 @@ class HelperPluginManagerTest extends TestCase
         $helpers = new HelperPluginManager($services);
         $helper  = $helpers->get('HeadTitle');
         $this->assertSame($translator, $helper->getTranslator());
-    }
-
-    /**
-     * @group 47
-     */
-    public function testInjectTranslatorWillReturnEarlyIfThePluginManagerDoesNotHaveAParentContainer(): void
-    {
-        if (method_exists($this->helpers, 'configure')) {
-            $this->markTestSkipped(
-                'Skip test when testing against laminas-servicemanager v3, as that implementation '
-                . 'guarantees a parent container in plugin managers'
-            );
-        }
-        $helpers = new HelperPluginManager();
-        $helper  = new HeadTitle();
-        $this->assertNull($helpers->injectTranslator($helper, $helpers));
-        $this->assertNull($helper->getTranslator());
     }
 
     public function testInjectTranslatorWillReturnEarlyIfTheHelperHasTranslatorAlready(): void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

It's no longer possible for laminas-view to be used with service manager v2, so this pull cleans up code to provide compatibility with it.