### PR TITLE
Resolve deprecations in Identity view helper

### DIFF
--- a/src/Helper/Identity.php
+++ b/src/Helper/Identity.php
@@ -10,12 +10,9 @@ use Laminas\View\Exception\RuntimeException;
 /**
  * View helper plugin to fetch the authenticated identity.
  */
-class Identity extends AbstractHelper
+final class Identity
 {
-    use DeprecatedAbstractHelperHierarchyTrait;
-
-    /** @var AuthenticationServiceInterface|null */
-    protected $authenticationService;
+    private ?AuthenticationServiceInterface $authenticationService;
 
     public function __construct(?AuthenticationServiceInterface $authenticationService = null)
     {
@@ -28,6 +25,7 @@ class Identity extends AbstractHelper
      * If none available, returns null.
      *
      * @return mixed|null
+     * @throws RuntimeException If the helper was not configured with an Authentication Service.
      */
     public function __invoke()
     {
@@ -39,33 +37,5 @@ class Identity extends AbstractHelper
         return $service->hasIdentity()
             ? $service->getIdentity()
             : null;
-    }
-
-    /**
-     * Set AuthenticationService instance
-     *
-     * @deprecated since >= 2.20.0. The authentication service should be provided to the constructor. This method will
-     *             be removed in version 3.0 of this component
-     *
-     * @return $this
-     */
-    public function setAuthenticationService(AuthenticationServiceInterface $authenticationService)
-    {
-        $this->authenticationService = $authenticationService;
-
-        return $this;
-    }
-
-    /**
-     * Get AuthenticationService instance
-     *
-     * @deprecated since >= 2.20.0. The authentication service should be provided to the constructor. This method will
-     *             be removed in version 3.0 of this component
-     *
-     * @return null|object
-     */
-    public function getAuthenticationService()
-    {
-        return $this->authenticationService;
     }
 }

--- a/src/Helper/Service/IdentityFactory.php
+++ b/src/Helper/Service/IdentityFactory.php
@@ -4,40 +4,18 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Authentication\AuthenticationService;
 use Laminas\Authentication\AuthenticationServiceInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\View\Helper\Identity;
+use Psr\Container\ContainerInterface;
 
 use function assert;
 
-/**
- * @psalm-suppress DeprecatedInterface
- */
-class IdentityFactory implements FactoryInterface
+final class IdentityFactory
 {
-    /**
-     * @param string|null $name
-     * @param array<array-key, mixed>|null $options
-     * @return Identity
-     */
-    public function __invoke(ContainerInterface $container, $name = null, ?array $options = null)
+    public function __invoke(ContainerInterface $container): Identity
     {
         return new Identity($this->discoverAuthenticationService($container));
-    }
-
-    /**
-     * Create service
-     *
-     * @param string|null $rName
-     * @param string|null $cName
-     * @return Identity
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator, $rName = null, $cName = null)
-    {
-        return $this($serviceLocator, $cName);
     }
 
     private function discoverAuthenticationService(ContainerInterface $container): ?AuthenticationServiceInterface

--- a/test/Helper/Service/IdentityFactoryTest.php
+++ b/test/Helper/Service/IdentityFactoryTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\View\Helper\Service;
 use Interop\Container\ContainerInterface;
 use Laminas\Authentication\AuthenticationService;
 use Laminas\Authentication\AuthenticationServiceInterface;
+use Laminas\View\Exception\RuntimeException;
 use Laminas\View\Helper\Identity;
 use Laminas\View\Helper\Service\IdentityFactory;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -36,12 +37,17 @@ class IdentityFactoryTest extends TestCase
         $plugin = $factory($this->services);
 
         $this->assertInstanceOf(Identity::class, $plugin);
-        $this->assertNull($plugin->getAuthenticationService());
+        $this->expectException(RuntimeException::class);
+        $plugin();
     }
 
     public function testFactoryReturnsIdentityWithConfiguredAuthenticationServiceWhenPresent(): void
     {
         $authService = $this->createMock(AuthenticationServiceInterface::class);
+        $authService->expects(self::once())
+            ->method('hasIdentity')
+            ->willReturn(false);
+
         $this->services->expects(self::once())
             ->method('has')
             ->with(AuthenticationService::class)
@@ -57,12 +63,15 @@ class IdentityFactoryTest extends TestCase
         $plugin = $factory($this->services);
 
         $this->assertInstanceOf(Identity::class, $plugin);
-        $this->assertSame($authService, $plugin->getAuthenticationService());
+        $this->assertNull($plugin());
     }
 
     public function testFactoryReturnsIdentityWithConfiguredAuthenticationServiceInterfaceWhenPresent(): void
     {
         $authService = $this->createMock(AuthenticationServiceInterface::class);
+        $authService->expects(self::once())
+            ->method('hasIdentity')
+            ->willReturn(false);
 
         $this->services->expects(self::exactly(2))
             ->method('has')
@@ -78,6 +87,6 @@ class IdentityFactoryTest extends TestCase
         $plugin = $factory($this->services);
 
         $this->assertInstanceOf(Identity::class, $plugin);
-        $this->assertSame($authService, $plugin->getAuthenticationService());
+        $this->assertNull($plugin());
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes
| QA            | yes

### Description

Removes deprecated methods and inheritance in the Identity helper, marking it final.
Removes factory interface inheritance and swaps service manager for container interface
Fixes factory tests to test helper behaviour instead of calling removed service getter.
