### PR TITLE
Workaround for Cyclic Incompatible Dependencies on 3.0.x

### DIFF
--- a/.laminas-ci/pre-install.sh
+++ b/.laminas-ci/pre-install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Temporary workaround for cyclic dependencies - can be removed once 3.0 has been released
+
+echo "Branch as 2.99.x in Pre-Install"
+
+git checkout -b 2.99.x


### PR DESCRIPTION
Adds a script to check out the current tree as a 2.99.x branch for CI runs so that composer will install cyclic incompatible dependencies.