### PR TITLE
Updates workflow file for docs build to use `DEPLOY_TOKEN` instead of wrong `DOCS_TOKEN`

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -12,5 +12,4 @@ jobs:
       - name: Build Docs
         uses: laminas/documentation-theme/github-actions/docs@master
         env:
-          DOCS_TOKEN: ${{ secrets.ORGANIZATION_ADMIN_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`DOCS_TOKEN` was never used.

Reference: https://github.com/laminas/documentation-theme/tree/master/github-actions/docs#environment