### PR TITLE
Stand alone plugin manager replacement

### DIFF
--- a/src/Exception/PluginCannotBeRetrievedException.php
+++ b/src/Exception/PluginCannotBeRetrievedException.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View\Exception;
+
+use Throwable;
+
+use function count;
+use function implode;
+use function sprintf;
+
+final class PluginCannotBeRetrievedException extends RuntimeException
+{
+    /** @param array<array-key, non-empty-string> $availablePlugins */
+    public static function becauseItHasNotBeenMapped(string $pluginName, array $availablePlugins): self
+    {
+        return new self(
+            sprintf(
+                'The plugin named "%s" cannot be retrieved because it does not exist in the list of known plugins. '
+                . 'The available plugins are "%s"',
+                $pluginName,
+                self::formatPluginNames($availablePlugins)
+            )
+        );
+    }
+
+    /** @param non-empty-string $pluginName */
+    public static function becauseItIsNotCallable(string $pluginName): self
+    {
+        return new self(
+            sprintf(
+                'The plugin named "%s" cannot be used because the value it resolves to is not `callable`',
+                $pluginName
+            )
+        );
+    }
+
+    /** @param non-empty-string $pluginName */
+    public static function becauseItCannotBeCreated(string $pluginName, Throwable $error): self
+    {
+        if ($error instanceof self) {
+            return new self(sprintf(
+                'The plugin named "%s" cannot be created because it is not an invokable object',
+                $pluginName
+            ), 0, $error);
+        }
+
+        return new self(sprintf(
+            'The plugin named "%s" cannot be create because an error occurred during instantiation: "%s"',
+            $pluginName,
+            $error->getMessage()
+        ), 0, $error);
+    }
+
+    /**
+     * @param non-empty-string $pluginName
+     * @param non-empty-string $target
+     */
+    public static function becauseItsTargetIsNotAClassString(string $pluginName, string $target): self
+    {
+        return new self(sprintf(
+            'The plugin named "%s" and mapped to the value "%s" cannot be created '
+            . 'because the value does not appear to be a class that can be instantiated.',
+            $pluginName,
+            $target
+        ));
+    }
+
+    /** @param array<array-key, non-empty-string> $names */
+    private static function formatPluginNames(array $names): string
+    {
+        if (! count($names)) {
+            return '<none>';
+        }
+
+        return implode(', ', $names);
+    }
+}

--- a/src/PluginManager.php
+++ b/src/PluginManager.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View;
+
+use Laminas\View\Exception\PluginCannotBeRetrievedException;
+use Psr\Container\ContainerInterface;
+use Throwable;
+
+use function array_key_exists;
+use function array_keys;
+use function class_exists;
+use function in_array;
+use function is_callable;
+
+/**
+ * @internal
+ */
+final class PluginManager
+{
+    private ContainerInterface $container;
+    /** @var array<non-empty-string, string|class-string> */
+    private array $pluginMap;
+    /** Determines whether an attempt is made to create a helper that is not already present in the container */
+    private bool $autoInvoke;
+
+    /** @param array<non-empty-string, non-empty-string|class-string> $pluginMap */
+    public function __construct(ContainerInterface $container, array $pluginMap, bool $autoInvoke)
+    {
+        $this->container  = $container;
+        $this->pluginMap  = $pluginMap;
+        $this->autoInvoke = $autoInvoke;
+    }
+
+    /** @param non-empty-string $pluginName */
+    public function has(string $pluginName): bool
+    {
+        $target = $this->resolveTarget($pluginName);
+        if (! $target) {
+            return false;
+        }
+
+        if ($this->container->has($target)) {
+            return true;
+        }
+
+        return $this->isNewAble($target);
+    }
+
+    /**
+     * @param non-empty-string $pluginName
+     * @thows PluginCannotBeRetrievedException If the plugin has not been mapped, does not exist or cannot be created.
+     */
+    public function get(string $pluginName): callable
+    {
+        $target = $this->resolveTarget($pluginName);
+        if (! $target) {
+            throw PluginCannotBeRetrievedException::becauseItHasNotBeenMapped(
+                $pluginName,
+                $this->availablePluginNames()
+            );
+        }
+
+        /** @psalm-var non-empty-string|class-string $target */
+        if ($this->container->has($target)) {
+            return $this->validatePlugin(
+                $pluginName,
+                $this->container->get($target)
+            );
+        }
+
+        if (! $this->isNewAble($target)) {
+            throw PluginCannotBeRetrievedException::becauseItsTargetIsNotAClassString($pluginName, $target);
+        }
+
+        /** @psalm-var class-string $target */
+        try {
+            return $this->validatePlugin(
+                $pluginName,
+                new $target()
+            );
+        } catch (Throwable $error) {
+            throw PluginCannotBeRetrievedException::becauseItCannotBeCreated($pluginName, $error);
+        }
+    }
+
+    /** @return string|class-string|null */
+    private function resolveTarget(string $value): ?string
+    {
+        if (array_key_exists($value, $this->pluginMap)) {
+            return $this->pluginMap[$value];
+        }
+
+        if (in_array($value, $this->pluginMap, true)) {
+            return $value;
+        }
+
+        return null;
+    }
+
+    private function isNewAble(string $target): bool
+    {
+        return $this->autoInvoke && class_exists($target);
+    }
+
+    /** @return array<array-key, non-empty-string> */
+    private function availablePluginNames(): array
+    {
+        return array_keys($this->pluginMap);
+    }
+
+    /**
+     * @param non-empty-string $name
+     * @param mixed $plugin
+     */
+    private function validatePlugin(string $name, $plugin): callable
+    {
+        if (is_callable($plugin)) {
+            return $plugin;
+        }
+
+        throw PluginCannotBeRetrievedException::becauseItIsNotCallable($name);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | not-yet
| BC Break      | yes
| New Feature   | yes
| RFC           | yes

### Description

Further to discussion in #121, this is an initial draft _(Without docs or tests)_ for a replacement plugin manager enabling the removal of the hard dependency on Laminas Service Manager.

The expectation is that view helpers are configured as a map of `['alias' => 'container-id-or-class-string']`. An attempt is made to `new` class-strings not present in the container and whatever comes out needs to be `callable`

Questions

- would it be advantageous to allow closures|callables as values in the map?
- would it be better to return `Closure` and use closure from callable before returning?
- should runtime modification of the configured helpers be allowed?
 