### PR TITLE
Introduces an Empty ConfigProvider and Module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,12 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
+    "extra": {
+        "laminas": {
+            "component": "Laminas\\View",
+            "config-provider": "Laminas\\View\\ConfigProvider"
+        }
+    },
     "require": {
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-dom": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "adb0342243aa19eb2796daf3fd170b5a",
+    "content-hash": "0c0fa8e97afa85daf93f2da903cd926e",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -6212,5 +6212,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View;
+
+use Laminas\ServiceManager\ConfigInterface;
+
+/**
+ * @see ConfigInterface
+ *
+ * @psalm-import-type ServiceManagerConfigurationType from ConfigInterface
+ */
+final class ConfigProvider
+{
+    public function __invoke(): array
+    {
+        return [
+            'dependencies'       => $this->getDependencyConfig(),
+            'view_helpers'       => $this->getViewHelperDependencyConfiguration(),
+            'view_helper_config' => $this->getViewHelperConfiguration(),
+        ];
+    }
+
+    /** @return ServiceManagerConfigurationType */
+    public function getDependencyConfig(): array
+    {
+        return [
+            'factories' => [],
+            'aliases'   => [],
+        ];
+    }
+
+    /** @return ServiceManagerConfigurationType */
+    public function getViewHelperDependencyConfiguration(): array
+    {
+        return [
+            'factories' => [],
+            'aliases'   => [],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public function getViewHelperConfiguration(): array
+    {
+        return [
+            'asset' => [
+                /**
+                 * The asset helper is configured with a map asset names as keys a relative file paths as values
+                 *
+                 * @see Helper\Asset
+                 * @see Helper\Service\AssetFactory
+                 */
+                'resource_map' => [],
+            ],
+
+            /**
+             * @see Helper\Doctype
+             * @see Helper\Service\DoctypeFactory
+             */
+            'doctype' => null,
+        ];
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View;
+
+final class Module
+{
+    /**
+     * Return laminas-view configuration for a laminas-mvc application.
+     *
+     * @return array<string, mixed>
+     */
+    public function getConfig(): array
+    {
+        $provider = new ConfigProvider();
+        return [
+            'service_manager'    => $provider->getDependencyConfig(),
+            'view_helpers'       => $provider->getViewHelperDependencyConfiguration(),
+            'view_helper_config' => $provider->getViewHelperConfiguration(),
+            'view_manager'       => [
+                'template_map'               => [],
+                'template_path_stack'        => [],
+                'prefix_template_path_stack' => [],
+            ],
+        ];
+    }
+}

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\View;
+
+use Laminas\View\ConfigProvider;
+use PHPUnit\Framework\TestCase;
+
+class ConfigProviderTest extends TestCase
+{
+    public function testThatInvokeReturnsANonEmptyArray(): void
+    {
+        self::assertNotEmpty((new ConfigProvider())->__invoke());
+    }
+
+    public function testThatConventionalMethodForDependencyConfigurationExists(): void
+    {
+        $provider = new ConfigProvider();
+        self::assertNotEmpty($provider->getDependencyConfig());
+    }
+}

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\View;
+
+use Laminas\View\Module;
+use PHPUnit\Framework\TestCase;
+
+class ModuleTest extends TestCase
+{
+    public function testThatGetConfigReturnsANonEmptyArray(): void
+    {
+        $module = new Module();
+        self::assertNotEmpty($module->getConfig());
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | no
| New Feature   | yes

### Description

Adds a `Module` and `ConfigProvider` that are effectively empty.

It's not possible to move all of the view helper configuration into the config provider without breaking BC.

Having them at least present and setup in composer.json for the component installer means that consumers will get used to having the provider/module injected into app config, thereby providing a way to introduce factories for various things on the journey to version 3.0

Theses also provide a useful reference point for documenting the expected keys for various things, like `view_helpers` for helper factories etc and `view_helper_config` for helper specific options.

Also see #110 for additional context