### PR TITLE
Clean up Asset helper and factory deprecating extraneous methods

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -18,11 +18,6 @@
       <code>getPathname</code>
     </MixedMethodCall>
   </file>
-  <file src="src/Helper/AbstractHelper.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>null|Renderer</code>
-    </ImplementedReturnTypeMismatch>
-  </file>
   <file src="src/Helper/AbstractHtmlElement.php">
     <MissingConstructor occurrences="13">
       <code>$closingBracket</code>
@@ -59,14 +54,6 @@
       <code>plugin</code>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
-  </file>
-  <file src="src/Helper/Asset.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;resourceMap[$asset]</code>
-    </MixedReturnStatement>
   </file>
   <file src="src/Helper/BasePath.php">
     <DocblockTypeContradiction occurrences="1">
@@ -785,9 +772,6 @@
     <InvalidThrow occurrences="1">
       <code>ExceptionInterface</code>
     </InvalidThrow>
-    <LessSpecificImplementedReturnType occurrences="1">
-      <code>self</code>
-    </LessSpecificImplementedReturnType>
     <MissingConstructor occurrences="1">
       <code>$plugins</code>
     </MissingConstructor>
@@ -1591,16 +1575,6 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Helper/Service/AssetFactory.php">
-    <DeprecatedInterface occurrences="1">
-      <code>AssetFactory</code>
-    </DeprecatedInterface>
-    <MixedArrayAccess occurrences="1">
-      <code>$config['view_helper_config']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
-      <code>$config</code>
-      <code>$configHelper</code>
-    </MixedAssignment>
     <PossiblyNullArgument occurrences="1">
       <code>$cName</code>
     </PossiblyNullArgument>

--- a/src/Helper/Asset.php
+++ b/src/Helper/Asset.php
@@ -7,31 +7,49 @@ namespace Laminas\View\Helper;
 use Laminas\View\Exception;
 
 use function array_key_exists;
+use function sprintf;
 
 /**
  * View helper plugin to fetch asset from resource map.
+ *
+ * @final
  */
 class Asset extends AbstractHelper
 {
-    /** @var array */
+    use DeprecatedAbstractHelperHierarchyTrait;
+
+    /** @var array<non-empty-string, non-empty-string> */
     protected $resourceMap = [];
 
     /**
-     * @param string $asset
-     * @return string
+     * @param array<non-empty-string, non-empty-string> $resourceMap
+     */
+    public function __construct(array $resourceMap = [])
+    {
+        $this->resourceMap = $resourceMap;
+    }
+
+    /**
+     * @param non-empty-string $asset
+     * @return non-empty-string
      * @throws Exception\InvalidArgumentException
      */
     public function __invoke($asset)
     {
         if (! array_key_exists($asset, $this->resourceMap)) {
-            throw new Exception\InvalidArgumentException('Asset is not defined.');
+            throw new Exception\InvalidArgumentException(sprintf(
+                'The asset with the name "%s" has not been defined.',
+                $asset
+            ));
         }
 
         return $this->resourceMap[$asset];
     }
 
     /**
-     * @param array $resourceMap
+     * @deprecated The Resource map should be provided to the constructor from version 3.0
+     *
+     * @param array<non-empty-string, non-empty-string> $resourceMap
      * @return $this
      */
     public function setResourceMap(array $resourceMap)
@@ -42,7 +60,9 @@ class Asset extends AbstractHelper
     }
 
     /**
-     * @return array
+     * @deprecated
+     *
+     * @return array<non-empty-string, non-empty-string>
      */
     public function getResourceMap()
     {

--- a/src/Helper/Asset.php
+++ b/src/Helper/Asset.php
@@ -47,7 +47,8 @@ class Asset extends AbstractHelper
     }
 
     /**
-     * @deprecated The Resource map should be provided to the constructor from version 3.0
+     * @deprecated since 2.20.0, this method will be removed in version 3.0.0 of this component.
+     *             The Resource map should be provided to the constructor from version 3.0
      *
      * @param array<non-empty-string, non-empty-string> $resourceMap
      * @return $this
@@ -60,7 +61,8 @@ class Asset extends AbstractHelper
     }
 
     /**
-     * @deprecated
+     * @deprecated since 2.20.0, this method will be removed in version 3.0.0 of this component.
+     *             Runtime retrieval of the resource map from the view will be removed without replacement.
      *
      * @return array<non-empty-string, non-empty-string>
      */

--- a/src/Helper/DeprecatedAbstractHelperHierarchyTrait.php
+++ b/src/Helper/DeprecatedAbstractHelperHierarchyTrait.php
@@ -18,7 +18,7 @@ trait DeprecatedAbstractHelperHierarchyTrait
     /**
      * Set the View object
      *
-     * @deprecated
+     * @deprecated since >= 2.20.0, this method will be removed in version 3.0 of this component.
      *
      * @return self
      */
@@ -32,7 +32,7 @@ trait DeprecatedAbstractHelperHierarchyTrait
     /**
      * Get the view object
      *
-     * @deprecated
+     * @deprecated since >= 2.20.0, this method will be removed in version 3.0 of this component.
      *
      * @return Renderer|null
      */

--- a/src/Helper/DeprecatedAbstractHelperHierarchyTrait.php
+++ b/src/Helper/DeprecatedAbstractHelperHierarchyTrait.php
@@ -6,22 +6,25 @@ namespace Laminas\View\Helper;
 
 use Laminas\View\Renderer\RendererInterface as Renderer;
 
-abstract class AbstractHelper implements HelperInterface
+use function assert;
+
+/**
+ * This trait is used to signal that the consuming helper will remove AbstractHelper from its hierarchy in version 3.0
+ *
+ * @internal Laminas\View
+ */
+trait DeprecatedAbstractHelperHierarchyTrait
 {
     /**
-     * View object instance
-     *
-     * @var Renderer|null
-     */
-    protected $view;
-
-    /**
      * Set the View object
+     *
+     * @deprecated
      *
      * @return self
      */
     public function setView(Renderer $view)
     {
+        assert($this instanceof AbstractHelper);
         $this->view = $view;
         return $this;
     }
@@ -29,10 +32,13 @@ abstract class AbstractHelper implements HelperInterface
     /**
      * Get the view object
      *
-     * @return null|Renderer
+     * @deprecated
+     *
+     * @return Renderer|null
      */
     public function getView()
     {
+        assert($this instanceof AbstractHelper);
         return $this->view;
     }
 }

--- a/src/Helper/Escaper/AbstractHelper.php
+++ b/src/Helper/Escaper/AbstractHelper.php
@@ -7,6 +7,7 @@ namespace Laminas\View\Helper\Escaper;
 use Laminas\Escaper\Escaper as Escape;
 use Laminas\View\Exception;
 use Laminas\View\Helper;
+use Laminas\View\Helper\DeprecatedAbstractHelperHierarchyTrait;
 
 use function is_array;
 use function is_object;
@@ -18,6 +19,8 @@ use function method_exists;
  */
 abstract class AbstractHelper extends Helper\AbstractHelper
 {
+    use DeprecatedAbstractHelperHierarchyTrait;
+
     public const RECURSE_NONE   = 0x00;
     public const RECURSE_ARRAY  = 0x01;
     public const RECURSE_OBJECT = 0x02;

--- a/src/Helper/HelperInterface.php
+++ b/src/Helper/HelperInterface.php
@@ -18,7 +18,7 @@ interface HelperInterface
     /**
      * Get the View object
      *
-     * @return Renderer
+     * @return Renderer|null
      */
     public function getView();
 }

--- a/src/Helper/Service/AssetFactory.php
+++ b/src/Helper/Service/AssetFactory.php
@@ -9,8 +9,12 @@ use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\View\Exception;
 use Laminas\View\Helper\Asset;
+use Traversable;
 
+use function gettype;
 use function is_array;
+use function iterator_to_array;
+use function sprintf;
 
 /**
  * @final
@@ -28,6 +32,8 @@ class AssetFactory implements FactoryInterface
     {
         /** @psalm-var mixed $config */
         $config = $container->get('config');
+        /** @psalm-var mixed $config */
+        $config = $config instanceof Traversable ? iterator_to_array($config, true) : $config;
         $config = is_array($config) ? $config : [];
 
         $helperConfig = $this->assertArray('view_helper_config', $config);
@@ -41,7 +47,8 @@ class AssetFactory implements FactoryInterface
     /**
      * Create service
      *
-     * @deprecated
+     * @deprecated since 2.20.0, this method will be removed in version 3.0.0 of this component.
+     *             Compatibility with the 2.x series of Laminas\ServiceManager is no longer supported.
      *
      * @param string|null $rName
      * @param string|null $cName
@@ -60,7 +67,12 @@ class AssetFactory implements FactoryInterface
     {
         $value = $array[$key] ?? [];
         if (! is_array($value)) {
-            throw new Exception\RuntimeException('Invalid resource map configuration.');
+            throw new Exception\RuntimeException(sprintf(
+                'Invalid resource map configuration. '
+                . 'Expected the key "%s" to contain an array value but received "%s"',
+                $key,
+                gettype($value)
+            ));
         }
 
         return $value;

--- a/src/Helper/Service/AssetFactory.php
+++ b/src/Helper/Service/AssetFactory.php
@@ -12,6 +12,10 @@ use Laminas\View\Helper\Asset;
 
 use function is_array;
 
+/**
+ * @final
+ * @psalm-suppress DeprecatedInterface Compatibility with Service Manager 2 should be removed in version 3.0.
+ */
 class AssetFactory implements FactoryInterface
 {
     /**
@@ -22,23 +26,22 @@ class AssetFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, ?array $options = null)
     {
-        $helper = new Asset();
-
+        /** @psalm-var mixed $config */
         $config = $container->get('config');
-        if (isset($config['view_helper_config']['asset'])) {
-            $configHelper = $config['view_helper_config']['asset'];
-            if (isset($configHelper['resource_map']) && is_array($configHelper['resource_map'])) {
-                $helper->setResourceMap($configHelper['resource_map']);
-            } else {
-                throw new Exception\RuntimeException('Invalid resource map configuration.');
-            }
-        }
+        $config = is_array($config) ? $config : [];
 
-        return $helper;
+        $helperConfig = $this->assertArray('view_helper_config', $config);
+        $helperConfig = $this->assertArray('asset', $helperConfig);
+        /** @psalm-var array<non-empty-string, non-empty-string> $resourceMap */
+        $resourceMap = $this->assertArray('resource_map', $helperConfig);
+
+        return new Asset($resourceMap);
     }
 
     /**
      * Create service
+     *
+     * @deprecated
      *
      * @param string|null $rName
      * @param string|null $cName
@@ -47,5 +50,19 @@ class AssetFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator, $rName = null, $cName = null)
     {
         return $this($serviceLocator, $cName);
+    }
+
+    /**
+     * @param array<array-key, mixed> $array
+     * @return array<array-key, mixed>
+     */
+    private function assertArray(string $key, array $array): array
+    {
+        $value = $array[$key] ?? [];
+        if (! is_array($value)) {
+            throw new Exception\RuntimeException('Invalid resource map configuration.');
+        }
+
+        return $value;
     }
 }

--- a/test/Helper/AssetTest.php
+++ b/test/Helper/AssetTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class AssetTest extends TestCase
 {
-    /** @var array<string, string> */
+    /** @var array<non-empty-string, non-empty-string> */
     protected $resourceMap = [
         'css/style.css' => 'css/style-3a97ff4ee3.css',
         'js/vendor.js'  => 'js/vendor-a507086eba.js',
@@ -24,8 +24,7 @@ class AssetTest extends TestCase
     {
         parent::setUp();
 
-        $this->asset = new Asset();
-        $this->asset->setResourceMap($this->resourceMap);
+        $this->asset = new Asset($this->resourceMap);
     }
 
     public function testHelperPluginManagerReturnsAssetHelper(): void
@@ -47,13 +46,14 @@ class AssetTest extends TestCase
     public function testInvalidAssetName(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Asset is not defined');
+        $this->expectExceptionMessage('The asset with the name "unknown" has not been defined');
 
         $this->asset->__invoke('unknown');
     }
 
     /**
      * @dataProvider assets
+     * @param non-empty-string $name
      */
     public function testInvokeResult(string $name, string $expected): void
     {
@@ -63,7 +63,7 @@ class AssetTest extends TestCase
     }
 
     /**
-     * @return array<array-key, array{0: string, 1: string}>
+     * @return array<array-key, array{0: non-empty-string, 1: non-empty-string}>
      */
     public function assets(): array
     {

--- a/test/Helper/Service/AssetFactoryTest.php
+++ b/test/Helper/Service/AssetFactoryTest.php
@@ -70,7 +70,10 @@ class AssetFactoryTest extends TestCase
         ]);
 
         $this->expectException(Exception\RuntimeException::class);
-        $this->expectExceptionMessage('Invalid resource map configuration');
+        $this->expectExceptionMessage(
+            'Invalid resource map configuration. Expected the key '
+            . '"resource_map" to contain an array value but received "string"'
+        );
         (new AssetFactory())($container, '');
     }
 

--- a/test/Helper/Service/AssetFactoryTest.php
+++ b/test/Helper/Service/AssetFactoryTest.php
@@ -12,6 +12,9 @@ use PHPUnit\Framework\TestCase;
 
 class AssetFactoryTest extends TestCase
 {
+    /**
+     * @deprecated for removal in 3.0
+     */
     public function testAssetFactoryCreateServiceCreatesAssetInstance(): void
     {
         $services = $this->getServices();
@@ -32,6 +35,9 @@ class AssetFactoryTest extends TestCase
         $this->assertInstanceOf(Asset::class, $asset);
     }
 
+    /**
+     * @deprecated for removal in 3.0
+     */
     public function testValidConfiguration(): void
     {
         $config = [
@@ -53,22 +59,78 @@ class AssetFactoryTest extends TestCase
         $this->assertEquals($config['view_helper_config']['asset']['resource_map'], $asset->getResourceMap());
     }
 
-    public function testInvalidConfiguration(): void
+    public function testThatAnExceptionWillBeThrownWhenTheResourceMapIsSetToANonArray(): void
     {
-        $config   = [
+        $container = $this->getServices([
             'view_helper_config' => [
-                'asset' => [],
+                'asset' => [
+                    'resource_map' => 'Not an array',
+                ],
             ],
-        ];
-        $services = $this->getServices($config);
-
-        $assetFactory = new AssetFactory();
+        ]);
 
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('Invalid resource map configuration');
-        $assetFactory($services, '');
+        (new AssetFactory())($container, '');
     }
 
+    /**
+     * @return array<string, array{0: array<string, mixed>}>
+     */
+    public function validConfigProvider(): array
+    {
+        return [
+            'No View Helper Configuration' => [
+                [],
+            ],
+            'No Asset Config At All'       => [
+                [
+                    'view_helper_config' => [],
+                ],
+            ],
+            'No Resource Map Key'          => [
+                [
+                    'view_helper_config' => [
+                        'asset' => [],
+                    ],
+                ],
+            ],
+            'Empty Resource Map'           => [
+                [
+                    'view_helper_config' => [
+                        'asset' => [
+                            'resource_map' => [],
+                        ],
+                    ],
+                ],
+            ],
+            'Non-Empty Resource Map'       => [
+                [
+                    'view_helper_config' => [
+                        'asset' => [
+                            'resource_map' => [
+                                'foo.css' => 'assets/foo.1.css',
+                                'bar.css' => 'assets/bar.1.css',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider validConfigProvider
+     * @param array<string, mixed> $config
+     */
+    public function testThatAnExceptionWillNotBeThrownWhenGivenUnsetOrEmptyArrayConfiguration(array $config): void
+    {
+        $container = $this->getServices($config);
+        (new AssetFactory())($container, 'foo');
+        self::assertTrue(true);
+    }
+
+    /** @param array<string, mixed> $config */
     private function getServices(array $config = []): ServiceManager
     {
         $services = $this->createMock(ServiceManager::class);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

- Introduces a trait that will be helpful to finding and removing inheritance from AbstractHelper
- Fixes possibly null return value of `getView()` in `HelperInterface`
- Deprecates runtime set/get of the Asset helper's resource map
- Improves the exception message for undefined assets
- Marks both the helper and the factory as @\final in doc block
- Slight change to behaviour of the factory so that an exception is only thrown if the resource map is configured as anything other than an array. Previously, an exception would be thrown for empty configuration
- General improvements to psalm type inference