### PR TITLE
Cleanup BasePath View Helper

### DIFF
--- a/src/Helper/BasePath.php
+++ b/src/Helper/BasePath.php
@@ -4,22 +4,28 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper;
 
-use Laminas\View\Exception;
+use Laminas\View\Exception\RuntimeException;
 
 use function ltrim;
 use function rtrim;
+use function sprintf;
 
 /**
  * Helper for retrieving the base path.
+ *
+ * @final
  */
 class BasePath extends AbstractHelper
 {
-    /**
-     * Base path
-     *
-     * @var string
-     */
+    use DeprecatedAbstractHelperHierarchyTrait;
+
+    /** @var string|null */
     protected $basePath;
+
+    public function __construct(?string $basePath = null)
+    {
+        $this->basePath = $basePath;
+    }
 
     /**
      * Returns site's base path, or file with base path prepended.
@@ -27,24 +33,31 @@ class BasePath extends AbstractHelper
      * $file is appended to the base path for simplicity.
      *
      * @param  string|null $file
-     * @throws Exception\RuntimeException
+     * @throws RuntimeException
      * @return string
      */
     public function __invoke($file = null)
     {
-        if (null === $this->basePath) {
-            throw new Exception\RuntimeException('No base path provided');
+        if ($this->basePath === null) {
+            throw new RuntimeException('No base path provided');
         }
 
-        if (null !== $file) {
-            $file = '/' . ltrim($file, '/');
+        if (! empty($file)) {
+            return sprintf(
+                '%s/%s',
+                rtrim($this->basePath, '/'),
+                ltrim($file, '/')
+            );
         }
 
-        return $this->basePath . $file;
+        return rtrim($this->basePath, '/');
     }
 
     /**
      * Set the base path.
+     *
+     * @deprecated since 2.21.0, this method will be removed in version 3.0.0 of this component.
+     *             The base path should be provided to the constructor from version 3.0
      *
      * @param  string $basePath
      * @return self

--- a/src/Helper/BasePath.php
+++ b/src/Helper/BasePath.php
@@ -42,7 +42,7 @@ class BasePath extends AbstractHelper
             throw new RuntimeException('No base path provided');
         }
 
-        if (! empty($file)) {
+        if ($file !== null && $file !== '') {
             return sprintf(
                 '%s/%s',
                 rtrim($this->basePath, '/'),

--- a/src/Helper/BasePath.php
+++ b/src/Helper/BasePath.php
@@ -56,9 +56,6 @@ class BasePath extends AbstractHelper
     /**
      * Set the base path.
      *
-     * @deprecated since 2.21.0, this method will be removed in version 3.0.0 of this component.
-     *             The base path should be provided to the constructor from version 3.0
-     *
      * @param  string $basePath
      * @return self
      */

--- a/src/Helper/BasePath.php
+++ b/src/Helper/BasePath.php
@@ -24,7 +24,9 @@ class BasePath extends AbstractHelper
 
     public function __construct(?string $basePath = null)
     {
-        $this->basePath = $basePath;
+        if ($basePath !== null) {
+            $this->setBasePath($basePath);
+        }
     }
 
     /**
@@ -45,12 +47,12 @@ class BasePath extends AbstractHelper
         if ($file !== null && $file !== '') {
             return sprintf(
                 '%s/%s',
-                rtrim($this->basePath, '/'),
+                $this->basePath,
                 ltrim($file, '/')
             );
         }
 
-        return rtrim($this->basePath, '/');
+        return $this->basePath;
     }
 
     /**

--- a/src/Helper/Service/BasePathFactory.php
+++ b/src/Helper/Service/BasePathFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View\Helper\Service;
+
+use ArrayAccess;
+use Laminas\View\Helper\BasePath;
+use Psr\Container\ContainerInterface;
+
+use function assert;
+use function is_array;
+use function is_string;
+
+final class BasePathFactory
+{
+    public function __invoke(ContainerInterface $container): BasePath
+    {
+        $config = $container->has('config')
+            ? $container->get('config')
+            : [];
+
+        assert(is_array($config) || $config instanceof ArrayAccess);
+
+        // The expected location in config for the base path in an MVC application
+        // is config.view_manager.base_path
+        // @link https://docs.laminas.dev/laminas-mvc/services/#viewmanager
+
+        $viewConfig = $config['view_manager'] ?? [];
+        assert(is_array($viewConfig));
+
+        $basePath = $viewConfig['base_path'] ?? null;
+        assert(is_string($basePath) || $basePath === null);
+
+        return new BasePath($basePath);
+    }
+}

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -248,7 +248,7 @@ class HelperPluginManager extends AbstractPluginManager
         Helper\HtmlAttributes::class => InvokableFactory::class,
         Helper\FlashMessenger::class => Helper\Service\FlashMessengerFactory::class,
         Helper\Identity::class       => Helper\Service\IdentityFactory::class,
-        Helper\BasePath::class       => InvokableFactory::class,
+        Helper\BasePath::class       => Helper\Service\BasePathFactory::class,
         Helper\Cycle::class          => InvokableFactory::class,
         Helper\DeclareVars::class    => InvokableFactory::class,
         // overridden in ViewHelperManagerFactory

--- a/test/Helper/BasePathTest.php
+++ b/test/Helper/BasePathTest.php
@@ -4,40 +4,46 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Helper;
 
+use Laminas\View\Exception\RuntimeException;
 use Laminas\View\Helper\BasePath;
 use PHPUnit\Framework\TestCase;
 
 class BasePathTest extends TestCase
 {
-    public function testBasePathWithoutFile(): void
+    /** @return array<array-key, array{0: string, 1: string|null, 2: string}> */
+    public function basePathDataProvider(): array
     {
-        $helper = new BasePath();
-        $helper->setBasePath('/foo');
-
-        $this->assertEquals('/foo', $helper());
+        return [
+            ['/foo', null, '/foo'],
+            ['/foo', 'bar', '/foo/bar'],
+            ['/foo', 'bar/', '/foo/bar/'],
+            ['/foo', '/bar/', '/foo/bar/'],
+            ['/foo/', null, '/foo'],
+            ['/foo/', 'bar', '/foo/bar'],
+            ['/foo/', 'bar/', '/foo/bar/'],
+            ['/foo/', '/bar/', '/foo/bar/'],
+            ['/foo//', '//bar', '/foo/bar'],
+            ['', null, ''],
+            ['', '', ''],
+            ['', 'bar', '/bar'],
+            ['', 'bar/', '/bar/'],
+            ['', '/bar/', '/bar/'],
+            ['', '//bar', '/bar'],
+        ];
     }
 
-    public function testBasePathWithFile(): void
+    /** @dataProvider basePathDataProvider */
+    public function testBasePathHelperYieldsExpectedOutput(string $basePath, ?string $argument, string $expect): void
     {
-        $helper = new BasePath();
-        $helper->setBasePath('/foo');
-
-        $this->assertEquals('/foo/bar', $helper('bar'));
+        $helper = new BasePath($basePath);
+        self::assertEquals($expect, $helper($argument));
     }
 
-    public function testBasePathNoDoubleSlashes(): void
+    public function testThatAnExceptionIsThrownWhenTheBasePathIsNull(): void
     {
-        $helper = new BasePath();
-        $helper->setBasePath('/');
-
-        $this->assertEquals('/', $helper('/'));
-    }
-
-    public function testBasePathWithFilePrefixedBySlash(): void
-    {
-        $helper = new BasePath();
-        $helper->setBasePath('/foo');
-
-        $this->assertEquals('/foo/bar', $helper('/bar'));
+        $helper = new BasePath(null);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No base path provided');
+        $helper();
     }
 }

--- a/test/Helper/BasePathTest.php
+++ b/test/Helper/BasePathTest.php
@@ -36,7 +36,7 @@ class BasePathTest extends TestCase
     public function testBasePathHelperYieldsExpectedOutput(string $basePath, ?string $argument, string $expect): void
     {
         $helper = new BasePath($basePath);
-        self::assertEquals($expect, $helper($argument));
+        self::assertEquals($expect, $helper->__invoke($argument));
     }
 
     public function testThatAnExceptionIsThrownWhenTheBasePathIsNull(): void
@@ -44,6 +44,13 @@ class BasePathTest extends TestCase
         $helper = new BasePath(null);
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('No base path provided');
-        $helper();
+        $helper->__invoke();
+    }
+
+    public function testThatTheBasePathCanBeChanged(): void
+    {
+        $helper = new BasePath(null);
+        $helper->setBasePath('something');
+        self::assertEquals('something/else', $helper->__invoke('else'));
     }
 }

--- a/test/Helper/Service/BasePathFactoryTest.php
+++ b/test/Helper/Service/BasePathFactoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\View\Helper\Service;
+
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\View\Helper\BasePath;
+use Laminas\View\Helper\Service\BasePathFactory;
+use Laminas\View\HelperPluginManager;
+use PHPUnit\Framework\TestCase;
+
+class BasePathFactoryTest extends TestCase
+{
+    private ServiceManager $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->container = new ServiceManager();
+    }
+
+    /** @return array<string, array{0: array}> */
+    public function configDataProvider(): array
+    {
+        return [
+            'Empty Config'             => [[]],
+            'Base Path Config Missing' => [['view_manager' => []]],
+            'Base Path Config Null'    => [['view_manager' => ['base_path' => null]]],
+            'Base Path Config Set'     => [['view_manager' => ['base_path' => '/foo']]],
+        ];
+    }
+
+    /** @dataProvider configDataProvider */
+    public function testFactoryWithVariousConfigurationSetups(array $config): void
+    {
+        $this->container->setService('config', $config);
+
+        $helper = (new BasePathFactory())($this->container);
+        self::assertInstanceOf(BasePath::class, $helper);
+    }
+
+    public function testHelperWillBeReturnedWhenThereIsNoConfigurationAtAll(): void
+    {
+        self::assertFalse($this->container->has('config'));
+        $helper = (new BasePathFactory())($this->container);
+        self::assertInstanceOf(BasePath::class, $helper);
+    }
+
+    public function testThatTheBasePathFactoryIsWiredUpByDefault(): void
+    {
+        $manager = new HelperPluginManager(new ServiceManager());
+        self::assertInstanceOf(BasePath::class, $manager->get(BasePath::class));
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | no
| New Feature   | yes
| QA            | yes

### Description

- Mark helper as final and deprecate inherited methods / inheritance
- Add constructor that accepts the configured base path
- Deprecate runtime modification of the base path
- Improve helper tests and cover uncovered paths
- Introduce and wire up a factory for the helper that retrieves the base path from the expected config as per MVC docs