### PR TITLE
Remove dependency on laminas-json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-json": "*",
         "laminas/laminas-eventmanager": "^3.4",
-        "laminas/laminas-json": "^3.3",
         "laminas/laminas-stdlib": "^3.6"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a003c15d0428178d28dd954a18766ec9",
+    "content-hash": "87da10378580603652a6399ab978b392",
     "packages": [
         {
             "name": "laminas/laminas-eventmanager",
@@ -71,67 +71,6 @@
                 }
             ],
             "time": "2021-09-07T22:35:32+00:00"
-        },
-        {
-            "name": "laminas/laminas-json",
-            "version": "3.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-json.git",
-                "reference": "9a0ce9f330b7d11e70c4acb44d67e8c4f03f437f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-json/zipball/9a0ce9f330b7d11e70c4acb44d67e8c4f03f437f",
-                "reference": "9a0ce9f330b7d11e70c4acb44d67e8c4f03f437f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
-            },
-            "conflict": {
-                "zendframework/zend-json": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.2.1",
-                "laminas/laminas-stdlib": "^2.7.7 || ^3.1",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "laminas/laminas-json-server": "For implementing JSON-RPC servers",
-                "laminas/laminas-xml2json": "For converting XML documents to JSON"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Json\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "provides convenience methods for serializing native PHP to JSON and decoding JSON to native PHP",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "json",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-json/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-json/issues",
-                "rss": "https://github.com/laminas/laminas-json/releases.atom",
-                "source": "https://github.com/laminas/laminas-json"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-09-02T18:02:31+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",

--- a/docs/book/helpers/json.md
+++ b/docs/book/helpers/json.md
@@ -19,29 +19,3 @@ determine how to handle the content.
 ```php
 <?= $this->json($this->data) ?>
 ```
-
-> WARNING: **Deprecated**
->
-> ### Enabling encoding using Laminas\Json\Expr
->
-> **This feature of the Json view helper has been deprecated in version 2.16 and will be removed in version 3.0.**
->
-> The JSON helper accepts an array of options that will be passed to `Laminas\Json\Json::encode()` and
-> used internally to encode data.
-> `Laminas\Json\Json::encode` allows the encoding of native JSON expressions using `Laminas\Json\Expr`
-> objects. This option is disabled by default. To enable this option, pass a boolean `true` to the
-> `enableJsonExprFinder` key of the options array:
->
-> ```php
-> <?= $this->json($this->data, ['enableJsonExprFinder' => true]) ?>
-> ``
->
-> The JSON helper accepts an array of options that will be passed to `Laminas\Json\Json::encode()` and
-> used internally to encode data.
-> `Laminas\Json\Json::encode` allows the encoding of native JSON expressions using `Laminas\Json\Expr`
-> objects. This option is disabled by default. To enable this option, pass a boolean `true` to the
-> `enableJsonExprFinder` key of the options array:
->
-> ```php
-> <?= $this->json($this->data, ['enableJsonExprFinder' => true]) ?>
-> ```

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -760,17 +760,6 @@
       <code>InlineScript</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="src/Helper/Json.php">
-    <MissingConstructor occurrences="1">
-      <code>$response</code>
-    </MissingConstructor>
-    <NullArgument occurrences="1">
-      <code>null</code>
-    </NullArgument>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>$this-&gt;response instanceof Response</code>
-    </RedundantConditionGivenDocblockType>
-  </file>
   <file src="src/Helper/Layout.php">
     <DocblockTypeContradiction occurrences="1">
       <code>null === $this-&gt;viewModelHelper</code>
@@ -1915,9 +1904,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Renderer/JsonRenderer.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>void</code>
-    </ImplementedReturnTypeMismatch>
     <MissingConstructor occurrences="1">
       <code>$jsonpCallback</code>
     </MissingConstructor>

--- a/src/Helper/Json.php
+++ b/src/Helper/Json.php
@@ -5,37 +5,30 @@ declare(strict_types=1);
 namespace Laminas\View\Helper;
 
 use Laminas\Http\Response;
-use Laminas\Json\Json as JsonFormatter;
 
-use function trigger_error;
+use function json_encode;
 
-use const E_USER_DEPRECATED;
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
 
 /**
  * Helper for simplifying JSON responses
  */
 class Json extends AbstractHelper
 {
-    /** @var Response */
+    /** @var Response|null */
     protected $response;
 
     /**
      * Encode data as JSON and set response header
      *
      * @param  mixed $data
-     * @param  array $jsonOptions Options to pass to JsonFormatter::encode()
-     * @return string|void
+     * @param  array{prettyPrint?: bool} $jsonOptions
+     * @return string
      */
     public function __invoke($data, array $jsonOptions = [])
     {
-        if (isset($jsonOptions['enableJsonExprFinder']) && $jsonOptions['enableJsonExprFinder'] === true) {
-            trigger_error(
-                'Json Expression functionality is deprecated and will be removed in laminas-view 3.0',
-                E_USER_DEPRECATED
-            );
-        }
-
-        $data = JsonFormatter::encode($data, null, $jsonOptions);
+        $data = json_encode($data, $this->optionsToFlags($jsonOptions));
 
         if ($this->response instanceof Response) {
             $headers = $this->response->getHeaders();
@@ -43,6 +36,16 @@ class Json extends AbstractHelper
         }
 
         return $data;
+    }
+
+    /** @param array{prettyPrint?: bool} $options */
+    private function optionsToFlags(array $options = []): int
+    {
+        $prettyPrint = $options['prettyPrint'] ?? false;
+        $flags       = JSON_THROW_ON_ERROR;
+        $flags      |= $prettyPrint ? 0 : JSON_PRETTY_PRINT;
+
+        return $flags;
     }
 
     /**

--- a/src/Model/JsonModel.php
+++ b/src/Model/JsonModel.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace Laminas\View\Model;
 
-use Laminas\Json\Json;
+use JsonException;
 use Laminas\Stdlib\ArrayUtils;
+use Laminas\View\Exception\DomainException;
 use Traversable;
+
+use function json_encode;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
 
 class JsonModel extends ViewModel
 {
@@ -56,13 +62,21 @@ class JsonModel extends ViewModel
             $variables = ArrayUtils::iteratorToArray($variables);
         }
 
-        $options = [
-            'prettyPrint' => $this->getOption('prettyPrint'),
-        ];
+        $options = (bool) $this->getOption('prettyPrint', false) ? JSON_PRETTY_PRINT : 0;
 
         if (null !== $this->jsonpCallback) {
-            return $this->jsonpCallback . '(' . Json::encode($variables, false, $options) . ');';
+            return $this->jsonpCallback . '(' . $this->jsonEncode($variables, $options) . ');';
         }
-        return Json::encode($variables, false, $options);
+        return $this->jsonEncode($variables, $options);
+    }
+
+    /** @param mixed $data */
+    private function jsonEncode($data, int $options): string
+    {
+        try {
+            return json_encode($data, $options | JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new DomainException('Failed to encode Json', (int) $e->getCode(), $e);
+        }
     }
 }

--- a/test/Helper/JsonTest.php
+++ b/test/Helper/JsonTest.php
@@ -6,9 +6,12 @@ namespace LaminasTest\View\Helper;
 
 use Laminas\Http\Header\HeaderInterface;
 use Laminas\Http\Response;
-use Laminas\Json\Json as JsonFormatter;
 use Laminas\View\Helper\Json as JsonHelper;
 use PHPUnit\Framework\TestCase;
+
+use function json_encode;
+
+use const JSON_THROW_ON_ERROR;
 
 /**
  * Test class for Laminas\View\Helper\Json
@@ -34,7 +37,7 @@ class JsonTest extends TestCase
         $this->helper->setResponse($this->response);
     }
 
-    public function verifyJsonHeader(): void
+    private function verifyJsonHeader(): void
     {
         $headers = $this->response->getHeaders();
         $this->assertTrue($headers->has('Content-Type'));
@@ -51,20 +54,11 @@ class JsonTest extends TestCase
 
     public function testJsonHelperReturnsJsonEncodedString(): void
     {
-        $data = $this->helper->__invoke('foobar');
-        $this->assertIsString($data);
-        $this->assertEquals('foobar', JsonFormatter::decode($data));
-    }
-
-    public function testThatADeprecationErrorIsTriggeredWhenExpressionFinderOptionIsUsed(): void
-    {
-        $this->expectDeprecation();
-        $this->helper->__invoke(['foo'], ['enableJsonExprFinder' => true]);
-    }
-
-    public function testThatADeprecationErrorIsNotTriggeredWhenExpressionFinderOptionIsNotUsed(): void
-    {
-        $this->expectNotToPerformAssertions();
-        $this->helper->__invoke(['foo'], ['enableJsonExprFinder' => 'anything other than true']);
+        $input  = [
+            'dory' => 'blue',
+            'nemo' => 'orange',
+        ];
+        $expect = json_encode($input, JSON_THROW_ON_ERROR);
+        self::assertJsonStringEqualsJsonString($expect, ($this->helper)($input));
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes

### Description

This pull supersedes #68 which got into a bit of mess.

Closes #33 

- Removes deprecated JSON Expr finder compatibility in view helper and related deprecation errors
- Removes composer dependency on `laminas-json`
- Removes outdated documentation for Json Epr finder
- Replaces usage of `Laminas\Json` with calls to native `json_encode`
- Update psalm baseline
