### PR TITLE
Declare required PHP extensions

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,6 +1,7 @@
 {
     "extensions": [
         "dom",
+        "filter",
         "intl"
     ],
     "ignore_php_platform_requirements": {

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,14 @@
     },
     "require": {
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
+        "ext-dom": "*",
+        "ext-filter": "*",
         "ext-json": "*",
         "laminas/laminas-eventmanager": "^3.4",
         "laminas/laminas-json": "^3.3",
         "laminas/laminas-stdlib": "^3.6"
     },
     "require-dev": {
-        "ext-dom": "*",
         "laminas/laminas-authentication": "^2.5",
         "laminas/laminas-coding-standard": "~2.3.0",
         "laminas/laminas-console": "^2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3052afdac31561cdc43064a657f79b64",
+    "content-hash": "b006af227ee9f4657dc359dfc15af9f6",
     "packages": [
         {
             "name": "laminas/laminas-eventmanager",

--- a/composer.lock
+++ b/composer.lock
@@ -6194,10 +6194,10 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
+        "ext-dom": "*",
+        "ext-filter": "*",
         "ext-json": "*"
     },
-    "platform-dev": {
-        "ext-dom": "*"
-    },
+    "platform-dev": [],
     "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Declares `dom` and `filter` extensions as dependencies - surfaced by #112 - I'm guessing that #112 might not be merged unless we can allow failures? Otherwise I can introduce appropriate deps and ignore obvious aliases or those in `suggest` on that pull to make it pass