### PR TITLE
qa: remove Prophecy usage where possible

### DIFF
--- a/test/Helper/AssetTest.php
+++ b/test/Helper/AssetTest.php
@@ -9,20 +9,16 @@ use Laminas\View\Exception;
 use Laminas\View\Helper\Asset;
 use Laminas\View\HelperPluginManager;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 
 class AssetTest extends TestCase
 {
-    use ProphecyTrait;
-
     /** @var array<string, string> */
     protected $resourceMap = [
         'css/style.css' => 'css/style-3a97ff4ee3.css',
         'js/vendor.js'  => 'js/vendor-a507086eba.js',
     ];
 
-    /** @var Asset */
-    protected $asset;
+    private Asset $asset;
 
     protected function setUp(): void
     {
@@ -80,9 +76,12 @@ class AssetTest extends TestCase
 
     protected function getHelperPluginManager(array $config = []): HelperPluginManager
     {
-        $services = $this->prophesize(ServiceManager::class);
-        $services->get('config')->willReturn($config);
+        $services = $this->createMock(ServiceManager::class);
+        $services->expects(self::atLeast(1))
+            ->method('get')
+            ->with('config')
+            ->willReturn($config);
 
-        return new HelperPluginManager($services->reveal());
+        return new HelperPluginManager($services);
     }
 }

--- a/test/Helper/Service/AssetFactoryTest.php
+++ b/test/Helper/Service/AssetFactoryTest.php
@@ -8,16 +8,10 @@ use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Exception;
 use Laminas\View\Helper\Asset;
 use Laminas\View\Helper\Service\AssetFactory;
-use Laminas\View\HelperPluginManager;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
-
-use function method_exists;
 
 class AssetFactoryTest extends TestCase
 {
-    use ProphecyTrait;
-
     public function testAssetFactoryCreateServiceCreatesAssetInstance(): void
     {
         $services = $this->getServices();
@@ -75,18 +69,14 @@ class AssetFactoryTest extends TestCase
         $assetFactory($services, '');
     }
 
-    protected function getServices(array $config = []): ServiceManager
+    private function getServices(array $config = []): ServiceManager
     {
-        $services = $this->prophesize(ServiceManager::class);
-        $services->get('config')->willReturn($config);
+        $services = $this->createMock(ServiceManager::class);
+        $services->expects(self::once())
+            ->method('get')
+            ->with('config')
+            ->willReturn($config);
 
-        $helpers = new HelperPluginManager($services->reveal());
-
-        // test if we are using Laminas\ServiceManager v3
-        if (method_exists($helpers, 'configure')) {
-            return $services->reveal();
-        }
-
-        return $helpers;
+        return $services;
     }
 }

--- a/test/HelperPluginManagerTest.php
+++ b/test/HelperPluginManagerTest.php
@@ -19,7 +19,6 @@ use Laminas\View\Helper\Url;
 use Laminas\View\HelperPluginManager;
 use Laminas\View\Renderer\PhpRenderer;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 
 use function method_exists;
 
@@ -28,8 +27,6 @@ use function method_exists;
  */
 class HelperPluginManagerTest extends TestCase
 {
-    use ProphecyTrait;
-
     private HelperPluginManager $helpers;
 
     protected function setUp(): void
@@ -182,7 +179,7 @@ class HelperPluginManagerTest extends TestCase
 
     public function testCanOverrideAFactoryViaConfigurationPassedToConstructor(): void
     {
-        $helper  = $this->prophesize(HelperInterface::class)->reveal();
+        $helper  = $this->createMock(HelperInterface::class);
         $helpers = new HelperPluginManager(new ServiceManager());
         $config  = new Config(
             [

--- a/test/Resolver/PrefixPathStackResolverTest.php
+++ b/test/Resolver/PrefixPathStackResolverTest.php
@@ -7,7 +7,6 @@ namespace LaminasTest\View\Resolver;
 use Laminas\View\Resolver\PrefixPathStackResolver;
 use Laminas\View\Resolver\ResolverInterface;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 
 use function realpath;
 
@@ -18,8 +17,6 @@ use function realpath;
  */
 class PrefixPathStackResolverTest extends TestCase
 {
-    use ProphecyTrait;
-
     private string $basePath;
 
     /**
@@ -66,13 +63,21 @@ class PrefixPathStackResolverTest extends TestCase
 
     public function testSetCustomPathStackResolver(): void
     {
-        $mockResolver = $this->prophesize(ResolverInterface::class);
-        $mockResolver->resolve('/bar', null)->willReturn('1111');
-        $mockResolver->resolve('/baz', null)->willReturn('2222');
-        $mockResolver->resolve('/tab', null)->willReturn(false);
+        $mockResolver = $this->createMock(ResolverInterface::class);
+        $mockResolver->expects(self::exactly(3))
+            ->method('resolve')
+            ->withConsecutive(
+                ['/bar', null],
+                ['/baz', null],
+                ['/tab', null]
+            )->willReturnOnConsecutiveCalls(
+                '1111',
+                '2222',
+                false
+            );
 
         $resolver = new PrefixPathStackResolver([
-            'foo' => $mockResolver->reveal(),
+            'foo' => $mockResolver,
         ]);
 
         $this->assertSame('1111', $resolver->resolve('foo/bar'));


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Updates all tests making use of Prophecy to use standard PHPUnit mocks and paves the way for removing it as a dev dependency in 3.0.x

Notable Exceptions:

- FlashMessengerTest - This test will be deleted in 3.0.x
- IdentityFactoryTest - This test is already updated in 3.0.x
