### PR TITLE
Improve type inference for Plugin Managers

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -5,6 +5,7 @@
         "intl"
     ],
     "ignore_php_platform_requirements": {
+        "8.0": true,
         "8.1": true
     }
 }

--- a/.psr-container.php.stub
+++ b/.psr-container.php.stub
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psr\Container {
+    /**
+     * Provides automatic type inference for Psalm when retrieving a service from a container using a FQCN
+     */
+    interface ContainerInterface
+    {
+        /** @param string|class-string $id */
+        public function has(string $id): bool;
+
+        /**
+         * @template T of object
+         * @psalm-param string|class-string<T> $id
+         * @psalm-return ($id is class-string ? T : mixed)
+         */
+        public function get(string $id): object;
+    }
+}

--- a/.psr-container.php.stub
+++ b/.psr-container.php.stub
@@ -12,7 +12,7 @@ namespace Psr\Container {
         public function has(string $id): bool;
 
         /**
-         * @template T of object
+         * @template T
          * @psalm-param string|class-string<T> $id
          * @psalm-return ($id is class-string ? T : mixed)
          */

--- a/.psr-container.php.stub
+++ b/.psr-container.php.stub
@@ -8,14 +8,17 @@ namespace Psr\Container {
      */
     interface ContainerInterface
     {
-        /** @param string|class-string $id */
-        public function has(string $id): bool;
+        /**
+         * @param string|class-string $id
+         * @return bool
+         */
+        public function has(string $id);
 
         /**
          * @template T
          * @psalm-param string|class-string<T> $id
          * @psalm-return ($id is class-string ? T : mixed)
          */
-        public function get(string $id): object;
+        public function get(string $id);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "laminas/laminas-escaper": "^2.5",
         "laminas/laminas-eventmanager": "^3.4",
         "laminas/laminas-json": "^3.3",
-        "laminas/laminas-servicemanager": "^3.12.0",
+        "laminas/laminas-servicemanager": "^3.14.0",
         "laminas/laminas-stdlib": "^3.10.1",
         "psr/container": "^1 || ^2"
     },

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
         "laminas/laminas-escaper": "^2.5",
         "laminas/laminas-eventmanager": "^3.4",
         "laminas/laminas-json": "^3.3",
-        "laminas/laminas-servicemanager": "^3.10",
-        "laminas/laminas-stdlib": "^3.6",
+        "laminas/laminas-servicemanager": "^3.12.0",
+        "laminas/laminas-stdlib": "^3.10.1",
         "psr/container": "^1 || ^2"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "46c472e2fc0fe89dcb9d1e8ef522dbb4",
+    "content-hash": "f9740d25a5b9d0482c3dedf4adc31831",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -3305,16 +3305,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.6.4",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "135607f9ccc297d6923d49c2bcf309f509413215"
+                "reference": "981cc368a216c988e862a75e526b6076987d1b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/135607f9ccc297d6923d49c2bcf309f509413215",
-                "reference": "135607f9ccc297d6923d49c2bcf309f509413215",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/981cc368a216c988e862a75e526b6076987d1b50",
+                "reference": "981cc368a216c988e862a75e526b6076987d1b50",
                 "shasum": ""
             },
             "require": {
@@ -3324,7 +3324,6 @@
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
                 "phpstan/phpstan": "^1.5",
-                "phpstan/phpstan-phpunit": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/phpunit": "^9.5",
                 "symfony/process": "^5.2"
@@ -3344,9 +3343,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.4"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.5.1"
             },
-            "time": "2022-06-26T13:09:08+00:00"
+            "time": "2022-05-05T11:32:40+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -198,16 +198,16 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.12.0",
+            "version": "3.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "05ac4b1fb1fe9333313eeafced9b6c7946589487"
+                "reference": "918de970b2c3d42acebff3d431d76db52b6a32a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/05ac4b1fb1fe9333313eeafced9b6c7946589487",
-                "reference": "05ac4b1fb1fe9333313eeafced9b6c7946589487",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/918de970b2c3d42acebff3d431d76db52b6a32a2",
+                "reference": "918de970b2c3d42acebff3d431d76db52b6a32a2",
                 "shasum": ""
             },
             "require": {
@@ -237,7 +237,7 @@
                 "phpbench/phpbench": "^1.1",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.16.1",
+                "psalm/plugin-phpunit": "^0.17.0",
                 "vimeo/psalm": "^4.8"
             },
             "suggest": {
@@ -285,7 +285,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-06-13T16:20:56+00:00"
+            "time": "2022-07-07T16:13:26+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -564,16 +564,16 @@
         },
         {
             "name": "brick/varexporter",
-            "version": "0.3.5",
+            "version": "0.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/varexporter.git",
-                "reference": "05241f28dfcba2b51b11e2d750e296316ebbe518"
+                "reference": "3e263cd718d242594c52963760fee2059fd5833c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/varexporter/zipball/05241f28dfcba2b51b11e2d750e296316ebbe518",
-                "reference": "05241f28dfcba2b51b11e2d750e296316ebbe518",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/3e263cd718d242594c52963760fee2059fd5833c",
+                "reference": "3e263cd718d242594c52963760fee2059fd5833c",
                 "shasum": ""
             },
             "require": {
@@ -583,7 +583,7 @@
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
                 "phpunit/phpunit": "^8.5 || ^9.0",
-                "vimeo/psalm": "4.4.1"
+                "vimeo/psalm": "4.23.0"
             },
             "type": "library",
             "autoload": {
@@ -601,9 +601,15 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/varexporter/issues",
-                "source": "https://github.com/brick/varexporter/tree/0.3.5"
+                "source": "https://github.com/brick/varexporter/tree/0.3.7"
             },
-            "time": "2021-02-10T13:53:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-06-29T23:37:57+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",
@@ -1181,16 +1187,16 @@
         },
         {
             "name": "laminas/laminas-authentication",
-            "version": "2.10.1",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-authentication.git",
-                "reference": "7308db03e11147fbf567b5004ac428bdaba267f9"
+                "reference": "51815691d862b82b749a4aa9c4f6ec078d579f74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-authentication/zipball/7308db03e11147fbf567b5004ac428bdaba267f9",
-                "reference": "7308db03e11147fbf567b5004ac428bdaba267f9",
+                "url": "https://api.github.com/repos/laminas/laminas-authentication/zipball/51815691d862b82b749a4aa9c4f6ec078d579f74",
+                "reference": "51815691d862b82b749a4aa9c4f6ec078d579f74",
                 "shasum": ""
             },
             "require": {
@@ -1201,7 +1207,7 @@
                 "zendframework/zend-authentication": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.3.0",
                 "laminas/laminas-crypt": "^2.6 || ^3.2.1",
                 "laminas/laminas-db": "^2.13",
                 "laminas/laminas-http": "^2.15.0",
@@ -1253,7 +1259,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-03-09T23:07:57+00:00"
+            "time": "2022-06-23T10:41:36+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
@@ -2038,16 +2044,16 @@
         },
         {
             "name": "laminas/laminas-mvc-plugin-flashmessenger",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-mvc-plugin-flashmessenger.git",
-                "reference": "420a99df81432140d78799a2e7cb34931fcdd619"
+                "reference": "86bb1c654e5fafaf34d4deaa7dc9af721fbcb42d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-mvc-plugin-flashmessenger/zipball/420a99df81432140d78799a2e7cb34931fcdd619",
-                "reference": "420a99df81432140d78799a2e7cb34931fcdd619",
+                "url": "https://api.github.com/repos/laminas/laminas-mvc-plugin-flashmessenger/zipball/86bb1c654e5fafaf34d4deaa7dc9af721fbcb42d",
+                "reference": "86bb1c654e5fafaf34d4deaa7dc9af721fbcb42d",
                 "shasum": ""
             },
             "require": {
@@ -2103,7 +2109,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-01-10T11:32:19+00:00"
+            "time": "2022-06-27T22:15:07+00:00"
         },
         {
             "name": "laminas/laminas-navigation",
@@ -2541,22 +2547,22 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.19.0",
+            "version": "2.20.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "4875d4e58b6f728981bb767a60530540f82ee1df"
+                "reference": "90304417929a51e42999b115907a39f4b658c131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/4875d4e58b6f728981bb767a60530540f82ee1df",
-                "reference": "4875d4e58b6f728981bb767a60530540f82ee1df",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/90304417929a51e42999b115907a39f4b658c131",
+                "reference": "90304417929a51e42999b115907a39f4b658c131",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.1",
+                "laminas/laminas-servicemanager": "^3.12.0",
                 "laminas/laminas-stdlib": "^3.10",
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
                 "zendframework/zend-validator": "*"
@@ -2565,27 +2571,24 @@
                 "laminas/laminas-cache": "^2.6.1",
                 "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-db": "^2.7",
-                "laminas/laminas-filter": "^2.6",
+                "laminas/laminas-filter": "^2.14.0",
                 "laminas/laminas-http": "^2.14.2",
-                "laminas/laminas-i18n": "^2.6",
-                "laminas/laminas-math": "^2.6",
-                "laminas/laminas-servicemanager": "^2.7.11 || ^3.0.3",
-                "laminas/laminas-session": "^2.8",
-                "laminas/laminas-uri": "^2.7",
+                "laminas/laminas-i18n": "^2.15.0",
+                "laminas/laminas-session": "^2.12.1",
+                "laminas/laminas-uri": "^2.9.1",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5.5",
                 "psalm/plugin-phpunit": "^0.15.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0",
-                "vimeo/psalm": "^4.3"
+                "vimeo/psalm": "^4.23"
             },
             "suggest": {
                 "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
                 "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
                 "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
                 "laminas/laminas-i18n-resources": "Translations of validator messages",
-                "laminas/laminas-math": "Laminas\\Math component, required by the Csrf validator",
                 "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
                 "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
                 "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
@@ -2627,7 +2630,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-06-09T21:49:40+00:00"
+            "time": "2022-07-01T07:39:15+00:00"
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
@@ -3302,16 +3305,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.6.2",
+            "version": "1.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "76150ae7512439b4e6903db834e4a327596b617d"
+                "reference": "135607f9ccc297d6923d49c2bcf309f509413215"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/76150ae7512439b4e6903db834e4a327596b617d",
-                "reference": "76150ae7512439b4e6903db834e4a327596b617d",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/135607f9ccc297d6923d49c2bcf309f509413215",
+                "reference": "135607f9ccc297d6923d49c2bcf309f509413215",
                 "shasum": ""
             },
             "require": {
@@ -3341,9 +3344,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.2"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.4"
             },
-            "time": "2022-06-10T09:29:33+00:00"
+            "time": "2022-06-26T13:09:08+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3665,16 +3668,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.20",
+            "version": "9.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba"
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/12bc8879fb65aef2138b26fc633cb1e3620cffba",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e32b76be457de00e83213528f6bb37e2a38fcb1",
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1",
                 "shasum": ""
             },
             "require": {
@@ -3708,7 +3711,6 @@
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*",
                 "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
@@ -3752,7 +3754,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.21"
             },
             "funding": [
                 {
@@ -3764,7 +3766,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-01T12:37:26+00:00"
+            "time": "2022-06-19T12:14:25+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4903,16 +4905,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.0",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
-                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -4955,20 +4957,20 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-13T06:31:38+00:00"
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.9",
+            "version": "v5.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "829d5d1bf60b2efeb0887b7436873becc71a45eb"
+                "reference": "4d671ab4ddac94ee439ea73649c69d9d200b5000"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/829d5d1bf60b2efeb0887b7436873becc71a45eb",
-                "reference": "829d5d1bf60b2efeb0887b7436873becc71a45eb",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4d671ab4ddac94ee439ea73649c69d9d200b5000",
+                "reference": "4d671ab4ddac94ee439ea73649c69d9d200b5000",
                 "shasum": ""
             },
             "require": {
@@ -5038,7 +5040,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.9"
+                "source": "https://github.com/symfony/console/tree/v5.4.10"
             },
             "funding": [
                 {
@@ -5054,11 +5056,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-18T06:17:34+00:00"
+            "time": "2022-06-26T13:00:04+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.1",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
@@ -5105,7 +5107,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
             },
             "funding": [
                 {
@@ -5617,16 +5619,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.5.1",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "24d9dc654b83e91aa59f9d167b131bc3b5bea24c"
+                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/24d9dc654b83e91aa59f9d167b131bc3b5bea24c",
-                "reference": "24d9dc654b83e91aa59f9d167b131bc3b5bea24c",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
+                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
                 "shasum": ""
             },
             "require": {
@@ -5680,7 +5682,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.5.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.2"
             },
             "funding": [
                 {
@@ -5696,20 +5698,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-13T20:07:29+00:00"
+            "time": "2022-05-30T19:17:29+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.9",
+            "version": "v5.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "985e6a9703ef5ce32ba617c9c7d97873bb7b2a99"
+                "reference": "4432bc7df82a554b3e413a8570ce2fea90e94097"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/985e6a9703ef5ce32ba617c9c7d97873bb7b2a99",
-                "reference": "985e6a9703ef5ce32ba617c9c7d97873bb7b2a99",
+                "url": "https://api.github.com/repos/symfony/string/zipball/4432bc7df82a554b3e413a8570ce2fea90e94097",
+                "reference": "4432bc7df82a554b3e413a8570ce2fea90e94097",
                 "shasum": ""
             },
             "require": {
@@ -5766,7 +5768,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.9"
+                "source": "https://github.com/symfony/string/tree/v5.4.10"
             },
             "funding": [
                 {
@@ -5782,7 +5784,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-19T10:40:37+00:00"
+            "time": "2022-06-26T15:57:47+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5836,16 +5838,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.23.0",
+            "version": "4.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "f1fe6ff483bf325c803df9f510d09a03fd796f88"
+                "reference": "06dd975cb55d36af80f242561738f16c5f58264f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f1fe6ff483bf325c803df9f510d09a03fd796f88",
-                "reference": "f1fe6ff483bf325c803df9f510d09a03fd796f88",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/06dd975cb55d36af80f242561738f16c5f58264f",
+                "reference": "06dd975cb55d36af80f242561738f16c5f58264f",
                 "shasum": ""
             },
             "require": {
@@ -5937,9 +5939,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.23.0"
+                "source": "https://github.com/vimeo/psalm/tree/4.24.0"
             },
-            "time": "2022-04-28T17:35:49+00:00"
+            "time": "2022-06-26T11:47:54+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/composer.lock
+++ b/composer.lock
@@ -4,44 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "adb0342243aa19eb2796daf3fd170b5a",
+    "content-hash": "46c472e2fc0fe89dcb9d1e8ef522dbb4",
     "packages": [
-        {
-            "name": "container-interop/container-interop",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "shasum": ""
-            },
-            "require": {
-                "psr/container": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "homepage": "https://github.com/container-interop/container-interop",
-            "support": {
-                "issues": "https://github.com/container-interop/container-interop/issues",
-                "source": "https://github.com/container-interop/container-interop/tree/master"
-            },
-            "abandoned": "psr/container",
-            "time": "2017-02-14T19:40:03+00:00"
-        },
         {
             "name": "laminas/laminas-escaper",
             "version": "2.10.0",
@@ -106,35 +70,36 @@
         },
         {
             "name": "laminas/laminas-eventmanager",
-            "version": "3.4.0",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-eventmanager.git",
-                "reference": "a93fd278c97b2d41ebbce5ba048a24e3e6f580ba"
+                "reference": "41f7209428f37cab9573365e361f4078209aaafa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/a93fd278c97b2d41ebbce5ba048a24e3e6f580ba",
-                "reference": "a93fd278c97b2d41ebbce5ba048a24e3e6f580ba",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/41f7209428f37cab9573365e361f4078209aaafa",
+                "reference": "41f7209428f37cab9573365e361f4078209aaafa",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
+                "container-interop/container-interop": "<1.2",
                 "zendframework/zend-eventmanager": "*"
             },
             "require-dev": {
-                "container-interop/container-interop": "^1.1",
                 "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-stdlib": "^3.6",
                 "phpbench/phpbench": "^1.1",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.5"
+                "phpunit/phpunit": "^9.5.5",
+                "psr/container": "^1.1.2 || ^2.0.2"
             },
             "suggest": {
-                "container-interop/container-interop": "^1.1, to use the lazy listeners feature",
-                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature",
+                "psr/container": "^1.1.2 || ^2.0.2, to use the lazy listeners feature"
             },
             "type": "library",
             "autoload": {
@@ -168,7 +133,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-07T22:35:32+00:00"
+            "time": "2022-04-06T21:05:17+00:00"
         },
         {
             "name": "laminas/laminas-json",
@@ -233,37 +198,39 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.10.0",
+            "version": "3.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "e52b985909e0940bf22d34f322eb3f48bbef6bd1"
+                "reference": "05ac4b1fb1fe9333313eeafced9b6c7946589487"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/e52b985909e0940bf22d34f322eb3f48bbef6bd1",
-                "reference": "e52b985909e0940bf22d34f322eb3f48bbef6bd1",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/05ac4b1fb1fe9333313eeafced9b6c7946589487",
+                "reference": "05ac4b1fb1fe9333313eeafced9b6c7946589487",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.2",
                 "laminas/laminas-stdlib": "^3.2.1",
                 "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
+                "ext-psr": "*",
                 "laminas/laminas-code": "<3.3.1",
                 "zendframework/zend-code": "<3.3.1",
                 "zendframework/zend-servicemanager": "*"
             },
             "provide": {
-                "container-interop/container-interop-implementation": "^1.2",
                 "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "container-interop/container-interop": "^1.2.0"
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.0",
-                "laminas/laminas-coding-standard": "~2.2.1",
-                "laminas/laminas-container-config-test": "^0.3",
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-container-config-test": "^0.6",
                 "laminas/laminas-dependency-plugin": "^2.1.2",
                 "mikey179/vfsstream": "^1.6.10@alpha",
                 "ocramius/proxy-manager": "^2.11",
@@ -282,6 +249,9 @@
             ],
             "type": "library",
             "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
                 "psr-4": {
                     "Laminas\\ServiceManager\\": "src/"
                 }
@@ -315,20 +285,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-18T20:19:36+00:00"
+            "time": "2022-06-13T16:20:56+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.7.1",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "bcd869e2fe88d567800057c1434f2380354fe325"
+                "reference": "0d669074845fc80a99add0f64025192f143ef836"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/bcd869e2fe88d567800057c1434f2380354fe325",
-                "reference": "bcd869e2fe88d567800057c1434f2380354fe325",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/0d669074845fc80a99add0f64025192f143ef836",
+                "reference": "0d669074845fc80a99add0f64025192f143ef836",
                 "shasum": ""
             },
             "require": {
@@ -374,7 +344,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-01-21T15:50:46+00:00"
+            "time": "2022-06-10T14:49:09+00:00"
         },
         {
             "name": "psr/container",
@@ -781,16 +751,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "5d8e574bb0e69188786b8ef77d43341222a41a71"
+                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/5d8e574bb0e69188786b8ef77d43341222a41a71",
-                "reference": "5d8e574bb0e69188786b8ef77d43341222a41a71",
+                "url": "https://api.github.com/repos/composer/semver/zipball/3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9",
                 "shasum": ""
             },
             "require": {
@@ -842,7 +812,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.3.1"
+                "source": "https://github.com/composer/semver/tree/3.3.2"
             },
             "funding": [
                 {
@@ -858,7 +828,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-16T11:22:07+00:00"
+            "time": "2022-04-01T19:23:25+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -1155,16 +1125,16 @@
         },
         {
             "name": "felixfbecker/language-server-protocol",
-            "version": "1.5.1",
+            "version": "v1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
-                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730"
+                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
-                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/6e82196ffd7c62f7794d778ca52b69feec9f2842",
+                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842",
                 "shasum": ""
             },
             "require": {
@@ -1205,9 +1175,9 @@
             ],
             "support": {
                 "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
-                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/1.5.1"
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.2"
             },
-            "time": "2021-02-22T14:02:09+00:00"
+            "time": "2022-03-02T22:36:06+00:00"
         },
         {
             "name": "laminas/laminas-authentication",
@@ -1474,16 +1444,16 @@
         },
         {
             "name": "laminas/laminas-feed",
-            "version": "2.16.0",
+            "version": "2.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-feed.git",
-                "reference": "cbd0e10c867a1efa6594164d229d8caf4a4ae4c7"
+                "reference": "1ccb024ea615606ed1d676ba0fa3f22a398f3ac0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-feed/zipball/cbd0e10c867a1efa6594164d229d8caf4a4ae4c7",
-                "reference": "cbd0e10c867a1efa6594164d229d8caf4a4ae4c7",
+                "url": "https://api.github.com/repos/laminas/laminas-feed/zipball/1ccb024ea615606ed1d676ba0fa3f22a398f3ac0",
+                "reference": "1ccb024ea615606ed1d676ba0fa3f22a398f3ac0",
                 "shasum": ""
             },
             "require": {
@@ -1547,7 +1517,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-12-17T09:12:35+00:00"
+            "time": "2022-03-24T10:26:04+00:00"
         },
         {
             "name": "laminas/laminas-filter",
@@ -1695,16 +1665,16 @@
         },
         {
             "name": "laminas/laminas-i18n",
-            "version": "2.14.0",
+            "version": "2.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-i18n.git",
-                "reference": "1fa15c41b683bedb2a846af54491868ddc73db38"
+                "reference": "1654fcd6cd27c01a902b47fe71fa583ad227268c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/1fa15c41b683bedb2a846af54491868ddc73db38",
-                "reference": "1fa15c41b683bedb2a846af54491868ddc73db38",
+                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/1654fcd6cd27c01a902b47fe71fa583ad227268c",
+                "reference": "1654fcd6cd27c01a902b47fe71fa583ad227268c",
                 "shasum": ""
             },
             "require": {
@@ -1713,6 +1683,7 @@
                 "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
+                "laminas/laminas-view": "<2.20.0",
                 "phpspec/prophecy": "<1.9.0",
                 "zendframework/zend-i18n": "*"
             },
@@ -1726,7 +1697,7 @@
                 "laminas/laminas-filter": "^2.10.0",
                 "laminas/laminas-servicemanager": "^3.7.0",
                 "laminas/laminas-validator": "^2.14.0",
-                "laminas/laminas-view": "^2.12.0",
+                "laminas/laminas-view": "^2.20.0",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.3",
                 "psalm/plugin-phpunit": "^0.16.1",
@@ -1778,7 +1749,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-02-21T20:41:26+00:00"
+            "time": "2022-04-01T10:47:19+00:00"
         },
         {
             "name": "laminas/laminas-loader",
@@ -2570,21 +2541,21 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.17.0",
+            "version": "2.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "bdd503adc83d814a5c94e598ea0eb9fc7ca56339"
+                "reference": "4875d4e58b6f728981bb767a60530540f82ee1df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/bdd503adc83d814a5c94e598ea0eb9fc7ca56339",
-                "reference": "bdd503adc83d814a5c94e598ea0eb9fc7ca56339",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/4875d4e58b6f728981bb767a60530540f82ee1df",
+                "reference": "4875d4e58b6f728981bb767a60530540f82ee1df",
                 "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "^1.1",
-                "laminas/laminas-stdlib": "^3.6",
+                "laminas/laminas-stdlib": "^3.10",
                 "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
@@ -2656,7 +2627,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-03-08T18:16:51+00:00"
+            "time": "2022-06-09T21:49:40+00:00"
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
@@ -2832,16 +2803,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.13.2",
+            "version": "v4.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
-                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/34bea19b6e03d8153165d8f30bba4c3be86184c1",
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1",
                 "shasum": ""
             },
             "require": {
@@ -2882,9 +2853,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.14.0"
             },
-            "time": "2021-11-30T19:35:32+00:00"
+            "time": "2022-05-31T20:59:12+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -3162,16 +3133,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706"
+                "reference": "77a32518733312af16a44300404e945338981de3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/93ebd0014cab80c4ea9f5e297ea48672f1b87706",
-                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
+                "reference": "77a32518733312af16a44300404e945338981de3",
                 "shasum": ""
             },
             "require": {
@@ -3206,9 +3177,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
             },
-            "time": "2022-01-04T19:58:01+00:00"
+            "time": "2022-03-15T21:29:03+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -3331,35 +3302,31 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.2.0",
+            "version": "1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e"
+                "reference": "76150ae7512439b4e6903db834e4a327596b617d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
-                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/76150ae7512439b4e6903db834e4a327596b617d",
+                "reference": "76150ae7512439b4e6903db834e4a327596b617d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/phpunit": "^9.5",
                 "symfony/process": "^5.2"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PHPStan\\PhpDocParser\\": [
@@ -3374,9 +3341,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.2.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.2"
             },
-            "time": "2021-09-16T20:46:02+00:00"
+            "time": "2022-06-10T09:29:33+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3698,16 +3665,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.19",
+            "version": "9.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "35ea4b7f3acabb26f4bb640f8c30866c401da807"
+                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/35ea4b7f3acabb26f4bb640f8c30866c401da807",
-                "reference": "35ea4b7f3acabb26f4bb640f8c30866c401da807",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/12bc8879fb65aef2138b26fc633cb1e3620cffba",
+                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba",
                 "shasum": ""
             },
             "require": {
@@ -3785,7 +3752,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.20"
             },
             "funding": [
                 {
@@ -3797,7 +3764,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-15T09:57:31+00:00"
+            "time": "2022-04-01T12:37:26+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4275,16 +4242,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.3",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
-                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
                 "shasum": ""
             },
             "require": {
@@ -4326,7 +4293,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
             },
             "funding": [
                 {
@@ -4334,7 +4301,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:52:38+00:00"
+            "time": "2022-04-03T09:37:03+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -4875,32 +4842,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "7.0.19",
+            "version": "7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "bef66a43815bbf9b5f49775e9ded3f7c6ba0cc37"
+                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/bef66a43815bbf9b5f49775e9ded3f7c6ba0cc37",
-                "reference": "bef66a43815bbf9b5f49775e9ded3f7c6ba0cc37",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/aff06ae7a84e4534bf6f821dc982a93a5d477c90",
+                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-                "php": "^7.1 || ^8.0",
-                "phpstan/phpdoc-parser": "^1.0.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.5.1",
                 "squizlabs/php_codesniffer": "^3.6.2"
             },
             "require-dev": {
-                "phing/phing": "2.17.2",
+                "phing/phing": "2.17.3",
                 "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpstan/phpstan": "1.4.6",
+                "phpstan/phpstan": "1.4.10|1.7.1",
                 "phpstan/phpstan-deprecation-rules": "1.0.0",
-                "phpstan/phpstan-phpunit": "1.0.0",
-                "phpstan/phpstan-strict-rules": "1.1.0",
-                "phpunit/phpunit": "7.5.20|8.5.21|9.5.16"
+                "phpstan/phpstan-phpunit": "1.0.0|1.1.1",
+                "phpstan/phpstan-strict-rules": "1.2.3",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.20"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -4920,7 +4887,7 @@
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/7.0.19"
+                "source": "https://github.com/slevomat/coding-standard/tree/7.2.1"
             },
             "funding": [
                 {
@@ -4932,20 +4899,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-01T18:01:41+00:00"
+            "time": "2022-05-25T10:58:12+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.2",
+            "version": "3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
+                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
                 "shasum": ""
             },
             "require": {
@@ -4988,20 +4955,20 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-12-12T21:44:58+00:00"
+            "time": "2022-06-13T06:31:38+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.5",
+            "version": "v5.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d8111acc99876953f52fe16d4c50eb60940d49ad"
+                "reference": "829d5d1bf60b2efeb0887b7436873becc71a45eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d8111acc99876953f52fe16d4c50eb60940d49ad",
-                "reference": "d8111acc99876953f52fe16d4c50eb60940d49ad",
+                "url": "https://api.github.com/repos/symfony/console/zipball/829d5d1bf60b2efeb0887b7436873becc71a45eb",
+                "reference": "829d5d1bf60b2efeb0887b7436873becc71a45eb",
                 "shasum": ""
             },
             "require": {
@@ -5071,7 +5038,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.5"
+                "source": "https://github.com/symfony/console/tree/v5.4.9"
             },
             "funding": [
                 {
@@ -5087,20 +5054,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-24T12:45:35+00:00"
+            "time": "2022-05-18T06:17:34+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.0",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8"
+                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/6f981ee24cf69ee7ce9736146d1c57c2780598a8",
-                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
                 "shasum": ""
             },
             "require": {
@@ -5138,7 +5105,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.1"
             },
             "funding": [
                 {
@@ -5154,20 +5121,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-12T14:48:14+00:00"
+            "time": "2022-01-02T09:53:40+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
+                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
-                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
                 "shasum": ""
             },
             "require": {
@@ -5182,7 +5149,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5220,7 +5187,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -5236,20 +5203,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-20T20:35:02+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783"
+                "reference": "433d05519ce6990bf3530fba6957499d327395c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/81b86b50cf841a64252b439e738e97f4a34e2783",
-                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/433d05519ce6990bf3530fba6957499d327395c2",
+                "reference": "433d05519ce6990bf3530fba6957499d327395c2",
                 "shasum": ""
             },
             "require": {
@@ -5261,7 +5228,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5301,7 +5268,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -5317,20 +5284,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-23T21:10:46+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+                "reference": "219aa369ceff116e673852dce47c3a41794c14bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/219aa369ceff116e673852dce47c3a41794c14bd",
+                "reference": "219aa369ceff116e673852dce47c3a41794c14bd",
                 "shasum": ""
             },
             "require": {
@@ -5342,7 +5309,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5385,7 +5352,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -5401,20 +5368,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825"
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0abb51d2f102e00a4eefcf46ba7fec406d245825",
-                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
                 "shasum": ""
             },
             "require": {
@@ -5429,7 +5396,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5468,7 +5435,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -5484,20 +5451,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-30T18:21:41+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "cc5db0e22b3cb4111010e48785a97f670b350ca5"
+                "reference": "e440d35fa0286f77fb45b79a03fedbeda9307e85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/cc5db0e22b3cb4111010e48785a97f670b350ca5",
-                "reference": "cc5db0e22b3cb4111010e48785a97f670b350ca5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/e440d35fa0286f77fb45b79a03fedbeda9307e85",
+                "reference": "e440d35fa0286f77fb45b79a03fedbeda9307e85",
                 "shasum": ""
             },
             "require": {
@@ -5506,7 +5473,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5547,7 +5514,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -5563,20 +5530,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-05T21:20:04+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "4407588e0d3f1f52efb65fbe92babe41f37fe50c"
+                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/4407588e0d3f1f52efb65fbe92babe41f37fe50c",
-                "reference": "4407588e0d3f1f52efb65fbe92babe41f37fe50c",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/cfa0ae98841b9e461207c13ab093d76b0fa7bace",
+                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace",
                 "shasum": ""
             },
             "require": {
@@ -5585,7 +5552,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5630,7 +5597,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -5646,26 +5613,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-04T08:16:47+00:00"
+            "time": "2022-05-10T07:21:04+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.5.0",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc"
+                "reference": "24d9dc654b83e91aa59f9d167b131bc3b5bea24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
-                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/24d9dc654b83e91aa59f9d167b131bc3b5bea24c",
+                "reference": "24d9dc654b83e91aa59f9d167b131bc3b5bea24c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "psr/container": "^1.1",
-                "symfony/deprecation-contracts": "^2.1"
+                "symfony/deprecation-contracts": "^2.1|^3"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -5713,7 +5680,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.5.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.1"
             },
             "funding": [
                 {
@@ -5729,20 +5696,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-04T16:48:04+00:00"
+            "time": "2022-03-13T20:07:29+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.3",
+            "version": "v5.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "92043b7d8383e48104e411bc9434b260dbeb5a10"
+                "reference": "985e6a9703ef5ce32ba617c9c7d97873bb7b2a99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/92043b7d8383e48104e411bc9434b260dbeb5a10",
-                "reference": "92043b7d8383e48104e411bc9434b260dbeb5a10",
+                "url": "https://api.github.com/repos/symfony/string/zipball/985e6a9703ef5ce32ba617c9c7d97873bb7b2a99",
+                "reference": "985e6a9703ef5ce32ba617c9c7d97873bb7b2a99",
                 "shasum": ""
             },
             "require": {
@@ -5799,7 +5766,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.3"
+                "source": "https://github.com/symfony/string/tree/v5.4.9"
             },
             "funding": [
                 {
@@ -5815,7 +5782,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2022-04-19T10:40:37+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5869,16 +5836,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.22.0",
+            "version": "4.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "fc2c6ab4d5fa5d644d8617089f012f3bb84b8703"
+                "reference": "f1fe6ff483bf325c803df9f510d09a03fd796f88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/fc2c6ab4d5fa5d644d8617089f012f3bb84b8703",
-                "reference": "fc2c6ab4d5fa5d644d8617089f012f3bb84b8703",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f1fe6ff483bf325c803df9f510d09a03fd796f88",
+                "reference": "f1fe6ff483bf325c803df9f510d09a03fd796f88",
                 "shasum": ""
             },
             "require": {
@@ -5903,6 +5870,7 @@
                 "php": "^7.1|^8",
                 "sebastian/diff": "^3.0 || ^4.0",
                 "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
+                "symfony/polyfill-php80": "^1.25",
                 "webmozart/path-util": "^2.3"
             },
             "provide": {
@@ -5969,9 +5937,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.22.0"
+                "source": "https://github.com/vimeo/psalm/tree/4.23.0"
             },
-            "time": "2022-02-24T20:34:05+00:00"
+            "time": "2022-04-28T17:35:49+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -6089,21 +6057,21 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.10.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
+                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0",
-                "symfony/polyfill-ctype": "^1.8"
+                "ext-ctype": "*",
+                "php": "^7.2 || ^8.0"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
@@ -6141,9 +6109,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
+                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
-            "time": "2021-03-09T10:59:23+00:00"
+            "time": "2022-06-03T18:03:27+00:00"
         },
         {
             "name": "webmozart/path-util",
@@ -6212,5 +6180,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
+<files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
   <file src="bin/templatemap_generator.php">
     <MissingParamType occurrences="1">
       <code>$templatePath</code>
@@ -710,38 +710,12 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Helper/Navigation.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>null === $this-&gt;plugins</code>
-    </DocblockTypeContradiction>
-    <FalsableReturnStatement occurrences="1">
-      <code>false</code>
-    </FalsableReturnStatement>
     <InvalidFunctionCall occurrences="1">
       <code>call_user_func_array($helper, $arguments)</code>
     </InvalidFunctionCall>
     <InvalidThrow occurrences="1">
       <code>ExceptionInterface</code>
     </InvalidThrow>
-    <MissingConstructor occurrences="1">
-      <code>$plugins</code>
-    </MissingConstructor>
-    <MixedArgument occurrences="2">
-      <code>$helper</code>
-      <code>$helper</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$helper</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>NavigationHelper</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="2">
-      <code>setContainer</code>
-      <code>setContainer</code>
-    </MixedMethodCall>
-    <MixedReturnStatement occurrences="1">
-      <code>$helper</code>
-    </MixedReturnStatement>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$container</code>
     </MoreSpecificImplementedParamType>
@@ -755,12 +729,6 @@
       <code>$view</code>
       <code>$view</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="4">
-      <code>$helper</code>
-      <code>$helper</code>
-      <code>$this-&gt;plugins</code>
-      <code>$view &amp;&amp; $this-&gt;plugins</code>
-    </RedundantConditionGivenDocblockType>
     <UndefinedInterfaceMethod occurrences="2">
       <code>hasTranslator</code>
       <code>setTranslator</code>
@@ -1631,9 +1599,6 @@
       <code>has</code>
       <code>has</code>
     </MixedMethodCall>
-    <NonInvariantDocblockPropertyType occurrences="1">
-      <code>$aliases</code>
-    </NonInvariantDocblockPropertyType>
     <PropertyTypeCoercion occurrences="1">
       <code>$this-&gt;initializers</code>
     </PropertyTypeCoercion>
@@ -1828,17 +1793,13 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Renderer/PhpRenderer.php">
-    <DocblockTypeContradiction occurrences="3">
+    <DocblockTypeContradiction occurrences="2">
       <code>gettype($helpers)</code>
       <code>gettype($variables)</code>
-      <code>is_callable($plugin)</code>
     </DocblockTypeContradiction>
     <ImplementedParamTypeMismatch occurrences="1">
       <code>$values</code>
     </ImplementedParamTypeMismatch>
-    <InvalidNullableReturnType occurrences="1">
-      <code>HelperPluginManager</code>
-    </InvalidNullableReturnType>
     <MixedArgument occurrences="4">
       <code>$__vars</code>
       <code>$this-&gt;__template</code>
@@ -1872,11 +1833,7 @@
     <MixedClone occurrences="1">
       <code>clone $this-&gt;vars()</code>
     </MixedClone>
-    <MixedFunctionCall occurrences="1">
-      <code>call_user_func_array($plugin, $argv)</code>
-    </MixedFunctionCall>
-    <MixedInferredReturnType occurrences="3">
-      <code>AbstractHelper</code>
+    <MixedInferredReturnType occurrences="2">
       <code>string</code>
       <code>string|Resolver</code>
     </MixedInferredReturnType>
@@ -1889,8 +1846,7 @@
       <code>$this-&gt;__templateResolver-&gt;resolve($name, $this)</code>
       <code>$this-&gt;getHelperPluginManager()-&gt;get($name, $options)</code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="2">
-      <code>$this-&gt;__helpers</code>
+    <NullableReturnStatement occurrences="1">
       <code>$this-&gt;__templateResolver</code>
     </NullableReturnStatement>
     <PossibleRawObjectIteration occurrences="1">
@@ -1919,9 +1875,6 @@
       <code>is_object($helpers)</code>
       <code>is_object($variables)</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedMethod occurrences="1">
-      <code>setCurrent</code>
-    </UndefinedMethod>
     <UnresolvableInclude occurrences="1">
       <code>include $this-&gt;__file</code>
     </UnresolvableInclude>
@@ -2490,9 +2443,6 @@
       <code>$values</code>
       <code>$values</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
-      <code>setCharset</code>
-    </MixedMethodCall>
     <MixedOperand occurrences="2">
       <code>$attributeEscaper('boo bah')</code>
       <code>$attributeEscaper('foo bar')</code>
@@ -2529,35 +2479,6 @@
       <code>offsetSetName</code>
       <code>setIndent</code>
     </UndefinedMagicMethod>
-    <UndefinedMethod occurrences="27">
-      <code>__invoke</code>
-      <code>__invoke</code>
-      <code>__invoke</code>
-      <code>__invoke</code>
-      <code>__invoke</code>
-      <code>__invoke</code>
-      <code>__invoke</code>
-      <code>appendHttpEquiv</code>
-      <code>appendHttpEquiv</code>
-      <code>appendHttpEquiv</code>
-      <code>appendHttpEquiv</code>
-      <code>setCharset</code>
-      <code>setCharset</code>
-      <code>setCharset</code>
-      <code>setName</code>
-      <code>setName</code>
-      <code>setName</code>
-      <code>setName</code>
-      <code>setName</code>
-      <code>setName</code>
-      <code>setProperty</code>
-      <code>toString</code>
-      <code>toString</code>
-      <code>toString</code>
-      <code>toString</code>
-      <code>toString</code>
-      <code>toString</code>
-    </UndefinedMethod>
   </file>
   <file src="test/Helper/HeadScriptTest.php">
     <InvalidDocblock occurrences="1">
@@ -2636,10 +2557,6 @@
       <code>setIndent</code>
       <code>setIndent</code>
     </UndefinedMagicMethod>
-    <UndefinedMethod occurrences="2">
-      <code>setDoctype</code>
-      <code>setDoctype</code>
-    </UndefinedMethod>
   </file>
   <file src="test/Helper/HeadStyleTest.php">
     <MixedArgument occurrences="14">
@@ -2715,23 +2632,12 @@
       <code>$this-&gt;view</code>
     </UndefinedThisPropertyAssignment>
   </file>
-  <file src="test/Helper/HtmlObjectTest.php">
-    <UndefinedMethod occurrences="2">
-      <code>__invoke</code>
-      <code>__invoke</code>
-    </UndefinedMethod>
-  </file>
   <file src="test/Helper/HtmlTagTest.php">
     <MixedArgument occurrences="3">
       <code>$escape($value)</code>
       <code>$escape($value)</code>
       <code>$escape('http://www.w3.org/1999/xhtml')</code>
     </MixedArgument>
-  </file>
-  <file src="test/Helper/LayoutTest.php">
-    <UndefinedMethod occurrences="1">
-      <code>setTemplate</code>
-    </UndefinedMethod>
   </file>
   <file src="test/Helper/Navigation/AbstractHelperTest.php">
     <MixedArgument occurrences="3">
@@ -2924,15 +2830,11 @@
       <code>getLabel</code>
       <code>getLabel</code>
     </PossiblyInvalidMethodCall>
-    <PossiblyNullReference occurrences="4">
+    <PossiblyNullReference occurrences="3">
       <code>getHref</code>
       <code>getLabel</code>
       <code>getLabel</code>
-      <code>plugin</code>
     </PossiblyNullReference>
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>plugin</code>
-    </UndefinedInterfaceMethod>
     <UnusedForeachValue occurrences="2">
       <code>$discard</code>
       <code>$discard</code>
@@ -3324,10 +3226,6 @@
     </InvalidArgument>
   </file>
   <file src="test/HelperPluginManagerCompatibilityTest.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>$this-&gt;getServiceNotFoundException()</code>
-      <code>$this-&gt;getServiceNotFoundException()</code>
-    </ArgumentTypeCoercion>
     <MixedArgument occurrences="2">
       <code>$target</code>
       <code>$target</code>
@@ -3346,12 +3244,7 @@
       <code>$container</code>
       <code>$container</code>
     </MissingClosureParamType>
-    <MixedAssignment occurrences="6">
-      <code>$helper</code>
-      <code>$helper</code>
-      <code>$helper</code>
-      <code>$helper</code>
-      <code>$helper</code>
+    <MixedAssignment occurrences="1">
       <code>$helperB</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="6">
@@ -3409,10 +3302,6 @@
     <PossiblyUndefinedMethod occurrences="1">
       <code>$vars</code>
     </PossiblyUndefinedMethod>
-    <UndefinedMethod occurrences="2">
-      <code>getCurrent</code>
-      <code>hasCurrent</code>
-    </UndefinedMethod>
     <UnusedClosureParam occurrences="2">
       <code>$errno</code>
       <code>$errstr</code>
@@ -3521,7 +3410,7 @@
     </MixedAssignment>
   </file>
   <file src="test/ViewTest.php">
-    <MissingClosureParamType occurrences="12">
+    <MissingClosureParamType occurrences="11">
       <code>$e</code>
       <code>$e</code>
       <code>$e</code>
@@ -3554,7 +3443,7 @@
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
-    <UnusedClosureParam occurrences="5">
+    <UnusedClosureParam occurrences="4">
       <code>$e</code>
       <code>$e</code>
       <code>$e</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -32,7 +32,6 @@
       <code>$closingBracket</code>
       <code>$closingBracket</code>
       <code>$closingBracket</code>
-      <code>$closingBracket</code>
     </MissingConstructor>
     <MixedArgument occurrences="1">
       <code>$val</code>
@@ -235,6 +234,9 @@
     <InvalidReturnType occurrences="1">
       <code>HeadLink</code>
     </InvalidReturnType>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>(object) $attributes</code>
+    </LessSpecificReturnStatement>
     <MixedArgument occurrences="13">
       <code>$args</code>
       <code>$args</code>
@@ -291,6 +293,9 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$value</code>
     </MoreSpecificImplementedParamType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>stdClass</code>
+    </MoreSpecificReturnType>
     <ParamNameMismatch occurrences="1">
       <code>$index</code>
     </ParamNameMismatch>
@@ -566,7 +571,9 @@
       <code>$item</code>
       <code>$item</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="1"/>
+    <MissingClosureReturnType occurrences="1">
+      <code>static fn($item) =&gt; $item</code>
+    </MissingClosureReturnType>
     <MixedArgument occurrences="2">
       <code>$item</code>
       <code>$separator</code>
@@ -773,7 +780,6 @@
       <code>$page-&gt;getTextDomain()</code>
     </MixedArgument>
     <MixedAssignment occurrences="4">
-      <code>$container</code>
       <code>$container</code>
       <code>$container</code>
       <code>$label</code>
@@ -1536,8 +1542,6 @@
       <code>$flashMessenger</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="1">
-      <code>get</code>
-      <code>get</code>
       <code>get</code>
     </MixedMethodCall>
     <ParamNameMismatch occurrences="1">
@@ -2584,9 +2588,6 @@
     <MixedAssignment occurrences="8">
       <code>$item</code>
       <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
       <code>$value</code>
       <code>$values</code>
       <code>$values</code>
@@ -2595,9 +2596,6 @@
       <code>$values</code>
     </MixedAssignment>
     <MixedPropertyFetch occurrences="6">
-      <code>$item-&gt;content</code>
-      <code>$item-&gt;content</code>
-      <code>$item-&gt;content</code>
       <code>$item-&gt;content</code>
       <code>$item-&gt;content</code>
       <code>$value-&gt;attributes</code>
@@ -2889,6 +2887,9 @@
       <code>$this-&gt;errorHandlerMessage</code>
     </PossiblyNullArgument>
     <TooManyArguments occurrences="1"/>
+    <UndefinedClass occurrences="1">
+      <code>PsrContainerDecorator</code>
+    </UndefinedClass>
     <UnusedClosureParam occurrences="1">
       <code>$code</code>
     </UnusedClosureParam>
@@ -2918,6 +2919,7 @@
     <UnevaluatedCode occurrences="4">
       <code>$nav = clone $this-&gt;nav2;</code>
       <code>$nav-&gt;addPage(['label' =&gt; 'Invalid', 'uri' =&gt; 'http://w.']);</code>
+      <code>static::fail('A Laminas\View\Exception\InvalidArgumentException was not thrown on invalid &lt;loc /&gt;');</code>
     </UnevaluatedCode>
   </file>
   <file src="test/Helper/PaginationControlTest.php">
@@ -3422,7 +3424,6 @@
       <code>$e</code>
       <code>$e</code>
       <code>$e</code>
-      <code>$e</code>
     </MissingClosureParamType>
     <MixedArgument occurrences="2">
       <code>$result-&gt;content</code>
@@ -3444,7 +3445,6 @@
       <code>null</code>
     </NullArgument>
     <UnusedClosureParam occurrences="4">
-      <code>$e</code>
       <code>$e</code>
       <code>$e</code>
       <code>$e</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.20.0@f82a70e7edfc6cf2705e9374c8a0b6a974a779ed">
+<files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
   <file src="bin/templatemap_generator.php">
     <MissingParamType occurrences="1">
       <code>$templatePath</code>
@@ -804,7 +804,7 @@
       <code>$page-&gt;getTextDomain()</code>
       <code>$page-&gt;getTextDomain()</code>
     </MixedArgument>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$container</code>
       <code>$container</code>
       <code>$container</code>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -45,4 +45,7 @@
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
+    <stubs>
+        <file name=".psr-container.php.stub" preloadClasses="true" />
+    </stubs>
 </psalm>

--- a/src/Helper/Navigation/AbstractHelper.php
+++ b/src/Helper/Navigation/AbstractHelper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper\Navigation;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\EventManager\EventManager;
 use Laminas\EventManager\EventManagerAwareInterface;
 use Laminas\EventManager\EventManagerInterface;

--- a/src/Helper/Navigation/PluginManager.php
+++ b/src/Helper/Navigation/PluginManager.php
@@ -16,7 +16,9 @@ use Laminas\View\HelperPluginManager;
  * Navigation\HelperInterface. Additionally, it registers a number of default
  * helpers.
  *
+ * @template InstanceType of HelperInterface|AbstractHelper
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
+ * @extends HelperPluginManager<InstanceType>
  */
 class PluginManager extends HelperPluginManager
 {

--- a/src/Helper/Navigation/PluginManager.php
+++ b/src/Helper/Navigation/PluginManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper\Navigation;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\HelperPluginManager;

--- a/src/Helper/Service/AssetFactory.php
+++ b/src/Helper/Service/AssetFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper\Service;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\View\Exception;

--- a/src/Helper/Service/FlashMessengerFactory.php
+++ b/src/Helper/Service/FlashMessengerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper\Service;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\View\Helper\FlashMessenger;

--- a/src/Helper/Service/HtmlAttributesFactory.php
+++ b/src/Helper/Service/HtmlAttributesFactory.php
@@ -8,8 +8,6 @@ use Laminas\Escaper\Escaper;
 use Laminas\View\Helper\HtmlAttributes;
 use Psr\Container\ContainerInterface;
 
-use function assert;
-
 final class HtmlAttributesFactory
 {
     public function __invoke(ContainerInterface $container): HtmlAttributes
@@ -17,8 +15,6 @@ final class HtmlAttributesFactory
         $escaper = $container->has(Escaper::class)
             ? $container->get(Escaper::class)
             : new Escaper();
-
-        assert($escaper instanceof Escaper);
 
         return new HtmlAttributes($escaper);
     }

--- a/src/Helper/Service/IdentityFactory.php
+++ b/src/Helper/Service/IdentityFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper\Service;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\Authentication\AuthenticationService;
 use Laminas\Authentication\AuthenticationServiceInterface;
 use Laminas\ServiceManager\FactoryInterface;

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -30,6 +30,8 @@ use function sprintf;
  * Helper\HelperInterface. Additionally, it registers a number of default
  * helpers.
  *
+ * @template InstanceType of Helper\HelperInterface|callable
+ * @extends AbstractPluginManager<InstanceType>
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  */
 class HelperPluginManager extends AbstractPluginManager
@@ -507,6 +509,7 @@ class HelperPluginManager extends AbstractPluginManager
      *
      * @param mixed $instance
      * @throws InvalidServiceException
+     * @psalm-assert InstanceType $instance
      */
     public function validate($instance)
     {
@@ -527,9 +530,13 @@ class HelperPluginManager extends AbstractPluginManager
      *
      * Proxies to `validate()`.
      *
+     * @deprecated Since 2.21.0 - This method will be removed in version 3.0. It provides BC with Service Manager v2
+     *             which can no longer be installed with this component.
+     *
      * @param mixed $instance
      * @return void
      * @throws InvalidHelperException
+     * @psalm-assert InstanceType $instance
      */
     public function validatePlugin($instance)
     {

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -14,6 +14,8 @@ use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Exception\InvalidHelperException;
+use Laminas\View\Helper\AbstractHelper;
+use Laminas\View\Helper\HelperInterface;
 use Psr\Container\ContainerInterface;
 
 use function get_class;
@@ -30,7 +32,8 @@ use function sprintf;
  * Helper\HelperInterface. Additionally, it registers a number of default
  * helpers.
  *
- * @template InstanceType of Helper\HelperInterface|callable
+ * @psalm-type ViewHelperType = HelperInterface|AbstractHelper|object
+ * @template InstanceType of ViewHelperType
  * @extends AbstractPluginManager<InstanceType>
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  */
@@ -42,8 +45,8 @@ class HelperPluginManager extends AbstractPluginManager
      * Most of these are present for legacy purposes, as v2 of the service
      * manager normalized names when fetching services.
      *
-     * @psalm-suppress DeprecatedClass
-     * @var array<string, string>
+     * @psalm-suppress DeprecatedClass, NonInvariantDocblockPropertyType
+     * @var non-empty-array<string, class-string>
      */
     protected $aliases = [
         'asset'               => Helper\Asset::class,
@@ -377,9 +380,9 @@ class HelperPluginManager extends AbstractPluginManager
     /**
      * Inject a helper instance with the registered renderer
      *
-     * @param ContainerInterface|Helper\HelperInterface $first helper instance
+     * @param ContainerInterface|HelperInterface $first helper instance
      *     under laminas-servicemanager v2, ContainerInterface under v3.
-     * @param ContainerInterface|Helper\HelperInterface $second
+     * @param ContainerInterface|HelperInterface $second
      *     ContainerInterface under laminas-servicemanager v3, helper instance
      *     under v2. Ignored regardless.
      * @return void
@@ -404,9 +407,9 @@ class HelperPluginManager extends AbstractPluginManager
     /**
      * Inject a helper instance with the registered translator
      *
-     * @param ContainerInterface|Helper\HelperInterface $first helper instance
+     * @param ContainerInterface|HelperInterface $first helper instance
      *     under laminas-servicemanager v2, ContainerInterface under v3.
-     * @param ContainerInterface|Helper\HelperInterface $second
+     * @param ContainerInterface|HelperInterface $second
      *     ContainerInterface under laminas-servicemanager v3, helper instance
      *     under v2. Ignored regardless.
      * @return void
@@ -461,9 +464,9 @@ class HelperPluginManager extends AbstractPluginManager
     /**
      * Inject a helper instance with the registered event manager
      *
-     * @param ContainerInterface|Helper\HelperInterface $first helper instance
+     * @param ContainerInterface|HelperInterface $first helper instance
      *     under laminas-servicemanager v2, ContainerInterface under v3.
-     * @param ContainerInterface|Helper\HelperInterface $second
+     * @param ContainerInterface|HelperInterface $second
      *     ContainerInterface under laminas-servicemanager v3, helper instance
      *     under v2. Ignored regardless.
      * @return void
@@ -513,12 +516,12 @@ class HelperPluginManager extends AbstractPluginManager
      */
     public function validate($instance)
     {
-        if (! is_callable($instance) && ! $instance instanceof Helper\HelperInterface) {
+        if (! is_callable($instance) && ! $instance instanceof HelperInterface) {
             throw new InvalidServiceException(
                 sprintf(
                     '%s can only create instances of %s and/or callables; %s is invalid',
                     static::class,
-                    Helper\HelperInterface::class,
+                    HelperInterface::class,
                     is_object($instance) ? get_class($instance) : gettype($instance)
                 )
             );

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -9,6 +9,7 @@ use Laminas\Filter\FilterChain;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Exception;
 use Laminas\View\Helper\AbstractHelper;
+use Laminas\View\Helper\HelperInterface;
 use Laminas\View\HelperPluginManager;
 use Laminas\View\Model\ModelInterface as Model;
 use Laminas\View\Renderer\RendererInterface as Renderer;
@@ -42,6 +43,8 @@ use function sprintf;
  * Note: all private variables in this class are prefixed with "__". This is to
  * mark them as part of the internal implementation, and thus prevent conflict
  * with variables injected into the renderer.
+ *
+ * @template InstanceType of callable|HelperInterface|AbstractHelper
  *
  * Convenience methods for build in helpers (@see __call):
  *
@@ -378,9 +381,9 @@ class PhpRenderer implements Renderer, TreeRendererInterface
     /**
      * Get plugin instance
      *
-     * @param  string     $name Name of plugin to return
+     * @param  string|class-string<InstanceType> $name Name of plugin to return
      * @param  null|array $options Options to pass to plugin constructor (if not already instantiated)
-     * @return AbstractHelper
+     * @return InstanceType
      */
     public function plugin($name, ?array $options = null)
     {

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -8,8 +8,7 @@ use ArrayAccess;
 use Laminas\Filter\FilterChain;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Exception;
-use Laminas\View\Helper\AbstractHelper;
-use Laminas\View\Helper\HelperInterface;
+use Laminas\View\Helper\ViewModel;
 use Laminas\View\HelperPluginManager;
 use Laminas\View\Model\ModelInterface as Model;
 use Laminas\View\Renderer\RendererInterface as Renderer;
@@ -44,7 +43,7 @@ use function sprintf;
  * mark them as part of the internal implementation, and thus prevent conflict
  * with variables injected into the renderer.
  *
- * @template InstanceType of callable|HelperInterface|AbstractHelper
+ * @psalm-import-type ViewHelperType from HelperPluginManager
  *
  * Convenience methods for build in helpers (@see __call):
  *
@@ -372,18 +371,23 @@ class PhpRenderer implements Renderer, TreeRendererInterface
      */
     public function getHelperPluginManager()
     {
-        if (null === $this->__helpers) {
-            $this->setHelperPluginManager(new HelperPluginManager(new ServiceManager()));
+        $pluginManager = $this->__helpers;
+
+        if (! $pluginManager instanceof HelperPluginManager) {
+            $pluginManager = new HelperPluginManager(new ServiceManager());
+            $this->setHelperPluginManager($pluginManager);
         }
-        return $this->__helpers;
+
+        return $pluginManager;
     }
 
     /**
      * Get plugin instance
      *
-     * @param  string|class-string<InstanceType> $name Name of plugin to return
+     * @template T
+     * @param  string|class-string<T> $name Name of plugin to return
      * @param  null|array $options Options to pass to plugin constructor (if not already instantiated)
-     * @return InstanceType
+     * @return ($name is class-string ? T : ViewHelperType|mixed)
      */
     public function plugin($name, ?array $options = null)
     {
@@ -401,10 +405,11 @@ class PhpRenderer implements Renderer, TreeRendererInterface
      *
      * @param  string $method
      * @param  array $argv
-     * @return mixed
+     * @return mixed|ViewHelperType
      */
     public function __call($method, $argv)
     {
+        /** @psalm-suppress MixedAssignment $plugin */
         $plugin = $this->plugin($method);
 
         if (is_callable($plugin)) {
@@ -477,7 +482,7 @@ class PhpRenderer implements Renderer, TreeRendererInterface
             unset($options);
 
             // Give view model awareness via ViewModel helper
-            $helper = $this->plugin('view_model');
+            $helper = $this->plugin(ViewModel::class);
             $helper->setCurrent($model);
 
             $values = $model->getVariables();

--- a/test/Helper/DeclareVarsTest.php
+++ b/test/Helper/DeclareVarsTest.php
@@ -8,7 +8,6 @@ use Laminas\View\Helper\DeclareVars;
 use Laminas\View\Renderer\PhpRenderer as View;
 use PHPUnit\Framework\TestCase;
 
-use function assert;
 use function str_replace;
 
 use const DIRECTORY_SEPARATOR;
@@ -28,8 +27,7 @@ class DeclareVarsTest extends TestCase
 
     private function declareVars(): void
     {
-        $helper = $this->view->plugin('declareVars');
-        assert($helper instanceof DeclareVars);
+        $helper = $this->view->plugin(DeclareVars::class);
 
         $helper->__invoke(
             'varName1',

--- a/test/Helper/HeadLinkTest.php
+++ b/test/Helper/HeadLinkTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\View\Helper;
 
 use Laminas\View\Exception;
 use Laminas\View\Helper;
+use Laminas\View\Helper\Doctype;
 use Laminas\View\Renderer\PhpRenderer as View;
 use PHPUnit\Framework\TestCase;
 
@@ -331,7 +332,7 @@ class HeadLinkTest extends TestCase
 
     public function testLinkRendersAsPlainHtmlIfDoctypeNotXhtml(): void
     {
-        $this->view->plugin('doctype')->__invoke('HTML4_STRICT');
+        $this->view->plugin(Doctype::class)->__invoke('HTML4_STRICT');
         $this->helper->__invoke(['rel' => 'icon', 'src' => '/foo/bar'])
                      ->__invoke(['rel' => 'foo', 'href' => '/bar/baz']);
         $test = $this->helper->toString();

--- a/test/Helper/HeadMetaTest.php
+++ b/test/Helper/HeadMetaTest.php
@@ -14,7 +14,6 @@ use Laminas\View\Renderer\PhpRenderer as View;
 use PHPUnit\Framework\TestCase;
 
 use function array_shift;
-use function assert;
 use function count;
 use function set_error_handler;
 use function sprintf;
@@ -39,12 +38,11 @@ class HeadMetaTest extends TestCase
     {
         Doctype::unsetDoctypeRegistry();
         $this->view = new View();
-        $doctype    = $this->view->plugin('doctype');
-        assert($doctype instanceof Doctype);
+        $doctype    = $this->view->plugin(Doctype::class);
         $doctype->__invoke('XHTML1_STRICT');
-        $this->helper = new Helper\HeadMeta();
+        $this->helper = new HeadMeta();
         $this->helper->setView($this->view);
-        $this->attributeEscaper = new Helper\EscapeHtmlAttr();
+        $this->attributeEscaper = new EscapeHtmlAttr();
     }
 
     public function handleErrors(int $errno, string $errstr): void
@@ -285,7 +283,7 @@ class HeadMetaTest extends TestCase
 
     public function testStringRepresentationReflectsDoctype(): void
     {
-        $this->view->plugin('doctype')->__invoke('HTML4_STRICT');
+        $this->view->plugin(Doctype::class)->__invoke('HTML4_STRICT');
         $this->helper->__invoke('some content', 'foo');
 
         $test = $this->helper->toString();
@@ -300,26 +298,26 @@ class HeadMetaTest extends TestCase
     public function testSetNameDoesntClobber(): void
     {
         $view = new View();
-        $view->plugin('headMeta')->setName('keywords', 'foo');
-        $view->plugin('headMeta')->appendHttpEquiv('pragma', 'bar');
-        $view->plugin('headMeta')->appendHttpEquiv('Cache-control', 'baz');
-        $view->plugin('headMeta')->setName('keywords', 'bat');
+        $view->plugin(HeadMeta::class)->setName('keywords', 'foo');
+        $view->plugin(HeadMeta::class)->appendHttpEquiv('pragma', 'bar');
+        $view->plugin(HeadMeta::class)->appendHttpEquiv('Cache-control', 'baz');
+        $view->plugin(HeadMeta::class)->setName('keywords', 'bat');
 
         $this->assertEquals(
             '<meta http-equiv="pragma" content="bar" />' . PHP_EOL . '<meta http-equiv="Cache-control" content="baz" />'
             . PHP_EOL . '<meta name="keywords" content="bat" />',
-            $view->plugin('headMeta')->toString()
+            $view->plugin(HeadMeta::class)->toString()
         );
     }
 
     public function testSetNameDoesntClobberPart2(): void
     {
         $view = new View();
-        $view->plugin('headMeta')->setName('keywords', 'foo');
-        $view->plugin('headMeta')->setName('description', 'foo');
-        $view->plugin('headMeta')->appendHttpEquiv('pragma', 'baz');
-        $view->plugin('headMeta')->appendHttpEquiv('Cache-control', 'baz');
-        $view->plugin('headMeta')->setName('keywords', 'bar');
+        $view->plugin(HeadMeta::class)->setName('keywords', 'foo');
+        $view->plugin(HeadMeta::class)->setName('description', 'foo');
+        $view->plugin(HeadMeta::class)->appendHttpEquiv('pragma', 'baz');
+        $view->plugin(HeadMeta::class)->appendHttpEquiv('Cache-control', 'baz');
+        $view->plugin(HeadMeta::class)->setName('keywords', 'bar');
 
         $expected = sprintf(
             '<meta name="description" content="foo" />%1$s'
@@ -329,14 +327,14 @@ class HeadMetaTest extends TestCase
             PHP_EOL
         );
 
-        $this->assertEquals($expected, $view->plugin('headMeta')->toString());
+        $this->assertEquals($expected, $view->plugin(HeadMeta::class)->toString());
     }
 
     public function testPlacesMetaTagsInProperOrder(): void
     {
         $view = new View();
-        $view->plugin('headMeta')->setName('keywords', 'foo');
-        $view->plugin('headMeta')->__invoke(
+        $view->plugin(HeadMeta::class)->setName('keywords', 'foo');
+        $view->plugin(HeadMeta::class)->__invoke(
             'some content',
             'bar',
             'name',
@@ -352,7 +350,7 @@ class HeadMetaTest extends TestCase
             $attributeEscaper('some content'),
             PHP_EOL
         );
-        $this->assertEquals($expected, $view->plugin('headMeta')->toString());
+        $this->assertEquals($expected, $view->plugin(HeadMeta::class)->toString());
     }
 
     public function testContainerMaintainsCorrectOrderOfItems(): void
@@ -378,44 +376,44 @@ class HeadMetaTest extends TestCase
     public function testCharsetValidateFail(): void
     {
         $view = new View();
-        $view->plugin('doctype')->__invoke('HTML4_STRICT');
+        $view->plugin(Doctype::class)->__invoke('HTML4_STRICT');
 
         $this->expectException(Exception\ExceptionInterface::class);
-        $view->plugin('headMeta')->setCharset('utf-8');
+        $view->plugin(HeadMeta::class)->setCharset('utf-8');
     }
 
     public function testCharset(): void
     {
         $view = new View();
-        $view->plugin('doctype')->__invoke('HTML5');
+        $view->plugin(Doctype::class)->__invoke('HTML5');
 
-        $view->plugin('headMeta')->setCharset('utf-8');
+        $view->plugin(HeadMeta::class)->setCharset('utf-8');
         $this->assertEquals(
             '<meta charset="utf-8">',
-            $view->plugin('headMeta')->toString()
+            $view->plugin(HeadMeta::class)->toString()
         );
 
-        $view->plugin('doctype')->__invoke('XHTML5');
+        $view->plugin(Doctype::class)->__invoke('XHTML5');
 
         $this->assertEquals(
             '<meta charset="utf-8"/>',
-            $view->plugin('headMeta')->toString()
+            $view->plugin(HeadMeta::class)->toString()
         );
     }
 
     public function testCharsetPosition(): void
     {
         $view = new View();
-        $view->plugin('doctype')->__invoke('HTML5');
+        $view->plugin(Doctype::class)->__invoke('HTML5');
 
-        $view->plugin('headMeta')
+        $view->plugin(HeadMeta::class)
             ->setProperty('description', 'foobar')
             ->setCharset('utf-8');
 
         $this->assertEquals(
             '<meta charset="utf-8">' . PHP_EOL
             . '<meta property="description" content="foobar">',
-            $view->plugin('headMeta')->toString()
+            $view->plugin(HeadMeta::class)->toString()
         );
     }
 
@@ -425,9 +423,9 @@ class HeadMetaTest extends TestCase
         $this->expectExceptionMessage('XHTML* doctype has no attribute charset; please use appendHttpEquiv()');
 
         $view = new View();
-        $view->plugin('doctype')->__invoke('XHTML1_RDFA');
+        $view->plugin(Doctype::class)->__invoke('XHTML1_RDFA');
 
-        $view->plugin('headMeta')
+        $view->plugin(HeadMeta::class)
              ->setCharset('utf-8');
     }
 

--- a/test/Helper/HeadScriptTest.php
+++ b/test/Helper/HeadScriptTest.php
@@ -8,6 +8,7 @@ use DOMDocument;
 use Generator;
 use Laminas\View;
 use Laminas\View\Helper;
+use Laminas\View\Helper\Doctype;
 use PHPUnit\Framework\TestCase;
 
 use function array_shift;
@@ -480,7 +481,7 @@ document.write(bar.strlen());');
     public function testOmitsTypeAttributeIfEmptyValueAndHtml5Doctype(): void
     {
         $view = new View\Renderer\PhpRenderer();
-        $view->plugin('doctype')->setDoctype(View\Helper\Doctype::HTML5);
+        $view->plugin(Doctype::class)->setDoctype(View\Helper\Doctype::HTML5);
         $this->helper->setView($view);
 
         $this->helper->__invoke()->appendScript('// some script' . PHP_EOL, '');
@@ -502,7 +503,7 @@ document.write(bar.strlen());');
     public function testOmitsTypeAttributeIfNoneGivenAndHtml5Doctype(): void
     {
         $view = new View\Renderer\PhpRenderer();
-        $view->plugin('doctype')->setDoctype(View\Helper\Doctype::HTML5);
+        $view->plugin(Doctype::class)->setDoctype(View\Helper\Doctype::HTML5);
         $this->helper->setView($view);
 
         $this->helper->__invoke()->appendScript('// some script' . PHP_EOL);

--- a/test/Helper/HtmlObjectTest.php
+++ b/test/Helper/HtmlObjectTest.php
@@ -59,7 +59,7 @@ class HtmlObjectTest extends TestCase
 
     public function testMakeHtmlObjectWithoutAttribsWithParamsHtml(): void
     {
-        $this->view->plugin('doctype')->__invoke(Doctype::HTML4_STRICT);
+        $this->view->plugin(Doctype::class)->__invoke(Doctype::HTML4_STRICT);
 
         $params = [
             'paramname1' => 'paramvalue1',
@@ -80,7 +80,7 @@ class HtmlObjectTest extends TestCase
 
     public function testMakeHtmlObjectWithoutAttribsWithParamsXhtml(): void
     {
-        $this->view->plugin('doctype')->__invoke(Doctype::XHTML1_STRICT);
+        $this->view->plugin(Doctype::class)->__invoke(Doctype::XHTML1_STRICT);
 
         $params = [
             'paramname1' => 'paramvalue1',

--- a/test/Helper/HtmlTagTest.php
+++ b/test/Helper/HtmlTagTest.php
@@ -10,7 +10,6 @@ use Laminas\View\Helper\HtmlTag;
 use Laminas\View\Renderer\PhpRenderer as View;
 use PHPUnit\Framework\TestCase;
 
-use function assert;
 use function sprintf;
 
 class HtmlTagTest extends TestCase
@@ -88,8 +87,7 @@ class HtmlTagTest extends TestCase
 
         $this->assertStringStartsWith('<html', $tag);
 
-        $escape = $this->view->plugin('escapehtmlattr');
-        assert($escape instanceof EscapeHtmlAttr);
+        $escape = $this->view->plugin(EscapeHtmlAttr::class);
 
         foreach ($attribs as $name => $value) {
             $this->assertStringContainsString(sprintf('%s="%s"', $name, $escape($value)), $tag);
@@ -109,8 +107,7 @@ class HtmlTagTest extends TestCase
 
     public function testAppropriateNamespaceAttributesAreSetIfFlagIsOn(): void
     {
-        $doctype = $this->view->plugin('doctype');
-        assert($doctype instanceof Doctype);
+        $doctype = $this->view->plugin(Doctype::class);
         $doctype->setDoctype('xhtml');
 
         $attribs = [
@@ -121,8 +118,7 @@ class HtmlTagTest extends TestCase
 
         $tag = $this->helper->openTag();
 
-        $escape = $this->view->plugin('escapehtmlattr');
-        assert($escape instanceof EscapeHtmlAttr);
+        $escape = $this->view->plugin(EscapeHtmlAttr::class);
 
         $this->assertStringContainsString(sprintf('%s="%s"', 'xmlns', $escape('http://www.w3.org/1999/xhtml')), $tag);
         foreach ($attribs as $name => $value) {

--- a/test/Helper/LayoutTest.php
+++ b/test/Helper/LayoutTest.php
@@ -11,8 +11,6 @@ use Laminas\View\Model\ViewModel;
 use Laminas\View\Renderer\PhpRenderer;
 use PHPUnit\Framework\TestCase;
 
-use function assert;
-
 class LayoutTest extends TestCase
 {
     private Layout $helper;
@@ -25,10 +23,8 @@ class LayoutTest extends TestCase
     protected function setUp(): void
     {
         $renderer        = new PhpRenderer();
-        $viewModelHelper = $renderer->plugin('view_model');
-        assert($viewModelHelper instanceof ViewModelHelper);
-        $helper = $renderer->plugin('layout');
-        assert($helper instanceof Layout);
+        $viewModelHelper = $renderer->plugin(ViewModelHelper::class);
+        $helper          = $renderer->plugin(Layout::class);
 
         $this->helper = $helper;
         $this->parent = new ViewModel();
@@ -64,8 +60,8 @@ class LayoutTest extends TestCase
     public function testRaisesExceptionIfViewModelHelperHasNoRoot(): void
     {
         $renderer = new PhpRenderer();
-        $renderer->plugin('view_model');
-        $helper = $renderer->plugin('layout');
+        $renderer->plugin(ViewModelHelper::class);
+        $helper = $renderer->plugin(Layout::class);
 
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('view model');

--- a/test/Helper/Navigation/LinksTest.php
+++ b/test/Helper/Navigation/LinksTest.php
@@ -13,6 +13,7 @@ use Laminas\Permissions\Acl\Role;
 use Laminas\View;
 use Laminas\View\Helper\Doctype;
 use Laminas\View\Helper\Navigation;
+use Laminas\View\Renderer\PhpRenderer;
 use RecursiveIteratorIterator;
 
 use function assert;
@@ -44,8 +45,9 @@ class LinksTest extends AbstractTest
         parent::setUp();
 
         // doctype fix (someone forgot to clean up after their unit tests)
-        $helper = $this->_helper->getView()->plugin('doctype');
-        assert($helper instanceof Doctype);
+        $renderer = $this->_helper->getView();
+        assert($renderer instanceof PhpRenderer);
+        $helper              = $renderer->plugin(Doctype::class);
         $this->doctypeHelper = $helper;
         $this->oldDoctype    = $helper->getDoctype();
         $this->doctypeHelper->setDoctype(

--- a/test/Helper/Navigation/NavigationTest.php
+++ b/test/Helper/Navigation/NavigationTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Helper\Navigation;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\I18n\Translator\Translator;
 use Laminas\Navigation\Navigation as Container;
 use Laminas\Navigation\Page;

--- a/test/Helper/Navigation/SitemapTest.php
+++ b/test/Helper/Navigation/SitemapTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\View\Helper\Navigation;
 
 use DOMDocument;
 use Laminas\View;
+use Laminas\View\Helper\BasePath;
 use Laminas\View\Helper\Navigation\Sitemap;
 use Throwable; // phpcs:ignore
 
@@ -59,7 +60,7 @@ class SitemapTest extends AbstractTest
         parent::setUp();
 
         $this->_helper->setFormatOutput(true);
-        $this->_helper->getView()->plugin('basepath')->setBasePath('');
+        $this->_helper->getView()->plugin(BasePath::class)->setBasePath('');
     }
 
     protected function tearDown(): void

--- a/test/Helper/RenderChildModelTest.php
+++ b/test/Helper/RenderChildModelTest.php
@@ -12,8 +12,6 @@ use Laminas\View\Renderer\PhpRenderer;
 use Laminas\View\Resolver\TemplateMapResolver;
 use PHPUnit\Framework\TestCase;
 
-use function assert;
-
 class RenderChildModelTest extends TestCase
 {
     private TemplateMapResolver $resolver;
@@ -34,12 +32,10 @@ class RenderChildModelTest extends TestCase
         $renderer->setCanRenderTrees(true);
         $renderer->setResolver($this->resolver);
 
-        $helper = $renderer->plugin('view_model');
-        assert($helper instanceof ViewModelHelper);
+        $helper                = $renderer->plugin(ViewModelHelper::class);
         $this->viewModelHelper = $helper;
 
-        $helper = $renderer->plugin('render_child_model');
-        assert($helper instanceof RenderChildModel);
+        $helper       = $renderer->plugin(RenderChildModel::class);
         $this->helper = $helper;
 
         $this->parent = new ViewModel();

--- a/test/Helper/RenderToPlaceholderTest.php
+++ b/test/Helper/RenderToPlaceholderTest.php
@@ -24,16 +24,14 @@ class RenderToPlaceholderTest extends TestCase
         assert($resolver instanceof TemplatePathStack);
         $resolver->addPath(__DIR__ . '/_files/scripts/');
 
-        $helper = $this->view->plugin('renderToPlaceholder');
-        assert($helper instanceof RenderToPlaceholder);
+        $helper       = $this->view->plugin(RenderToPlaceholder::class);
         $this->helper = $helper;
     }
 
     public function testDefaultEmpty(): void
     {
         $this->helper->__invoke('rendertoplaceholderscript.phtml', 'fooPlaceholder');
-        $placeholder = $this->view->plugin('placeholder');
-        assert($placeholder instanceof Placeholder);
+        $placeholder = $this->view->plugin(Placeholder::class);
         $this->assertEquals("Foo Bar\n", $placeholder->__invoke('fooPlaceholder')->getValue());
     }
 }

--- a/test/HelperPluginManagerCompatibilityTest.php
+++ b/test/HelperPluginManagerCompatibilityTest.php
@@ -86,24 +86,4 @@ class HelperPluginManagerCompatibilityTest extends TestCase
     {
         $this->markTestSkipped('instanceOf is not used with this implementation');
     }
-
-    /**
-     * @todo remove this test once we set the minimum laminas-servicemanager version to 3
-     */
-    public function testRegisteringInvalidElementRaisesException(): void
-    {
-        $this->expectException($this->getServiceNotFoundException());
-        $this->getPluginManager()->setService('test', $this);
-    }
-
-    /**
-     * @todo remove this test once we set the minimum laminas-servicemanager version to 3
-     */
-    public function testLoadingInvalidElementRaisesException(): void
-    {
-        $manager = $this->getPluginManager();
-        $manager->setInvokableClass('test', static::class);
-        $this->expectException($this->getServiceNotFoundException());
-        $manager->get('test');
-    }
 }

--- a/test/HelperPluginManagerTest.php
+++ b/test/HelperPluginManagerTest.php
@@ -47,13 +47,13 @@ class HelperPluginManagerTest extends TestCase
     {
         $renderer = new PhpRenderer();
         $this->helpers->setRenderer($renderer);
-        $helper = $this->helpers->get('doctype');
+        $helper = $this->helpers->get(Doctype::class);
         $this->assertSame($renderer, $helper->getView());
     }
 
     public function testNoRendererInjectedInHelperWhenRendererIsNotPresent(): void
     {
-        $helper = $this->helpers->get('doctype');
+        $helper = $this->helpers->get(Doctype::class);
         $this->assertNull($helper->getView());
     }
 
@@ -98,7 +98,7 @@ class HelperPluginManagerTest extends TestCase
         $services   = new ServiceManager();
         $config->configureServiceManager($services);
         $helpers = new HelperPluginManager($services);
-        $helper  = $helpers->get('HeadTitle');
+        $helper  = $helpers->get(HeadTitle::class);
         $this->assertSame($translator, $helper->getTranslator());
     }
 
@@ -115,7 +115,7 @@ class HelperPluginManagerTest extends TestCase
         $services   = new ServiceManager();
         $config->configureServiceManager($services);
         $helpers = new HelperPluginManager($services);
-        $helper  = $helpers->get('HeadTitle');
+        $helper  = $helpers->get(HeadTitle::class);
         $this->assertSame($translator, $helper->getTranslator());
     }
 
@@ -132,7 +132,7 @@ class HelperPluginManagerTest extends TestCase
         $services   = new ServiceManager();
         $config->configureServiceManager($services);
         $helpers = new HelperPluginManager($services);
-        $helper  = $helpers->get('HeadTitle');
+        $helper  = $helpers->get(HeadTitle::class);
         $this->assertSame($translator, $helper->getTranslator());
     }
 
@@ -172,7 +172,7 @@ class HelperPluginManagerTest extends TestCase
             ]
         );
         $config->configureServiceManager($helpers);
-        $this->assertSame($helper, $helpers->get('url'));
+        $this->assertSame($helper, $helpers->get(Url::class));
     }
 
     public function testCanUseCallableAsHelper(): void

--- a/test/PhpRendererTest.php
+++ b/test/PhpRendererTest.php
@@ -13,6 +13,7 @@ use Laminas\View\Exception\ExceptionInterface;
 use Laminas\View\Exception\RuntimeException;
 use Laminas\View\Exception\UnexpectedValueException;
 use Laminas\View\Helper\Doctype;
+use Laminas\View\Helper\ViewModel as ViewModelHelper;
 use Laminas\View\HelperPluginManager;
 use Laminas\View\Model\ViewModel;
 use Laminas\View\Renderer\PhpRenderer;
@@ -323,7 +324,7 @@ class PhpRendererTest extends TestCase
         $model->setTemplate('empty');
 
         $this->renderer->render($model);
-        $helper = $this->renderer->plugin('view_model');
+        $helper = $this->renderer->plugin(ViewModelHelper::class);
         $this->assertTrue($helper->hasCurrent());
         $this->assertSame($model, $helper->getCurrent());
     }

--- a/test/Resolver/RelativeFallbackResolverTest.php
+++ b/test/Resolver/RelativeFallbackResolverTest.php
@@ -31,8 +31,7 @@ class RelativeFallbackResolverTest extends TestCase
         $renderer       = new PhpRenderer();
         $view           = new ViewModel();
         $view->setTemplate('foo/zaz');
-        $helper = $renderer->plugin('view_model');
-        /** @var ViewModelHelper $helper */
+        $helper = $renderer->plugin(ViewModelHelper::class);
         $helper->setCurrent($view);
 
         $test = $resolver->resolve('bar', $renderer);
@@ -47,8 +46,7 @@ class RelativeFallbackResolverTest extends TestCase
         $renderer = new PhpRenderer();
         $view     = new ViewModel();
         $view->setTemplate('name-space/any-view');
-        /** @var ViewModelHelper $helper */
-        $helper = $renderer->plugin('view_model');
+        $helper = $renderer->plugin(ViewModelHelper::class);
         $helper->setCurrent($view);
 
         $test = $resolver->resolve('bar', $renderer);
@@ -67,8 +65,7 @@ class RelativeFallbackResolverTest extends TestCase
         $renderer = new PhpRenderer();
         $view     = new ViewModel();
         $view->setTemplate('foo/zaz');
-        $helper = $renderer->plugin('view_model');
-        /** @var ViewModelHelper $helper */
+        $helper = $renderer->plugin(ViewModelHelper::class);
         $helper->setCurrent($view);
 
         $test = $resolver->resolve('bar', $renderer);

--- a/test/ViewTest.php
+++ b/test/ViewTest.php
@@ -294,9 +294,9 @@ class ViewTest extends TestCase
     public function testCanTriggerPostRendererEvent(): void
     {
         $this->attachTestStrategies();
-        $test = (object) ['flag' => false];
-        $this->view->getEventManager()->attach(ViewEvent::EVENT_RENDERER_POST, function ($e) use ($test) {
-            $test->flag = true;
+        $flag = false;
+        $this->view->getEventManager()->attach(ViewEvent::EVENT_RENDERER_POST, function () use (&$flag) {
+            $flag = true;
         });
         $variables = [
             'foo' => 'bar',
@@ -304,7 +304,7 @@ class ViewTest extends TestCase
         ];
         $this->model->setVariables($variables);
         $this->view->render($this->model);
-        $this->assertTrue($test->flag);
+        $this->assertTrue($flag);
     }
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

General type inference improvements

There's a couple of outstanding psalm issues that I think should probably be baselined.

- HeadLink - psalm now complains about stdClass, which can be annotated as object for the most part, but HeadLink has parameter types explicitly set to `stdClass`
- Psalm is moaning about the plugin managers with `MethodSignatureMismatch` for `Method Laminas\ServiceManager\ServiceManager::has with return type '' is different to return type 'bool'` - This is really weird because bool is the return type all the way up the inheritance chain 🤷‍♂️
- Navigation is looking for non-existent classes - should probably sort that out separately
