### PR TITLE
Helper and Inheritance Deprecations

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -19,7 +19,7 @@
     </MixedMethodCall>
   </file>
   <file src="src/Helper/AbstractHtmlElement.php">
-    <MissingConstructor occurrences="13">
+    <MissingConstructor occurrences="12">
       <code>$closingBracket</code>
       <code>$closingBracket</code>
       <code>$closingBracket</code>
@@ -611,28 +611,6 @@
       <code>plugin</code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="src/Helper/HtmlList.php">
-    <InvalidParamDefault occurrences="1">
-      <code>array</code>
-    </InvalidParamDefault>
-    <MixedAssignment occurrences="3">
-      <code>$escaper</code>
-      <code>$item</code>
-      <code>$item</code>
-    </MixedAssignment>
-    <MixedFunctionCall occurrences="1">
-      <code>$escaper($item)</code>
-    </MixedFunctionCall>
-    <MixedOperand occurrences="1">
-      <code>$item</code>
-    </MixedOperand>
-    <PossiblyNullReference occurrences="1">
-      <code>plugin</code>
-    </PossiblyNullReference>
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>plugin</code>
-    </UndefinedInterfaceMethod>
-  </file>
   <file src="src/Helper/HtmlObject.php">
     <DocblockTypeContradiction occurrences="1">
       <code>is_array($content)</code>
@@ -732,32 +710,9 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/Layout.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>null === $this-&gt;viewModelHelper</code>
-    </DocblockTypeContradiction>
-    <MissingConstructor occurrences="1">
-      <code>$viewModelHelper</code>
-    </MissingConstructor>
-    <MixedAssignment occurrences="1">
-      <code>$this-&gt;viewModelHelper</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>ViewModel</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;viewModelHelper</code>
-    </MixedReturnStatement>
-    <PossiblyNullReference occurrences="3">
-      <code>getTemplate</code>
-      <code>plugin</code>
-      <code>setTemplate</code>
-    </PossiblyNullReference>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $template</code>
     </RedundantCastGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>plugin</code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/Navigation.php">
     <DocblockTypeContradiction occurrences="1">
@@ -1670,12 +1625,6 @@
     <PossiblyInvalidArgument occurrences="1">
       <code>$options</code>
     </PossiblyInvalidArgument>
-  </file>
-  <file src="src/Helper/ViewModel.php">
-    <MissingConstructor occurrences="2">
-      <code>$current</code>
-      <code>$root</code>
-    </MissingConstructor>
   </file>
   <file src="src/HelperPluginManager.php">
     <DocblockTypeContradiction occurrences="2">
@@ -2785,12 +2734,6 @@
     <UndefinedThisPropertyAssignment occurrences="1">
       <code>$this-&gt;view</code>
     </UndefinedThisPropertyAssignment>
-  </file>
-  <file src="test/Helper/HtmlListTest.php">
-    <InvalidArgument occurrences="2">
-      <code>false</code>
-      <code>false</code>
-    </InvalidArgument>
   </file>
   <file src="test/Helper/HtmlObjectTest.php">
     <UndefinedMethod occurrences="2">

--- a/src/Helper/HtmlAttributes.php
+++ b/src/Helper/HtmlAttributes.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Laminas\View\Helper;
 
 use Laminas\Escaper\Escaper;
-use Laminas\View\Helper\Escaper\AbstractHelper as AbstractEscapeHelper;
 use Laminas\View\HtmlAttributesSet;
-use Laminas\View\Renderer\PhpRenderer;
-
-use function assert;
 
 /**
  * Helper for creating HtmlAttributesSet objects
+ *
+ * @final
  */
 class HtmlAttributes extends AbstractHelper
 {

--- a/src/Helper/HtmlAttributes.php
+++ b/src/Helper/HtmlAttributes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper;
 
+use Laminas\Escaper\Escaper;
 use Laminas\View\Helper\Escaper\AbstractHelper as AbstractEscapeHelper;
 use Laminas\View\HtmlAttributesSet;
 use Laminas\View\Renderer\PhpRenderer;
@@ -15,6 +16,15 @@ use function assert;
  */
 class HtmlAttributes extends AbstractHelper
 {
+    use DeprecatedAbstractHelperHierarchyTrait;
+
+    private Escaper $escaper;
+
+    public function __construct(?Escaper $escaper = null)
+    {
+        $this->escaper = $escaper ?: new Escaper();
+    }
+
     /**
      * Returns a new HtmlAttributesSet object, optionally initializing it with
      * the provided value.
@@ -23,14 +33,8 @@ class HtmlAttributes extends AbstractHelper
      */
     public function __invoke(iterable $attributes = []): HtmlAttributesSet
     {
-        $renderer = $this->getView();
-        assert($renderer instanceof PhpRenderer);
-        $escapePlugin = $renderer->plugin('escapeHtml');
-        assert($escapePlugin instanceof AbstractEscapeHelper);
-        $escaper = $escapePlugin->getEscaper();
-
         return new HtmlAttributesSet(
-            $escaper,
+            $this->escaper,
             $attributes
         );
     }

--- a/src/Helper/HtmlList.php
+++ b/src/Helper/HtmlList.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper;
 
+use Laminas\Escaper\Escaper;
 use Laminas\View\Exception;
+use Laminas\View\HtmlAttributesSet;
 
 use function is_array;
 use function sprintf;
@@ -15,20 +17,40 @@ use const PHP_EOL;
 
 /**
  * Helper for ordered and unordered lists
+ *
+ * @psalm-import-type AttributeSet from HtmlAttributesSet
+ * @final
  */
 class HtmlList extends AbstractHtmlElement
 {
+    use DeprecatedAbstractHelperHierarchyTrait;
+
+    private Escaper $escaper;
+
+    /**
+     * @deprecated since 2.20.x - There is no reason for this helper to extend AbstractHtmlElement.
+     *             The inheritance tree will be removed in version 3.0 of this component
+     *
+     * @var string
+     */
+    protected $closingBracket = '';
+
+    public function __construct(?Escaper $escaper = null)
+    {
+        $this->escaper = $escaper ?: new Escaper();
+    }
+
     /**
      * Generates a 'List' element.
      *
-     * @param  array $items   Array with the elements of the list
-     * @param  bool  $ordered Specifies ordered/unordered list; default unordered
-     * @param  array $attribs Attributes for the ol/ul tag.
-     * @param  bool  $escape  Escape the items.
-     * @throws Exception\InvalidArgumentException
+     * @param  array<array-key, scalar|array> $items Array with the elements of the list
+     * @param  bool                           $ordered Specifies ordered/unordered list; default unordered
+     * @param  AttributeSet|null              $attribs Attributes for the ol/ul tag.
+     * @param  bool                           $escape Whether to Escape the items.
+     * @throws Exception\InvalidArgumentException If $items is empty.
      * @return string The list XHTML.
      */
-    public function __invoke(array $items, $ordered = false, $attribs = false, $escape = true)
+    public function __invoke(array $items, $ordered = false, $attribs = null, $escape = true)
     {
         if (empty($items)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -41,30 +63,28 @@ class HtmlList extends AbstractHtmlElement
 
         foreach ($items as $item) {
             if (! is_array($item)) {
-                if ($escape) {
-                    $escaper = $this->getView()->plugin('escapeHtml');
-                    $item    = $escaper($item);
-                }
-                $list .= '<li>' . $item . '</li>' . PHP_EOL;
+                $markup = $escape
+                    ? $this->escaper->escapeHtml((string) $item)
+                    : (string) $item;
+                $list  .= '<li>' . $markup . '</li>' . PHP_EOL;
             } else {
-                $itemLength = 5 + strlen(PHP_EOL);
+                /** @psalm-var list<scalar|list<scalar>> $item */
+                $itemLength = strlen('</li>' . PHP_EOL);
                 if ($itemLength < strlen($list)) {
                     $list = substr($list, 0, strlen($list) - $itemLength)
-                     . $this($item, $ordered, $attribs, $escape) . '</li>' . PHP_EOL;
+                     . $this->__invoke($item, $ordered, $attribs, $escape) . '</li>' . PHP_EOL;
                 } else {
-                    $list .= '<li>' . $this($item, $ordered, $attribs, $escape) . '</li>' . PHP_EOL;
+                    $list .= '<li>' . $this->__invoke($item, $ordered, $attribs, $escape) . '</li>' . PHP_EOL;
                 }
             }
         }
 
-        if ($attribs) {
-            $attribs = $this->htmlAttribs($attribs);
-        } else {
-            $attribs = '';
-        }
+        $attributes = is_array($attribs)
+            ? (string) new HtmlAttributesSet($this->escaper, $attribs)
+            : '';
 
         $tag = $ordered ? 'ol' : 'ul';
 
-        return '<' . $tag . $attribs . '>' . PHP_EOL . $list . '</' . $tag . '>' . PHP_EOL;
+        return '<' . $tag . $attributes . '>' . PHP_EOL . $list . '</' . $tag . '>' . PHP_EOL;
     }
 }

--- a/src/Helper/Json.php
+++ b/src/Helper/Json.php
@@ -13,10 +13,18 @@ use const E_USER_DEPRECATED;
 
 /**
  * Helper for simplifying JSON responses
+ *
+ * @psalm-suppress DeprecatedProperty
  */
 class Json extends AbstractHelper
 {
-    /** @var Response */
+    use DeprecatedAbstractHelperHierarchyTrait;
+
+    /**
+     * @deprecated since >= 2.20.0
+     *
+     * @var Response
+     */
     protected $response;
 
     /**
@@ -47,6 +55,11 @@ class Json extends AbstractHelper
 
     /**
      * Set the response object
+     *
+     * @deprecated since >= 2.20.0. If you need to set response headers, use the methods available in
+     *             the framework. For example in Laminas MVC this can be achieved in the controller or in
+     *             Mezzio, you can change response headers in Middleware. This method will be removed in 3.0
+     *             without replacement functionality.
      *
      * @return Json
      */

--- a/src/Helper/Json.php
+++ b/src/Helper/Json.php
@@ -15,6 +15,7 @@ use const E_USER_DEPRECATED;
  * Helper for simplifying JSON responses
  *
  * @psalm-suppress DeprecatedProperty
+ * @final
  */
 class Json extends AbstractHelper
 {

--- a/src/Helper/ViewModel.php
+++ b/src/Helper/ViewModel.php
@@ -8,19 +8,23 @@ use Laminas\View\Model\ModelInterface as Model;
 
 /**
  * Helper for storing and retrieving the root and current view model
+ *
+ * @final
  */
 class ViewModel extends AbstractHelper
 {
-    /** @var Model */
+    use DeprecatedAbstractHelperHierarchyTrait;
+
+    /** @var Model|null */
     protected $current;
 
-    /** @var Model */
+    /** @var Model|null */
     protected $root;
 
     /**
      * Set the current view model
      *
-     * @return ViewModel
+     * @return $this
      */
     public function setCurrent(Model $model)
     {
@@ -31,7 +35,7 @@ class ViewModel extends AbstractHelper
     /**
      * Get the current view model
      *
-     * @return null|Model
+     * @return Model|null
      */
     public function getCurrent()
     {
@@ -51,7 +55,7 @@ class ViewModel extends AbstractHelper
     /**
      * Set the root view model
      *
-     * @return ViewModel
+     * @return $this
      */
     public function setRoot(Model $model)
     {
@@ -62,7 +66,7 @@ class ViewModel extends AbstractHelper
     /**
      * Get the root view model
      *
-     * @return null|Model
+     * @return Model|null
      */
     public function getRoot()
     {

--- a/src/HtmlAttributesSet.php
+++ b/src/HtmlAttributesSet.php
@@ -26,6 +26,8 @@ use const JSON_THROW_ON_ERROR;
 
 /**
  * Class for storing and processing HTML tag attributes.
+ *
+ * @psalm-type AttributeSet = iterable<string, scalar|array|null>
  */
 final class HtmlAttributesSet extends ArrayObject
 {

--- a/src/HtmlAttributesSet.php
+++ b/src/HtmlAttributesSet.php
@@ -27,7 +27,7 @@ use const JSON_THROW_ON_ERROR;
 /**
  * Class for storing and processing HTML tag attributes.
  *
- * @psalm-type AttributeSet = iterable<string, scalar|array|null>
+ * @psalm-type AttributeSet = array<string, scalar|array|null>
  */
 final class HtmlAttributesSet extends ArrayObject
 {
@@ -46,7 +46,7 @@ final class HtmlAttributesSet extends ArrayObject
     /**
      * Set several attributes at once.
      *
-     * @param iterable<string, scalar|array|null> $attributes
+     * @param AttributeSet $attributes
      */
     public function set(iterable $attributes): self
     {
@@ -79,7 +79,7 @@ final class HtmlAttributesSet extends ArrayObject
     /**
      * Merge attributes with existing attributes.
      *
-     * @param iterable<string, scalar|array|null> $attributes
+     * @param AttributeSet $attributes
      */
     public function merge(iterable $attributes): self
     {

--- a/test/Helper/HtmlAttributesTest.php
+++ b/test/Helper/HtmlAttributesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Helper;
 
+use Laminas\Escaper\Escaper;
 use Laminas\View\Helper\HtmlAttributes;
-use Laminas\View\Renderer\PhpRenderer;
 use PHPUnit\Framework\TestCase;
 
 class HtmlAttributesTest extends TestCase
@@ -16,8 +16,7 @@ class HtmlAttributesTest extends TestCase
     {
         parent::setUp();
 
-        $this->helper = new HtmlAttributes();
-        $this->helper->setView(new PhpRenderer());
+        $this->helper = new HtmlAttributes(new Escaper());
     }
 
     public function testThatInvokeWillReturnAttributeSetWithTheExpectedValues(): void

--- a/test/Helper/HtmlListTest.php
+++ b/test/Helper/HtmlListTest.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\View\Helper;
 
 use Laminas\View\Exception;
-use Laminas\View\Helper;
-use Laminas\View\Renderer\PhpRenderer as View;
+use Laminas\View\Helper\HtmlList;
 use PHPUnit\Framework\TestCase;
 
 use function array_walk_recursive;
@@ -15,21 +14,11 @@ use const PHP_EOL;
 
 class HtmlListTest extends TestCase
 {
-    /** @var Helper\HtmlList */
-    public $helper;
-    private View $view;
+    public HtmlList $helper;
 
-    /**
-     * Sets up the fixture, for example, open a network connection.
-     * This method is called before a test is executed.
-     *
-     * @access protected
-     */
     protected function setUp(): void
     {
-        $this->view   = new View();
-        $this->helper = new Helper\HtmlList();
-        $this->helper->setView($this->view);
+        $this->helper = new HtmlList();
     }
 
     public function testMakeUnorderedList(): void
@@ -135,7 +124,7 @@ class HtmlListTest extends TestCase
     {
         $items = ['one <b>small</b> test'];
 
-        $list = $this->helper->__invoke($items, false, false, false);
+        $list = $this->helper->__invoke($items, false, null, false);
 
         $this->assertStringContainsString('<ul>', $list);
         $this->assertStringContainsString('</ul>', $list);
@@ -147,7 +136,7 @@ class HtmlListTest extends TestCase
     {
         $items = ['<b>one</b>', ['<b>four</b>', '<b>five</b>', '<b>six</b>'], '<b>two</b>', '<b>three</b>'];
 
-        $list = $this->helper->__invoke($items, false, false, false);
+        $list = $this->helper->__invoke($items, false, null, false);
 
         foreach ($items[1] as $item) {
             $this->assertStringContainsString($item, $list);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | no
| New Feature   | yes
| QA            | yes

### Description

- Json Helper: Deprecate inheritance tree, deprecate `setResponse()` so it's effectively just `json_encode()` _(Eventually)_ - The response really shouldn't be modified in the view should it?
- HtmlAttributes Helper: Deprecate inheritance tree - it only needs an escaper to do its job
- The HTML List helper - also only needs access to an escaper
- <del>The Gravatar helper is deprecated completely with all its setters and getters. An alternative implementation is provided that simply returns an <img> tag based on its arguments</del> Moved to #147
- The view model helper doesn't need its current inheritance tree
- The layout helper only needs access to the view model helper so it is changed to pave the way for factory based constructor injection of the dependent helper

There's no need IMO to have this block a 2.20 release