### PR TITLE
Clean up `Escape*` helpers, deprecate extraneous methods that allow changing encoding/escaper on helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         "sort-packages": true,
         "platform": {
             "php": "7.4"
+        },
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "require": {
@@ -26,6 +29,7 @@
         "ext-dom": "*",
         "ext-filter": "*",
         "ext-json": "*",
+        "laminas/laminas-escaper": "^2.5",
         "laminas/laminas-eventmanager": "^3.4",
         "laminas/laminas-json": "^3.3",
         "laminas/laminas-stdlib": "^3.6"
@@ -34,7 +38,6 @@
         "laminas/laminas-authentication": "^2.5",
         "laminas/laminas-coding-standard": "~2.3.0",
         "laminas/laminas-console": "^2.6",
-        "laminas/laminas-escaper": "^2.5",
         "laminas/laminas-feed": "^2.15",
         "laminas/laminas-filter": "^2.13.0",
         "laminas/laminas-http": "^2.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,70 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af00e3c151551c356fee4221bee4d45d",
+    "content-hash": "108c843dcdae0797c001b109a5ca28a5",
     "packages": [
+        {
+            "name": "laminas/laminas-escaper",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-escaper.git",
+                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/891ad70986729e20ed2e86355fcf93c9dc238a5f",
+                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+            },
+            "conflict": {
+                "zendframework/zend-escaper": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "phpunit/phpunit": "^9.3",
+                "psalm/plugin-phpunit": "^0.12.2",
+                "vimeo/psalm": "^3.16"
+            },
+            "suggest": {
+                "ext-iconv": "*",
+                "ext-mbstring": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "escaper",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-escaper/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-escaper/issues",
+                "rss": "https://github.com/laminas/laminas-escaper/releases.atom",
+                "source": "https://github.com/laminas/laminas-escaper"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-02T17:10:53+00:00"
+        },
         {
             "name": "laminas/laminas-eventmanager",
             "version": "3.4.0",
@@ -1274,68 +1336,6 @@
             },
             "abandoned": "laminas/laminas-cli",
             "time": "2019-12-31T16:31:45+00:00"
-        },
-        {
-            "name": "laminas/laminas-escaper",
-            "version": "2.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/891ad70986729e20ed2e86355fcf93c9dc238a5f",
-                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
-            },
-            "conflict": {
-                "zendframework/zend-escaper": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "phpunit/phpunit": "^9.3",
-                "psalm/plugin-phpunit": "^0.12.2",
-                "vimeo/psalm": "^3.16"
-            },
-            "suggest": {
-                "ext-iconv": "*",
-                "ext-mbstring": "*"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Escaper\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "escaper",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-escaper/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-escaper/issues",
-                "rss": "https://github.com/laminas/laminas-escaper/releases.atom",
-                "source": "https://github.com/laminas/laminas-escaper"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-09-02T17:10:53+00:00"
         },
         {
             "name": "laminas/laminas-feed",
@@ -4407,16 +4407,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.3",
+            "version": "5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
+                "reference": "19c519631c5a511b7ed0ad64a6713fdb3fd25fe4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/19c519631c5a511b7ed0ad64a6713fdb3fd25fe4",
+                "reference": "19c519631c5a511b7ed0ad64a6713fdb3fd25fe4",
                 "shasum": ""
             },
             "require": {
@@ -4459,7 +4459,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.4"
             },
             "funding": [
                 {
@@ -4467,7 +4467,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-11T13:31:12+00:00"
+            "time": "2022-02-10T07:01:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -5429,12 +5429,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.19.0@a2ad69ae4f5ab1f7d225a8dc4e2ec2d9415ed599">
+<files psalm-version="4.20.0@f82a70e7edfc6cf2705e9374c8a0b6a974a779ed">
   <file src="bin/templatemap_generator.php">
     <MissingParamType occurrences="1">
       <code>$templatePath</code>
@@ -155,31 +155,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$registry</code>
     </PropertyNotSetInConstructor>
-  </file>
-  <file src="src/Helper/EscapeCss.php">
-    <PossiblyNullReference occurrences="1">
-      <code>escapeCss</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="src/Helper/EscapeHtml.php">
-    <PossiblyNullReference occurrences="1">
-      <code>escapeHtml</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="src/Helper/EscapeHtmlAttr.php">
-    <PossiblyNullReference occurrences="1">
-      <code>escapeHtmlAttr</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="src/Helper/EscapeJs.php">
-    <PossiblyNullReference occurrences="1">
-      <code>escapeJs</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="src/Helper/EscapeUrl.php">
-    <PossiblyNullReference occurrences="1">
-      <code>escapeUrl</code>
-    </PossiblyNullReference>
   </file>
   <file src="src/Helper/Escaper/AbstractHelper.php">
     <MixedAssignment occurrences="2">
@@ -2445,10 +2420,6 @@
     </UndefinedMethod>
   </file>
   <file src="test/Helper/GravatarTest.php">
-    <DeprecatedMethod occurrences="2">
-      <code>getAttribs</code>
-      <code>setAttribs</code>
-    </DeprecatedMethod>
     <InvalidScalarArgument occurrences="3">
       <code>$value</code>
       <code>$value</code>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -26,7 +26,21 @@
             <errorLevel type="suppress">
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
             </errorLevel>
+            <errorLevel type="suppress">
+                <directory name="test" />
+                <referencedMethod name="Laminas\View\Helper\Escaper\AbstractHelper::__construct"/>
+            </errorLevel>
         </InternalMethod>
+        <DeprecatedMethod>
+            <errorLevel type="suppress">
+                <directory name="test" />
+                <referencedMethod name="Laminas\View\Helper\Escaper\AbstractHelper::setEncoding" />
+            </errorLevel>
+            <errorLevel type="suppress">
+                <directory name="test" />
+                <referencedMethod name="Laminas\View\Helper\Escaper\AbstractHelper::getEscaper" />
+            </errorLevel>
+        </DeprecatedMethod>
     </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>

--- a/src/Helper/EscapeCss.php
+++ b/src/Helper/EscapeCss.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Laminas\View\Helper;
 
 /**
- * Helper for escaping values
+ * @final
  */
 class EscapeCss extends Escaper\AbstractHelper
 {
     /**
-     * Escape a value for current escaping strategy
-     *
      * @param  string $value
      * @return string
      */

--- a/src/Helper/EscapeHtml.php
+++ b/src/Helper/EscapeHtml.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Laminas\View\Helper;
 
 /**
- * Helper for escaping values
+ * @final
  */
 class EscapeHtml extends Escaper\AbstractHelper
 {
     /**
-     * Escape a value for current escaping strategy
-     *
      * @param  string $value
      * @return string
      */

--- a/src/Helper/EscapeHtmlAttr.php
+++ b/src/Helper/EscapeHtmlAttr.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Laminas\View\Helper;
 
 /**
- * Helper for escaping values
+ * @final
  */
 class EscapeHtmlAttr extends Escaper\AbstractHelper
 {
     /**
-     * Escape a value for current escaping strategy
-     *
      * @param  string $value
      * @return string
      */

--- a/src/Helper/EscapeJs.php
+++ b/src/Helper/EscapeJs.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Laminas\View\Helper;
 
 /**
- * Helper for escaping values
+ * @final
  */
 class EscapeJs extends Escaper\AbstractHelper
 {
     /**
-     * Escape a value for current escaping strategy
-     *
      * @param  string $value
      * @return string
      */

--- a/src/Helper/EscapeUrl.php
+++ b/src/Helper/EscapeUrl.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Laminas\View\Helper;
 
 /**
- * Helper for escaping values
+ * @final
  */
 class EscapeUrl extends Escaper\AbstractHelper
 {
     /**
-     * Escape a value for current escaping strategy
-     *
      * @param  string $value
      * @return string
      */

--- a/src/Helper/Escaper/AbstractHelper.php
+++ b/src/Helper/Escaper/AbstractHelper.php
@@ -32,13 +32,13 @@ abstract class AbstractHelper extends Helper\AbstractHelper
     /** @var Escape|null */
     protected $escaper;
 
-    /** @psalm-suppress DeprecatedProperty */
+    /**
+     * @param non-empty-string $encoding
+     * @psalm-suppress DeprecatedProperty
+     */
     public function __construct(?Escape $escaper = null, string $encoding = 'UTF-8')
     {
-        if ($escaper) {
-            $this->escaper = $escaper;
-        }
-
+        $this->escaper  = $escaper;
         $this->encoding = $escaper ? $escaper->getEncoding() : $encoding;
     }
 
@@ -102,7 +102,7 @@ abstract class AbstractHelper extends Helper\AbstractHelper
      *
      * @deprecated Will be removed in 3.0.
      *
-     * @param  string $encoding
+     * @param  non-empty-string $encoding
      * @throws Exception\InvalidArgumentException
      * @return AbstractHelper
      * @psalm-suppress DeprecatedProperty

--- a/src/Helper/Escaper/AbstractHelper.php
+++ b/src/Helper/Escaper/AbstractHelper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper\Escaper;
 
-use Laminas\Escaper;
+use Laminas\Escaper\Escaper as Escape;
 use Laminas\View\Exception;
 use Laminas\View\Helper;
 
@@ -14,22 +14,33 @@ use function is_string;
 use function method_exists;
 
 /**
- * Helper for escaping values
+ * @psalm-internal Laminas\View
  */
 abstract class AbstractHelper extends Helper\AbstractHelper
 {
-    /**
-     * @const Recursion constants
-     */
     public const RECURSE_NONE   = 0x00;
     public const RECURSE_ARRAY  = 0x01;
     public const RECURSE_OBJECT = 0x02;
 
-    /** @var string Encoding */
-    protected $encoding = 'UTF-8';
+    /**
+     * @deprecated
+     *
+     * @var string
+     */
+    protected $encoding;
 
-    /** @var Escaper\Escaper|null */
+    /** @var Escape|null */
     protected $escaper;
+
+    /** @psalm-suppress DeprecatedProperty */
+    public function __construct(?Escape $escaper = null, string $encoding = 'UTF-8')
+    {
+        if ($escaper) {
+            $this->escaper = $escaper;
+        }
+
+        $this->encoding = $escaper ? $escaper->getEncoding() : $encoding;
+    }
 
     /**
      * Invoke this helper: escape a value
@@ -89,9 +100,12 @@ abstract class AbstractHelper extends Helper\AbstractHelper
     /**
      * Set the encoding to use for escape operations
      *
+     * @deprecated Will be removed in 3.0.
+     *
      * @param  string $encoding
      * @throws Exception\InvalidArgumentException
      * @return AbstractHelper
+     * @psalm-suppress DeprecatedProperty
      */
     public function setEncoding($encoding)
     {
@@ -110,7 +124,10 @@ abstract class AbstractHelper extends Helper\AbstractHelper
     /**
      * Get the encoding to use for escape operations
      *
+     * @deprecated Will be removed in 3.0.
+     *
      * @return string
+     * @psalm-suppress DeprecatedProperty
      */
     public function getEncoding()
     {
@@ -118,11 +135,14 @@ abstract class AbstractHelper extends Helper\AbstractHelper
     }
 
     /**
-     * Set instance of Escaper
+     * Set instance of Escape
+     *
+     * @deprecated The escaper should be provided to the constructor. This method will be removed in 3.0.
      *
      * @return $this
+     * @psalm-suppress DeprecatedProperty
      */
-    public function setEscaper(Escaper\Escaper $escaper)
+    public function setEscaper(Escape $escaper)
     {
         $this->escaper  = $escaper;
         $this->encoding = $escaper->getEncoding();
@@ -133,12 +153,15 @@ abstract class AbstractHelper extends Helper\AbstractHelper
     /**
      * Get instance of Escaper
      *
-     * @return null|Escaper\Escaper
+     * @deprecated To be removed in 3.0
+     *
+     * @return Escape
+     * @psalm-suppress DeprecatedProperty
      */
     public function getEscaper()
     {
         if (null === $this->escaper) {
-            $this->setEscaper(new Escaper\Escaper($this->getEncoding()));
+            $this->escaper = new Escape($this->encoding);
         }
 
         return $this->escaper;

--- a/src/Helper/HtmlAttributes.php
+++ b/src/Helper/HtmlAttributes.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper;
 
-use Laminas\Escaper\Escaper;
 use Laminas\View\Helper\Escaper\AbstractHelper as AbstractEscapeHelper;
 use Laminas\View\HtmlAttributesSet;
 use Laminas\View\Renderer\PhpRenderer;
@@ -29,7 +28,6 @@ class HtmlAttributes extends AbstractHelper
         $escapePlugin = $renderer->plugin('escapeHtml');
         assert($escapePlugin instanceof AbstractEscapeHelper);
         $escaper = $escapePlugin->getEscaper();
-        assert($escaper instanceof Escaper);
 
         return new HtmlAttributesSet(
             $escaper,

--- a/test/Helper/EscapeCssTest.php
+++ b/test/Helper/EscapeCssTest.php
@@ -160,11 +160,15 @@ class EscapeCssTest extends TestCase
     public function testSettingEncodingToEmptyStringShouldThrowException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        /** @psalm-suppress InvalidArgument */
         $this->helper->setEncoding('');
         $this->helper->getEscaper();
     }
 
-    /** @dataProvider supportedEncodingsProvider */
+    /**
+     * @dataProvider supportedEncodingsProvider
+     * @param non-empty-string $encoding
+     */
     public function testSettingValidEncodingShouldNotThrowExceptions(string $encoding): void
     {
         $this->helper->setEncoding($encoding);

--- a/test/Helper/EscapeHtmlAttrTest.php
+++ b/test/Helper/EscapeHtmlAttrTest.php
@@ -160,11 +160,15 @@ class EscapeHtmlAttrTest extends TestCase
     public function testSettingEncodingToEmptyStringShouldThrowException(): void
     {
         $this->expectException(\Laminas\Escaper\Exception\InvalidArgumentException::class);
+        /** @psalm-suppress InvalidArgument */
         $this->helper->setEncoding('');
         $this->helper->getEscaper();
     }
 
-    /** @dataProvider supportedEncodingsProvider */
+    /**
+     * @dataProvider supportedEncodingsProvider
+     * @param non-empty-string $encoding
+     */
     public function testSettingValidEncodingShouldNotThrowExceptions(string $encoding): void
     {
         $this->helper->setEncoding($encoding);

--- a/test/Helper/EscapeHtmlTest.php
+++ b/test/Helper/EscapeHtmlTest.php
@@ -182,4 +182,13 @@ class EscapeHtmlTest extends TestCase
         $this->helper->setEncoding('completely-invalid');
         $this->helper->getEscaper();
     }
+
+    public function testThatAnEscaperProvidedToTheConstructorWillBeUsedWithItsConfiguredEncoding(): void
+    {
+        $escaper = new Escaper('iso-8859-1');
+        $helper  = new EscapeHelper($escaper, 'UTF-8');
+
+        self::assertSame($escaper, $helper->getEscaper());
+        self::assertEquals('iso-8859-1', $helper->getEncoding());
+    }
 }

--- a/test/Helper/EscapeHtmlTest.php
+++ b/test/Helper/EscapeHtmlTest.php
@@ -159,11 +159,15 @@ class EscapeHtmlTest extends TestCase
     public function testSettingEncodingToEmptyStringShouldThrowException(): void
     {
         $this->expectException(\Laminas\Escaper\Exception\InvalidArgumentException::class);
+        /** @psalm-suppress InvalidArgument */
         $this->helper->setEncoding('');
         $this->helper->getEscaper();
     }
 
-    /** @dataProvider supportedEncodingsProvider */
+    /**
+     * @dataProvider supportedEncodingsProvider
+     * @param non-empty-string $encoding
+     */
     public function testSettingValidEncodingShouldNotThrowExceptions(string $encoding): void
     {
         $this->helper->setEncoding($encoding);

--- a/test/Helper/EscapeJsTest.php
+++ b/test/Helper/EscapeJsTest.php
@@ -160,11 +160,15 @@ class EscapeJsTest extends TestCase
     public function testSettingEncodingToEmptyStringShouldThrowException(): void
     {
         $this->expectException(\Laminas\Escaper\Exception\InvalidArgumentException::class);
+        /** @psalm-suppress InvalidArgument */
         $this->helper->setEncoding('');
         $this->helper->getEscaper();
     }
 
-    /** @dataProvider supportedEncodingsProvider */
+    /**
+     * @dataProvider supportedEncodingsProvider
+     * @param non-empty-string $encoding
+     */
     public function testSettingValidEncodingShouldNotThrowExceptions(string $encoding): void
     {
         $this->helper->setEncoding($encoding);

--- a/test/Helper/EscapeUrlTest.php
+++ b/test/Helper/EscapeUrlTest.php
@@ -160,11 +160,15 @@ class EscapeUrlTest extends TestCase
     public function testSettingEncodingToEmptyStringShouldThrowException(): void
     {
         $this->expectException(\Laminas\Escaper\Exception\InvalidArgumentException::class);
+        /** @psalm-suppress InvalidArgument */
         $this->helper->setEncoding('');
         $this->helper->getEscaper();
     }
 
-    /** @dataProvider supportedEncodingsProvider */
+    /**
+     * @dataProvider supportedEncodingsProvider
+     * @param non-empty-string $encoding
+     */
     public function testSettingValidEncodingShouldNotThrowExceptions(string $encoding): void
     {
         $this->helper->setEncoding($encoding);

--- a/test/Helper/EscaperEncodingsTrait.php
+++ b/test/Helper/EscaperEncodingsTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Helper;
 
+use function assert;
+
 trait EscaperEncodingsTrait
 {
     /** @var list<string> */
@@ -44,10 +46,11 @@ trait EscaperEncodingsTrait
         'macroman',
     ];
 
-    /** @return iterable<string, array<int, string>> */
+    /** @return iterable<string, array<int, non-empty-string>> */
     public function supportedEncodingsProvider(): iterable
     {
         foreach ($this->supportedEncodings as $encoding) {
+            assert(! empty($encoding));
             yield $encoding => [$encoding];
         }
     }

--- a/test/Helper/EscaperEncodingsTrait.php
+++ b/test/Helper/EscaperEncodingsTrait.php
@@ -6,8 +6,8 @@ namespace LaminasTest\View\Helper;
 
 trait EscaperEncodingsTrait
 {
-    /** @var string[] */
-    private $supportedEncodings = [
+    /** @var list<string> */
+    private array $supportedEncodings = [
         'iso-8859-1',
         'iso8859-1',
         'iso-8859-5',


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | no
| RFC           | yes
| QA            | yes

### Description

- The Escaper library is a hard dependency - moved from dev deps.
- The escaper helpers should only need to expose an __invoke method. Deprecate everything else.
- Provide transitional constructor that can be updated to _require_ a configured escaper provided by DI with encoding configured from config.view in 3.0
- Annotate helpers as final so they can be made final in 3.0
- Annotate abstract helper as internal

In 3.0 - I think that inheritance from the main abstract helper can be removed - there is no reason for these helpers to expose the renderer and they don't need it themselves.