### PR TITLE
Correct plugin manager type annotations

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1594,7 +1594,7 @@
       <code>$container</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
-      <code>($name is class-string ? T : callable)</code>
+      <code>($name is class-string ? T : HelperInterface|callable)</code>
     </MixedInferredReturnType>
     <MixedMethodCall occurrences="8">
       <code>get</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1593,6 +1593,9 @@
       <code>$container</code>
       <code>$container</code>
     </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>($name is class-string ? T : callable)</code>
+    </MixedInferredReturnType>
     <MixedMethodCall occurrences="8">
       <code>get</code>
       <code>get</code>
@@ -1603,6 +1606,9 @@
       <code>has</code>
       <code>has</code>
     </MixedMethodCall>
+    <MixedReturnStatement occurrences="1">
+      <code>parent::get($name, $options)</code>
+    </MixedReturnStatement>
     <PropertyTypeCoercion occurrences="1">
       <code>$this-&gt;initializers</code>
     </PropertyTypeCoercion>
@@ -1845,10 +1851,9 @@
       <code>getArrayCopy</code>
       <code>new $helpers(new ServiceManager())</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="3">
+    <MixedReturnStatement occurrences="2">
       <code>$this-&gt;__filterChain-&gt;filter($this-&gt;__content)</code>
       <code>$this-&gt;__templateResolver-&gt;resolve($name, $this)</code>
-      <code>$this-&gt;getHelperPluginManager()-&gt;get($name, $options)</code>
     </MixedReturnStatement>
     <NullableReturnStatement occurrences="1">
       <code>$this-&gt;__templateResolver</code>
@@ -3246,17 +3251,6 @@
       <code>$container</code>
       <code>$container</code>
     </MissingClosureParamType>
-    <MixedAssignment occurrences="1">
-      <code>$helperB</code>
-    </MixedAssignment>
-    <MixedMethodCall occurrences="6">
-      <code>getTranslator</code>
-      <code>getTranslator</code>
-      <code>getTranslator</code>
-      <code>getTranslator</code>
-      <code>getView</code>
-      <code>getView</code>
-    </MixedMethodCall>
     <UnusedClosureParam occurrences="2">
       <code>$container</code>
       <code>$container</code>

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -554,7 +554,7 @@ class HelperPluginManager extends AbstractPluginManager
      * @param class-string<T>|string $name Service name of plugin to retrieve.
      * @param null|array<mixed> $options Options to use when creating the instance.
      * @return HelperInterface|callable
-     * @psalm-return ($name is class-string ? T : callable)
+     * @psalm-return ($name is class-string ? T : HelperInterface|callable)
      */
     public function get($name, ?array $options = null)
     {

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -14,7 +14,6 @@ use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Exception\InvalidHelperException;
-use Laminas\View\Helper\AbstractHelper;
 use Laminas\View\Helper\HelperInterface;
 use Psr\Container\ContainerInterface;
 
@@ -32,7 +31,7 @@ use function sprintf;
  * Helper\HelperInterface. Additionally, it registers a number of default
  * helpers.
  *
- * @psalm-type ViewHelperType = HelperInterface|AbstractHelper|object
+ * @psalm-type ViewHelperType = HelperInterface|callable
  * @template InstanceType of ViewHelperType
  * @extends AbstractPluginManager<InstanceType>
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
@@ -512,7 +511,7 @@ class HelperPluginManager extends AbstractPluginManager
      *
      * @param mixed $instance
      * @throws InvalidServiceException
-     * @psalm-assert InstanceType $instance
+     * @psalm-assert HelperInterface|callable $instance
      */
     public function validate($instance)
     {
@@ -539,7 +538,7 @@ class HelperPluginManager extends AbstractPluginManager
      * @param mixed $instance
      * @return void
      * @throws InvalidHelperException
-     * @psalm-assert InstanceType $instance
+     * @psalm-assert HelperInterface|callable $instance
      */
     public function validatePlugin($instance)
     {
@@ -548,5 +547,18 @@ class HelperPluginManager extends AbstractPluginManager
         } catch (InvalidServiceException $e) {
             throw new InvalidHelperException($e->getMessage(), $e->getCode(), $e);
         }
+    }
+
+    /**
+     * @inheritDoc
+     * @template T
+     * @param class-string<T>|string $name Service name of plugin to retrieve.
+     * @param null|array<mixed> $options Options to use when creating the instance.
+     * @return HelperInterface|callable
+     * @psalm-return ($name is class-string ? T : callable)
+     */
+    public function get($name, ?array $options = null)
+    {
+        return parent::get($name, $options);
     }
 }

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -31,9 +31,8 @@ use function sprintf;
  * Helper\HelperInterface. Additionally, it registers a number of default
  * helpers.
  *
- * @psalm-type ViewHelperType = HelperInterface|callable
- * @template InstanceType of ViewHelperType
- * @extends AbstractPluginManager<InstanceType>
+ * @template InstanceType of HelperInterface|callable
+ * @extends AbstractPluginManager<HelperInterface|callable>
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  */
 class HelperPluginManager extends AbstractPluginManager

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -8,6 +8,7 @@ use ArrayAccess;
 use Laminas\Filter\FilterChain;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Exception;
+use Laminas\View\Helper\HelperInterface;
 use Laminas\View\Helper\ViewModel;
 use Laminas\View\HelperPluginManager;
 use Laminas\View\Model\ModelInterface as Model;
@@ -42,8 +43,6 @@ use function sprintf;
  * Note: all private variables in this class are prefixed with "__". This is to
  * mark them as part of the internal implementation, and thus prevent conflict
  * with variables injected into the renderer.
- *
- * @psalm-import-type ViewHelperType from HelperPluginManager
  *
  * Convenience methods for build in helpers (@see __call):
  *
@@ -387,7 +386,7 @@ class PhpRenderer implements Renderer, TreeRendererInterface
      * @template T
      * @param  string|class-string<T> $name Name of plugin to return
      * @param  null|array $options Options to pass to plugin constructor (if not already instantiated)
-     * @return ($name is class-string ? T : ViewHelperType|mixed)
+     * @return ($name is class-string ? T : HelperInterface|callable)
      */
     public function plugin($name, ?array $options = null)
     {
@@ -405,7 +404,7 @@ class PhpRenderer implements Renderer, TreeRendererInterface
      *
      * @param  string $method
      * @param  array $argv
-     * @return mixed|ViewHelperType
+     * @return HelperInterface|callable|mixed
      */
     public function __call($method, $argv)
     {

--- a/test/HelperPluginManagerTest.php
+++ b/test/HelperPluginManagerTest.php
@@ -157,6 +157,7 @@ class HelperPluginManagerTest extends TestCase
             }
         );
         $helperB = $helpers->get('TestHelper');
+        self::assertInstanceOf(HeadTitle::class, $helperB);
         $this->assertSame($translatorA, $helperB->getTranslator());
     }
 

--- a/test/StaticAnalysis/PluginRetrieval.php
+++ b/test/StaticAnalysis/PluginRetrieval.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\View\StaticAnalysis;
+
+use Laminas\View\Helper\GravatarImage;
+use Laminas\View\Helper\Layout;
+use Laminas\View\HelperPluginManager;
+
+final class PluginRetrieval
+{
+    private HelperPluginManager $pluginManager;
+
+    public function __construct(HelperPluginManager $pluginManager)
+    {
+        $this->pluginManager = $pluginManager;
+    }
+
+    /** @param non-empty-string $email */
+    public function retrieveHelperByClassName(string $email): string
+    {
+        return ($this->pluginManager->get(GravatarImage::class))($email);
+    }
+
+    public function retrievalByAliasAssumesCallable(): void
+    {
+        $helper = $this->pluginManager->get('something');
+        $helper();
+    }
+
+    public function retrievalByClassNameInfersKnownMethods(): string
+    {
+        $helper = $this->pluginManager->get(Layout::class);
+
+        return $helper->getLayout();
+    }
+}

--- a/test/StaticAnalysis/PluginRetrieval.php
+++ b/test/StaticAnalysis/PluginRetrieval.php
@@ -23,12 +23,6 @@ final class PluginRetrieval
         return ($this->pluginManager->get(GravatarImage::class))($email);
     }
 
-    public function retrievalByAliasAssumesCallable(): void
-    {
-        $helper = $this->pluginManager->get('something');
-        $helper();
-    }
-
     public function retrievalByClassNameInfersKnownMethods(): string
     {
         $helper = $this->pluginManager->get(Layout::class);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Corrects the type annotation for the Helper Plugin Manager.

The plugin manager accepts and returns either implementations of HelperInterface or a callable - the previous types were incorrect.

2 psalm issues are baselined for `HelperPluginManager::get()`, `MixedInferredReturnType` and `MixedReturnStatement` because psalm cannot guarantee that get() does not return mixed as defined by AbstractPluginManager when given an arbitrary string.