### PR TITLE
Resolve deprecations in Asset view helper

### DIFF
--- a/src/Helper/Asset.php
+++ b/src/Helper/Asset.php
@@ -11,15 +11,11 @@ use function sprintf;
 
 /**
  * View helper plugin to fetch asset from resource map.
- *
- * @final
  */
-class Asset extends AbstractHelper
+final class Asset
 {
-    use DeprecatedAbstractHelperHierarchyTrait;
-
     /** @var array<non-empty-string, non-empty-string> */
-    protected $resourceMap = [];
+    private array $resourceMap;
 
     /**
      * @param array<non-empty-string, non-empty-string> $resourceMap
@@ -34,7 +30,7 @@ class Asset extends AbstractHelper
      * @return non-empty-string
      * @throws Exception\InvalidArgumentException
      */
-    public function __invoke($asset)
+    public function __invoke(string $asset): string
     {
         if (! array_key_exists($asset, $this->resourceMap)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -44,30 +40,5 @@ class Asset extends AbstractHelper
         }
 
         return $this->resourceMap[$asset];
-    }
-
-    /**
-     * @deprecated since 2.20.0, this method will be removed in version 3.0.0 of this component.
-     *             The Resource map should be provided to the constructor from version 3.0
-     *
-     * @param array<non-empty-string, non-empty-string> $resourceMap
-     * @return $this
-     */
-    public function setResourceMap(array $resourceMap)
-    {
-        $this->resourceMap = $resourceMap;
-
-        return $this;
-    }
-
-    /**
-     * @deprecated since 2.20.0, this method will be removed in version 3.0.0 of this component.
-     *             Runtime retrieval of the resource map from the view will be removed without replacement.
-     *
-     * @return array<non-empty-string, non-empty-string>
-     */
-    public function getResourceMap()
-    {
-        return $this->resourceMap;
     }
 }

--- a/src/Helper/Service/AssetFactory.php
+++ b/src/Helper/Service/AssetFactory.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper\Service;
 
-use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
-use Laminas\View\Exception;
+use Laminas\View\Exception\RuntimeException;
 use Laminas\View\Helper\Asset;
+use Psr\Container\ContainerInterface;
 use Traversable;
 
 use function gettype;
@@ -16,19 +14,12 @@ use function is_array;
 use function iterator_to_array;
 use function sprintf;
 
-/**
- * @final
- * @psalm-suppress DeprecatedInterface Compatibility with Service Manager 2 should be removed in version 3.0.
- */
-class AssetFactory implements FactoryInterface
+final class AssetFactory
 {
     /**
-     * @param string $name
-     * @param null|array $options
-     * @return Asset
-     * @throws Exception\RuntimeException
+     * @throws RuntimeException
      */
-    public function __invoke(ContainerInterface $container, $name, ?array $options = null)
+    public function __invoke(ContainerInterface $container): Asset
     {
         /** @psalm-var mixed $config */
         $config = $container->get('config');
@@ -45,21 +36,6 @@ class AssetFactory implements FactoryInterface
     }
 
     /**
-     * Create service
-     *
-     * @deprecated since 2.20.0, this method will be removed in version 3.0.0 of this component.
-     *             Compatibility with the 2.x series of Laminas\ServiceManager is no longer supported.
-     *
-     * @param string|null $rName
-     * @param string|null $cName
-     * @return Asset
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator, $rName = null, $cName = null)
-    {
-        return $this($serviceLocator, $cName);
-    }
-
-    /**
      * @param array<array-key, mixed> $array
      * @return array<array-key, mixed>
      */
@@ -67,7 +43,7 @@ class AssetFactory implements FactoryInterface
     {
         $value = $array[$key] ?? [];
         if (! is_array($value)) {
-            throw new Exception\RuntimeException(sprintf(
+            throw new RuntimeException(sprintf(
                 'Invalid resource map configuration. '
                 . 'Expected the key "%s" to contain an array value but received "%s"',
                 $key,

--- a/test/Helper/Service/AssetFactoryTest.php
+++ b/test/Helper/Service/AssetFactoryTest.php
@@ -4,59 +4,22 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Helper\Service;
 
-use Laminas\ServiceManager\ServiceManager;
-use Laminas\View\Exception;
+use Laminas\View\Exception\RuntimeException;
 use Laminas\View\Helper\Asset;
 use Laminas\View\Helper\Service\AssetFactory;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 class AssetFactoryTest extends TestCase
 {
-    /**
-     * @deprecated for removal in 3.0
-     */
-    public function testAssetFactoryCreateServiceCreatesAssetInstance(): void
-    {
-        $services = $this->getServices();
-
-        $assetFactory = new AssetFactory();
-        $asset        = $assetFactory->createService($services);
-
-        $this->assertInstanceOf(Asset::class, $asset);
-    }
-
     public function testAssetFactoryInvokableCreatesAssetInstance(): void
     {
         $services = $this->getServices();
 
         $assetFactory = new AssetFactory();
-        $asset        = $assetFactory($services, '');
+        $asset        = $assetFactory($services);
 
         $this->assertInstanceOf(Asset::class, $asset);
-    }
-
-    /**
-     * @deprecated for removal in 3.0
-     */
-    public function testValidConfiguration(): void
-    {
-        $config = [
-            'view_helper_config' => [
-                'asset' => [
-                    'resource_map' => [
-                        'css/style.css' => 'css/style-3a97ff4ee3.css',
-                        'js/vendor.js'  => 'js/vendor-a507086eba.js',
-                    ],
-                ],
-            ],
-        ];
-
-        $services     = $this->getServices($config);
-        $assetFactory = new AssetFactory();
-
-        $asset = $assetFactory($services, '');
-
-        $this->assertEquals($config['view_helper_config']['asset']['resource_map'], $asset->getResourceMap());
     }
 
     public function testThatAnExceptionWillBeThrownWhenTheResourceMapIsSetToANonArray(): void
@@ -69,12 +32,12 @@ class AssetFactoryTest extends TestCase
             ],
         ]);
 
-        $this->expectException(Exception\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
             'Invalid resource map configuration. Expected the key '
             . '"resource_map" to contain an array value but received "string"'
         );
-        (new AssetFactory())($container, '');
+        (new AssetFactory())($container);
     }
 
     /**
@@ -129,14 +92,14 @@ class AssetFactoryTest extends TestCase
     public function testThatAnExceptionWillNotBeThrownWhenGivenUnsetOrEmptyArrayConfiguration(array $config): void
     {
         $container = $this->getServices($config);
-        (new AssetFactory())($container, 'foo');
+        (new AssetFactory())($container);
         self::assertTrue(true);
     }
 
     /** @param array<string, mixed> $config */
-    private function getServices(array $config = []): ServiceManager
+    private function getServices(array $config = []): ContainerInterface
     {
-        $services = $this->createMock(ServiceManager::class);
+        $services = $this->createMock(ContainerInterface::class);
         $services->expects(self::once())
             ->method('get')
             ->with('config')


### PR DESCRIPTION


|    Q          |   A
|-------------- | ------
| BC Break      | yes
| QA            | yes

### Description

Removes deprecated methods and inheritance in the Asset helper, marking it final.
Removes factory interface inheritance and swaps service manager for container interface
Removes deprecated/obsolete tests
