### PR TITLE
Update Locked Psalm Version and fix new errors

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -135,16 +135,16 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.7.0",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "cba75fad2053bb5dc8d3e7f5e62b61d75eecfaf1"
+                "reference": "bcd869e2fe88d567800057c1434f2380354fe325"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/cba75fad2053bb5dc8d3e7f5e62b61d75eecfaf1",
-                "reference": "cba75fad2053bb5dc8d3e7f5e62b61d75eecfaf1",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/bcd869e2fe88d567800057c1434f2380354fe325",
+                "reference": "bcd869e2fe88d567800057c1434f2380354fe325",
                 "shasum": ""
             },
             "require": {
@@ -190,7 +190,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-01-10T11:18:55+00:00"
+            "time": "2022-01-21T15:50:46+00:00"
         }
     ],
     "packages-dev": [
@@ -405,16 +405,16 @@
         },
         {
             "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.4",
+            "version": "1.11.99.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "b174585d1fe49ceed21928a945138948cb394600"
+                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b174585d1fe49ceed21928a945138948cb394600",
-                "reference": "b174585d1fe49ceed21928a945138948cb394600",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b4f54f74ef3453349c24a845d22392cd31e65f1d",
+                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d",
                 "shasum": ""
             },
             "require": {
@@ -458,7 +458,7 @@
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
             "support": {
                 "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.4"
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.5"
             },
             "funding": [
                 {
@@ -474,27 +474,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-13T08:41:34+00:00"
+            "time": "2022-01-17T14:14:24+00:00"
         },
         {
             "name": "composer/pcre",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "3d322d715c43a1ac36c7fe215fa59336265500f2"
+                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/3d322d715c43a1ac36c7fe215fa59336265500f2",
-                "reference": "3d322d715c43a1ac36c7fe215fa59336265500f2",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/67a32d7d6f9f560b726ab25a061b38ff3a80c560",
+                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1",
+                "phpstan/phpstan": "^1.3",
                 "phpstan/phpstan-strict-rules": "^1.1",
                 "symfony/phpunit-bridge": "^4.2 || ^5"
             },
@@ -529,7 +529,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/1.0.0"
+                "source": "https://github.com/composer/pcre/tree/1.0.1"
             },
             "funding": [
                 {
@@ -545,7 +545,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-06T15:17:27+00:00"
+            "time": "2022-01-21T20:24:37+00:00"
         },
         {
             "name": "composer/semver",
@@ -2513,16 +2513,16 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.15.1",
+            "version": "2.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "fbd87f30c0a27aaeeee8adb2f934c14fb6046c80"
+                "reference": "329900ab7674c198e91e85b2e09080cdf493ce07"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/fbd87f30c0a27aaeeee8adb2f934c14fb6046c80",
-                "reference": "fbd87f30c0a27aaeeee8adb2f934c14fb6046c80",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/329900ab7674c198e91e85b2e09080cdf493ce07",
+                "reference": "329900ab7674c198e91e85b2e09080cdf493ce07",
                 "shasum": ""
             },
             "require": {
@@ -2599,7 +2599,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-12-02T14:23:06+00:00"
+            "time": "2022-01-21T14:30:01+00:00"
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
@@ -3640,16 +3640,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.11",
+            "version": "9.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2406855036db1102126125537adb1406f7242fdd"
+                "reference": "597cb647654ede35e43b137926dfdfef0fb11743"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2406855036db1102126125537adb1406f7242fdd",
-                "reference": "2406855036db1102126125537adb1406f7242fdd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/597cb647654ede35e43b137926dfdfef0fb11743",
+                "reference": "597cb647654ede35e43b137926dfdfef0fb11743",
                 "shasum": ""
             },
             "require": {
@@ -3727,7 +3727,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.11"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.13"
             },
             "funding": [
                 {
@@ -3739,7 +3739,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-25T07:07:57+00:00"
+            "time": "2022-01-24T07:33:35+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4982,16 +4982,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.2",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a2c6b7ced2eb7799a35375fb9022519282b5405e"
+                "reference": "a2a86ec353d825c75856c6fd14fac416a7bdb6b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a2c6b7ced2eb7799a35375fb9022519282b5405e",
-                "reference": "a2c6b7ced2eb7799a35375fb9022519282b5405e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a2a86ec353d825c75856c6fd14fac416a7bdb6b8",
+                "reference": "a2a86ec353d825c75856c6fd14fac416a7bdb6b8",
                 "shasum": ""
             },
             "require": {
@@ -5061,7 +5061,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.2"
+                "source": "https://github.com/symfony/console/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -5077,7 +5077,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-20T16:11:12+00:00"
+            "time": "2022-01-26T16:28:35+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5723,16 +5723,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.2",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "e6a5d5ecf6589c5247d18e0e74e30b11dfd51a3d"
+                "reference": "92043b7d8383e48104e411bc9434b260dbeb5a10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/e6a5d5ecf6589c5247d18e0e74e30b11dfd51a3d",
-                "reference": "e6a5d5ecf6589c5247d18e0e74e30b11dfd51a3d",
+                "url": "https://api.github.com/repos/symfony/string/zipball/92043b7d8383e48104e411bc9434b260dbeb5a10",
+                "reference": "92043b7d8383e48104e411bc9434b260dbeb5a10",
                 "shasum": ""
             },
             "require": {
@@ -5789,7 +5789,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.2"
+                "source": "https://github.com/symfony/string/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -5805,7 +5805,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-16T21:52:00+00:00"
+            "time": "2022-01-02T09:53:40+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5859,16 +5859,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.18.1",
+            "version": "4.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "dda05fa913f4dc6eb3386f2f7ce5a45d37a71bcb"
+                "reference": "a2ad69ae4f5ab1f7d225a8dc4e2ec2d9415ed599"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/dda05fa913f4dc6eb3386f2f7ce5a45d37a71bcb",
-                "reference": "dda05fa913f4dc6eb3386f2f7ce5a45d37a71bcb",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/a2ad69ae4f5ab1f7d225a8dc4e2ec2d9415ed599",
+                "reference": "a2ad69ae4f5ab1f7d225a8dc4e2ec2d9415ed599",
                 "shasum": ""
             },
             "require": {
@@ -5959,9 +5959,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.18.1"
+                "source": "https://github.com/vimeo/psalm/tree/4.19.0"
             },
-            "time": "2022-01-08T21:21:26+00:00"
+            "time": "2022-01-27T19:00:37+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.18.1@dda05fa913f4dc6eb3386f2f7ce5a45d37a71bcb">
+<files psalm-version="4.19.0@a2ad69ae4f5ab1f7d225a8dc4e2ec2d9415ed599">
   <file src="bin/templatemap_generator.php">
     <MissingParamType occurrences="1">
       <code>$templatePath</code>
@@ -604,9 +604,7 @@
       <code>$item</code>
       <code>$item</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="2">
-      <code>fn ($item) </code>
-    </MissingClosureReturnType>
+    <MissingClosureReturnType occurrences="1"/>
     <MixedArgument occurrences="2">
       <code>$item</code>
       <code>$separator</code>
@@ -1735,9 +1733,6 @@
       <code>! $events</code>
       <code>! $events</code>
     </DocblockTypeContradiction>
-    <InvalidScalarArgument occurrences="1">
-      <code>$e-&gt;getCode()</code>
-    </InvalidScalarArgument>
     <MixedArgument occurrences="4">
       <code>$container-&gt;get('EventManager')</code>
       <code>$container-&gt;get('MvcTranslator')</code>
@@ -2213,9 +2208,6 @@
     </UnevaluatedCode>
   </file>
   <file src="src/Variables.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>'ArrayIterator'</code>
-    </ArgumentTypeCoercion>
     <MixedArgument occurrences="2">
       <code>$key</code>
       <code>$value</code>
@@ -2649,7 +2641,7 @@
       <code>$item-&gt;{$item-&gt;type}</code>
       <code>$value-&gt;modifiers</code>
     </MixedPropertyFetch>
-    <UndefinedMagicMethod occurrences="13">
+    <UndefinedMagicMethod occurrences="12">
       <code>getArrayCopy</code>
       <code>getArrayCopy</code>
       <code>getArrayCopy</code>
@@ -2661,7 +2653,6 @@
       <code>offsetSetName</code>
       <code>offsetSetName</code>
       <code>offsetSetName</code>
-      <code>setFoo</code>
       <code>setIndent</code>
     </UndefinedMagicMethod>
     <UndefinedMethod occurrences="27">
@@ -2777,18 +2768,7 @@
     </UndefinedMethod>
   </file>
   <file src="test/Helper/HeadStyleTest.php">
-    <ArgumentTypeCoercion occurrences="3">
-      <code>'stdClass'</code>
-      <code>'stdClass'</code>
-      <code>'stdClass'</code>
-    </ArgumentTypeCoercion>
-    <MixedArgument occurrences="20">
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
+    <MixedArgument occurrences="14">
       <code>$item-&gt;content</code>
       <code>$item-&gt;content</code>
       <code>$value</code>
@@ -2810,7 +2790,7 @@
       <code>$values[1]</code>
       <code>$values[2]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="11">
+    <MixedAssignment occurrences="8">
       <code>$item</code>
       <code>$item</code>
       <code>$item</code>
@@ -2823,7 +2803,7 @@
       <code>$values</code>
       <code>$values</code>
     </MixedAssignment>
-    <MixedPropertyFetch occurrences="9">
+    <MixedPropertyFetch occurrences="6">
       <code>$item-&gt;content</code>
       <code>$item-&gt;content</code>
       <code>$item-&gt;content</code>
@@ -3176,7 +3156,6 @@
     <UnevaluatedCode occurrences="4">
       <code>$nav = clone $this-&gt;nav2;</code>
       <code>$nav-&gt;addPage(['label' =&gt; 'Invalid', 'uri' =&gt; 'http://w.']);</code>
-      <code>$this-&gt;fail('A Laminas\View\Exception\InvalidArgumentException was not thrown on invalid &lt;loc /&gt;');</code>
     </UnevaluatedCode>
   </file>
   <file src="test/Helper/PaginationControlTest.php">
@@ -3711,9 +3690,6 @@
       <code>$priority</code>
       <code>$priority</code>
     </MixedAssignment>
-    <TooManyArguments occurrences="1">
-      <code>detach</code>
-    </TooManyArguments>
   </file>
   <file src="test/ViewTest.php">
     <MissingClosureParamType occurrences="12">

--- a/test/Helper/HeadLinkTest.php
+++ b/test/Helper/HeadLinkTest.php
@@ -200,6 +200,7 @@ class HeadLinkTest extends TestCase
     public function testOverloadingThrowsExceptionWithNoArguments(): void
     {
         $this->expectException(Exception\ExceptionInterface::class);
+        /** @psalm-suppress TooFewArguments */
         $this->helper->appendStylesheet();
     }
 
@@ -479,6 +480,7 @@ class HeadLinkTest extends TestCase
 
     public function testItempropAttributeIsSupported(): void
     {
+        /** @psalm-suppress TooFewArguments */
         $this->helper->prependAlternate(['itemprop' => 'url', 'href' => '/bar/baz', 'rel' => 'canonical']);
         $this->assertStringContainsString('itemprop="url"', $this->helper->toString());
     }

--- a/test/Helper/HeadMetaTest.php
+++ b/test/Helper/HeadMetaTest.php
@@ -195,12 +195,14 @@ class HeadMetaTest extends TestCase
     public function testOverloadingThrowsExceptionWithFewerThanTwoArgs(): void
     {
         $this->expectException(Exception\ExceptionInterface::class);
+        /** @psalm-suppress TooFewArguments */
         $this->helper->setName('foo');
     }
 
     public function testOverloadingThrowsExceptionWithInvalidMethodType(): void
     {
         $this->expectException(Exception\ExceptionInterface::class);
+        /** @psalm-suppress UndefinedMagicMethod */
         $this->helper->setFoo('foo');
     }
 

--- a/test/Helper/HeadScriptTest.php
+++ b/test/Helper/HeadScriptTest.php
@@ -11,6 +11,7 @@ use Laminas\View\Helper;
 use PHPUnit\Framework\TestCase;
 
 use function array_shift;
+use function assert;
 use function count;
 use function sprintf;
 use function strtolower;
@@ -210,6 +211,7 @@ class HeadScriptTest extends TestCase
     {
         $this->expectException(View\Exception\BadMethodCallException::class);
         $this->expectExceptionMessage('Method "setScript" requires at least one argument');
+        /** @psalm-suppress TooFewArguments */
         $this->helper->setScript();
     }
 
@@ -217,6 +219,7 @@ class HeadScriptTest extends TestCase
     {
         $this->expectException(View\Exception\BadMethodCallException::class);
         $this->expectExceptionMessage('Method "offsetSetScript" requires at least two arguments, an index and source');
+        /** @psalm-suppress TooFewArguments */
         $this->helper->offsetSetScript(1);
     }
 
@@ -265,6 +268,8 @@ class HeadScriptTest extends TestCase
         $this->assertStringContainsString('src="foo"', $string);
         $this->assertStringContainsString('bar', $string);
         $this->assertStringContainsString('baz', $string);
+
+        assert($string !== '');
 
         $doc = new DOMDocument();
         $dom = $doc->loadHtml($string);

--- a/test/Helper/HeadStyleTest.php
+++ b/test/Helper/HeadStyleTest.php
@@ -209,8 +209,9 @@ class HeadStyleTest extends TestCase
                      ->__invoke($style2, 'PREPEND')
                      ->__invoke($style3, 'APPEND');
         $html = $this->helper->toString();
-        $doc  = new DOMDocument();
-        $dom  = $doc->loadHtml($html);
+        self::assertNotEmpty($html);
+        $doc = new DOMDocument();
+        $dom = $doc->loadHtml($html);
         $this->assertTrue($dom);
 
         $styles = substr_count($html, '<style type="text/css"');
@@ -254,6 +255,7 @@ class HeadStyleTest extends TestCase
     {
         $this->expectException(View\Exception\BadMethodCallException::class);
         $this->expectExceptionMessage('Method "appendStyle" requires minimally content for the stylesheet');
+        /** @psalm-suppress TooFewArguments */
         $this->helper->appendStyle();
     }
 

--- a/test/Helper/Navigation/SitemapTest.php
+++ b/test/Helper/Navigation/SitemapTest.php
@@ -196,12 +196,15 @@ class SitemapTest extends AbstractTest
         $this->_helper->setUseSitemapValidators(false);
 
         $expected = $this->getExpectedFileContents('sitemap/invalid.xml');
+        self::assertNotEmpty($expected);
 
         // using DOMDocument::saveXML() to prevent differences in libxml from invalidating test
         $expectedDom = new DOMDocument();
         $receivedDom = new DOMDocument();
         $expectedDom->loadXML($expected);
-        $receivedDom->loadXML($this->_helper->render($nav));
+        $rendered = $this->_helper->render($nav);
+        self::assertNotEmpty($rendered);
+        $receivedDom->loadXML($rendered);
         $this->assertEquals($expectedDom->saveXML(), $receivedDom->saveXML());
     }
 


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Updates locked dependencies for 2.x which includes a newer version of Psalm.

The new version of Psalm is causing fresh errors which have been fixed along with an updated baseline which will help CI pass in other pulls, namely #126
