### PR TITLE
Removes asserting an implementation from the Layout helper

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -712,9 +712,15 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/Layout.php">
+    <PossiblyNullReference occurrences="1">
+      <code>plugin</code>
+    </PossiblyNullReference>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $template</code>
     </RedundantCastGivenDocblockType>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>plugin</code>
+    </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/Navigation.php">
     <InvalidFunctionCall occurrences="1">

--- a/src/Helper/Layout.php
+++ b/src/Helper/Layout.php
@@ -100,7 +100,7 @@ class Layout extends AbstractHelper
     {
         if (! $this->viewModelHelper) {
             /**
-             * @psalm-suppress DeprecatedMethod
+             * @psalm-suppress PossiblyNullReference, UndefinedInterfaceMethod
              */
             $helper = $this->getView()->plugin('view_model');
             assert($helper instanceof ViewModel);

--- a/src/Helper/Layout.php
+++ b/src/Helper/Layout.php
@@ -99,9 +99,10 @@ class Layout extends AbstractHelper
     {
         if (! $this->viewModelHelper) {
             /**
-             * @psalm-suppress PossiblyNullReference, UndefinedInterfaceMethod
+             * @psalm-suppress DeprecatedMethod
              */
-            $helper = $this->getView()->plugin('view_model');
+            $renderer = $this->getView();
+            $helper = $renderer->plugin('view_model');
             assert($helper instanceof ViewModel);
             $this->viewModelHelper = $helper;
         }

--- a/src/Helper/Layout.php
+++ b/src/Helper/Layout.php
@@ -99,7 +99,7 @@ class Layout extends AbstractHelper
     {
         if (! $this->viewModelHelper) {
             $renderer = $this->getView();
-            $helper = $renderer->plugin('view_model');
+            $helper   = $renderer->plugin('view_model');
             assert($helper instanceof ViewModel);
             $this->viewModelHelper = $helper;
         }

--- a/src/Helper/Layout.php
+++ b/src/Helper/Layout.php
@@ -102,9 +102,7 @@ class Layout extends AbstractHelper
             /**
              * @psalm-suppress DeprecatedMethod
              */
-            $renderer = $this->getView();
-            assert($renderer instanceof PhpRenderer);
-            $helper = $renderer->plugin('view_model');
+            $helper = $this->getView()->plugin('view_model');
             assert($helper instanceof ViewModel);
             $this->viewModelHelper = $helper;
         }

--- a/src/Helper/Layout.php
+++ b/src/Helper/Layout.php
@@ -6,7 +6,6 @@ namespace Laminas\View\Helper;
 
 use Laminas\View\Exception;
 use Laminas\View\Model\ModelInterface as Model;
-use Laminas\View\Renderer\PhpRenderer;
 
 use function assert;
 use function sprintf;

--- a/src/Helper/Layout.php
+++ b/src/Helper/Layout.php
@@ -6,6 +6,7 @@ namespace Laminas\View\Helper;
 
 use Laminas\View\Exception;
 use Laminas\View\Model\ModelInterface as Model;
+use Laminas\View\Renderer\PhpRenderer;
 
 use function assert;
 use function sprintf;
@@ -98,9 +99,6 @@ class Layout extends AbstractHelper
     protected function getViewModelHelper()
     {
         if (! $this->viewModelHelper) {
-            /**
-             * @psalm-suppress DeprecatedMethod
-             */
             $renderer = $this->getView();
             $helper = $renderer->plugin('view_model');
             assert($helper instanceof ViewModel);


### PR DESCRIPTION
### Feature Request


|    Q        |   A
|------------ | ------
| New Feature | no
| RFC         | no
| BC Break    | somewhat

Fixes #172 

#### Summary

An assertion was added to Layout::getViewModelHelper() which prohibits OSS implementations of RendererInterface in the wild, for example, Twig's [TwigRenderer](https://github.com/kokspflanze/ZfcTwig/blob/master/src/View/TwigRenderer.php).

    protected function getViewModelHelper()
    {
        if (! $this->viewModelHelper) {
            /**
             * @psalm-suppress DeprecatedMethod
             */
            $renderer = $this->getView();
            assert($renderer instanceof PhpRenderer); // offending assertion
            $helper = $renderer->plugin('view_model');
            assert($helper instanceof ViewModel);
            $this->viewModelHelper = $helper;
        }

        return $this->viewModelHelper;
    }
