### PR TITLE
Gravatar Helper: Reinstates constants for images and ratings

### DIFF
--- a/src/Helper/GravatarImage.php
+++ b/src/Helper/GravatarImage.php
@@ -19,11 +19,21 @@ final class GravatarImage
 {
     private const GRAVATAR_URL = '//www.gravatar.com/avatar';
 
+    /**
+     * RATING_* constants describe the "rating" of the avatar image that is most suitable for your audience.
+     *
+     * @link https://en.gravatar.com/site/implement/images/#rating
+     */
     public const RATING_G  = 'g';
     public const RATING_PG = 'pg';
     public const RATING_R  = 'r';
     public const RATING_X  = 'x';
 
+    /**
+     * DEFAULT_* constants describe the fallback image type that will be displayed when a profile does not exist.
+     *
+     * @link https://en.gravatar.com/site/implement/images/#default-image
+     */
     public const DEFAULT_404       = '404';
     public const DEFAULT_MP        = 'mp';
     public const DEFAULT_IDENTICON = 'identicon';

--- a/src/Helper/GravatarImage.php
+++ b/src/Helper/GravatarImage.php
@@ -19,19 +19,36 @@ final class GravatarImage
 {
     private const GRAVATAR_URL = '//www.gravatar.com/avatar';
 
+    public const RATING_G  = 'g';
+    public const RATING_PG = 'pg';
+    public const RATING_R  = 'r';
+    public const RATING_X  = 'x';
+
+    public const DEFAULT_404       = '404';
+    public const DEFAULT_MP        = 'mp';
+    public const DEFAULT_IDENTICON = 'identicon';
+    public const DEFAULT_MONSTERID = 'monsterid';
+    public const DEFAULT_WAVATAR   = 'wavatar';
+    public const DEFAULT_RETRO     = 'retro';
+    public const DEFAULT_ROBOHASH  = 'robohash';
+    public const DEFAULT_BLANK     = 'blank';
+
     public const RATINGS = [
-        'g',
-        'pg',
-        'r',
-        'x',
+        self::RATING_G,
+        self::RATING_PG,
+        self::RATING_R,
+        self::RATING_X,
     ];
 
     public const DEFAULT_IMAGE_VALUES = [
-        '404',
-        'mm',
-        'identicon',
-        'monsterid',
-        'wavatar',
+        self::DEFAULT_404,
+        self::DEFAULT_MP,
+        self::DEFAULT_IDENTICON,
+        self::DEFAULT_MONSTERID,
+        self::DEFAULT_WAVATAR,
+        self::DEFAULT_RETRO,
+        self::DEFAULT_ROBOHASH,
+        self::DEFAULT_BLANK,
     ];
 
     private Escaper $escaper;
@@ -52,8 +69,8 @@ final class GravatarImage
         string $emailAddress,
         int $imageSize = 80,
         array $imageAttributes = [],
-        string $defaultImage = 'mm',
-        string $rating = 'g'
+        string $defaultImage = self::DEFAULT_MP,
+        string $rating = self::RATING_G
     ): string {
         $imageAttributes['width'] = $imageAttributes['height'] = $imageSize;
         $imageAttributes['alt']   = $imageAttributes['alt'] ?? '';


### PR DESCRIPTION
The previous version of this helper declared constants for default image types and ratings. They have been reinstated, adding ones that didn't exist. Tests have been updated to replace string literals with constants and also the expected strings are escaped to make the expected output easier to read.

Closes #161 

Relevant to #158 
