### PR TITLE
Deprecate placeholder `Registry` and its test

### DIFF
--- a/src/Helper/Placeholder/Registry.php
+++ b/src/Helper/Placeholder/Registry.php
@@ -18,6 +18,9 @@ use const E_USER_DEPRECATED;
 
 /**
  * Registry for placeholder containers
+ *
+ * @deprecated since >= 2.20.0. This class is currently unused and will be removed in version 3.0 of this component.
+ *             There is no replacement.
  */
 class Registry
 {

--- a/test/Helper/Placeholder/RegistryTest.php
+++ b/test/Helper/Placeholder/RegistryTest.php
@@ -10,6 +10,11 @@ use Laminas\View\Helper\Placeholder\Registry;
 use LaminasTest\View\Helper\TestAsset;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @deprecated To be removed in v3.0 along with {@link Registry}
+ *
+ * @psalm-suppress DeprecatedClass, DeprecatedMethod
+ */
 class RegistryTest extends TestCase
 {
     /** @var Registry */


### PR DESCRIPTION
### Description

The old singleton registry for placeholder containers is currently unused - deprecate for removal in 3.0…

Also, no public usage anywhere else either: https://packanalyst.com/class?q=Laminas%5CView%5CHelper%5CPlaceholder%5CRegistry