### PR TITLE
Fix psalm issues due to improved upstream types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "laminas/laminas-authentication": "^2.13",
-        "laminas/laminas-coding-standard": "~2.4.0",
+        "laminas/laminas-coding-standard": "~2.5.0",
         "laminas/laminas-console": "^2.8",
         "laminas/laminas-feed": "^2.19",
         "laminas/laminas-filter": "^2.28.1",
@@ -55,7 +55,7 @@
         "laminas/laminas-uri": "^2.10",
         "phpunit/phpunit": "^9.5.26",
         "psalm/plugin-phpunit": "^0.18.3",
-        "vimeo/psalm": "^5.0"
+        "vimeo/psalm": "^5.4"
     },
     "conflict": {
         "container-interop/container-interop": "<1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d582176751ecf6bb9e85da7a095d25a",
+    "content-hash": "7a6c32d337e10e181f41f9f79a766818",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -70,16 +70,16 @@
         },
         {
             "name": "laminas/laminas-eventmanager",
-            "version": "3.6.0",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-eventmanager.git",
-                "reference": "3f1afbad86cd34a431fdc069f265cfe6f8fc8308"
+                "reference": "5a5114ab2d3fa4424faa46a2fb0a4e49a61f6eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/3f1afbad86cd34a431fdc069f265cfe6f8fc8308",
-                "reference": "3f1afbad86cd34a431fdc069f265cfe6f8fc8308",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/5a5114ab2d3fa4424faa46a2fb0a4e49a61f6eba",
+                "reference": "5a5114ab2d3fa4424faa46a2fb0a4e49a61f6eba",
                 "shasum": ""
             },
             "require": {
@@ -90,13 +90,13 @@
                 "zendframework/zend-eventmanager": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
                 "laminas/laminas-stdlib": "^3.15",
-                "phpbench/phpbench": "^1.2.6",
-                "phpunit/phpunit": "^9.5.25",
-                "psalm/plugin-phpunit": "^0.17.0",
+                "phpbench/phpbench": "^1.2.7",
+                "phpunit/phpunit": "^9.5.26",
+                "psalm/plugin-phpunit": "^0.18.0",
                 "psr/container": "^1.1.2 || ^2.0.2",
-                "vimeo/psalm": "^4.28"
+                "vimeo/psalm": "^5.0.0"
             },
             "suggest": {
                 "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature",
@@ -134,7 +134,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-11T12:46:13+00:00"
+            "time": "2023-01-11T19:52:45+00:00"
         },
         {
             "name": "laminas/laminas-json",
@@ -199,16 +199,16 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.19.0",
+            "version": "3.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "ed160729bb8721127efdaac799f9a298963345b1"
+                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/ed160729bb8721127efdaac799f9a298963345b1",
-                "reference": "ed160729bb8721127efdaac799f9a298963345b1",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
+                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
                 "shasum": ""
             },
             "require": {
@@ -231,14 +231,14 @@
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.11.99.5",
                 "laminas/laminas-coding-standard": "~2.4.0",
-                "laminas/laminas-container-config-test": "^0.7",
+                "laminas/laminas-container-config-test": "^0.8",
                 "laminas/laminas-dependency-plugin": "^2.2",
                 "mikey179/vfsstream": "^1.6.11@alpha",
                 "ocramius/proxy-manager": "^2.14.1",
-                "phpbench/phpbench": "^1.2.6",
-                "phpunit/phpunit": "^9.5.25",
-                "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.28"
+                "phpbench/phpbench": "^1.2.7",
+                "phpunit/phpunit": "^9.5.26",
+                "psalm/plugin-phpunit": "^0.18.0",
+                "vimeo/psalm": "^5.0.0"
             },
             "suggest": {
                 "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
@@ -285,7 +285,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-10T20:59:22+00:00"
+            "time": "2022-12-01T17:03:38+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -1186,6 +1186,67 @@
             "time": "2022-03-02T22:36:06+00:00"
         },
         {
+            "name": "fidry/cpu-core-counter",
+            "version": "0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/79261cc280aded96d098e1b0e0ba0c4881b432c2",
+                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^1.9.2",
+                "phpstan/phpstan-deprecation-rules": "^1.0.0",
+                "phpstan/phpstan-phpunit": "^1.2.2",
+                "phpstan/phpstan-strict-rules": "^1.4.4",
+                "phpunit/phpunit": "^9.5.26 || ^8.5.31",
+                "theofidry/php-cs-fixer-config": "^1.0",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-16T22:01:02+00:00"
+        },
+        {
             "name": "laminas/laminas-authentication",
             "version": "2.13.0",
             "source": {
@@ -1263,20 +1324,20 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "eb076dd86aa93dd424856b150c9b6f76c1fdfabc"
+                "reference": "c1aaa18a7c860c6932677a3e4ec13161f9fc7d61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/eb076dd86aa93dd424856b150c9b6f76c1fdfabc",
-                "reference": "eb076dd86aa93dd424856b150c9b6f76c1fdfabc",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/c1aaa18a7c860c6932677a3e4ec13161f9fc7d61",
+                "reference": "c1aaa18a7c860c6932677a3e4ec13161f9fc7d61",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
                 "php": "^7.4 || ^8.0",
                 "slevomat/coding-standard": "^7.0",
                 "squizlabs/php_codesniffer": "^3.6",
@@ -1315,7 +1376,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-08-24T17:45:47+00:00"
+            "time": "2023-01-05T15:53:40+00:00"
         },
         {
             "name": "laminas/laminas-config",
@@ -2863,59 +2924,6 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.2"
             },
             "time": "2022-11-12T15:38:23+00:00"
-        },
-        {
-            "name": "openlss/lib-array2xml",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nullivex/lib-array2xml.git",
-                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
-                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "LSS": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Bryan Tong",
-                    "email": "bryan@nullivex.com",
-                    "homepage": "https://www.nullivex.com"
-                },
-                {
-                    "name": "Tony Butler",
-                    "email": "spudz76@gmail.com",
-                    "homepage": "https://www.nullivex.com"
-                }
-            ],
-            "description": "Array2XML conversion library credit to lalit.org",
-            "homepage": "https://www.nullivex.com",
-            "keywords": [
-                "array",
-                "array conversion",
-                "xml",
-                "xml conversion"
-            ],
-            "support": {
-                "issues": "https://github.com/nullivex/lib-array2xml/issues",
-                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
-            },
-            "time": "2019-03-29T20:06:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -4846,6 +4854,70 @@
             "time": "2022-05-25T10:58:12+00:00"
         },
         {
+            "name": "spatie/array-to-xml",
+            "version": "2.17.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/array-to-xml.git",
+                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
+                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.2",
+                "pestphp/pest": "^1.21",
+                "phpunit/phpunit": "^9.0",
+                "spatie/pest-plugin-snapshots": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ArrayToXml\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://freek.dev",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Convert an array to xml",
+            "homepage": "https://github.com/spatie/array-to-xml",
+            "keywords": [
+                "array",
+                "convert",
+                "xml"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/array-to-xml/tree/2.17.1"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-26T08:22:07+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.7.1",
             "source": {
@@ -5761,16 +5833,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.0.0",
+            "version": "5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "4e177bf0c9f03c17d2fbfd83b7cc9c47605274d8"
+                "reference": "62db5d4f6a7ae0a20f7cc5a4952d730272fc0863"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/4e177bf0c9f03c17d2fbfd83b7cc9c47605274d8",
-                "reference": "4e177bf0c9f03c17d2fbfd83b7cc9c47605274d8",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/62db5d4f6a7ae0a20f7cc5a4952d730272fc0863",
+                "reference": "62db5d4f6a7ae0a20f7cc5a4952d730272fc0863",
                 "shasum": ""
             },
             "require": {
@@ -5789,11 +5861,12 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.2",
+                "fidry/cpu-core-counter": "^0.4.0",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
                 "nikic/php-parser": "^4.13",
-                "openlss/lib-array2xml": "^1.0",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
                 "sebastian/diff": "^4.0",
+                "spatie/array-to-xml": "^2.17.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
                 "symfony/filesystem": "^5.4 || ^6.0",
                 "symfony/polyfill-php80": "^1.25"
@@ -5859,9 +5932,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.0.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.4.0"
             },
-            "time": "2022-11-30T06:06:01+00:00"
+            "time": "2022-12-19T21:31:12+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.0.0@4e177bf0c9f03c17d2fbfd83b7cc9c47605274d8">
+<files psalm-version="5.4.0@62db5d4f6a7ae0a20f7cc5a4952d730272fc0863">
   <file src="bin/templatemap_generator.php">
     <MissingParamType occurrences="1">
       <code>$templatePath</code>
@@ -378,14 +378,6 @@
       <code>$index</code>
       <code>$index</code>
     </ParamNameMismatch>
-    <PossiblyInvalidArgument occurrences="2">
-      <code>$args[0]</code>
-      <code>$args[1]</code>
-    </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="2">
-      <code>$args[0]</code>
-      <code>$args[1]</code>
-    </PossiblyInvalidCast>
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;view</code>
     </PossiblyNullArgument>
@@ -736,9 +728,10 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/Navigation/AbstractHelper.php">
-    <DocblockTypeContradiction occurrences="3">
+    <DocblockTypeContradiction occurrences="4">
       <code>! is_int($this-&gt;minDepth)</code>
       <code>! is_string($message)</code>
+      <code>$container instanceof AbstractContainer</code>
       <code>null === $this-&gt;container</code>
     </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch occurrences="2">
@@ -794,12 +787,6 @@
     <PossiblyFalseArgument occurrences="1">
       <code>strrpos($prefix, '\\')</code>
     </PossiblyFalseArgument>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$container</code>
-    </PossiblyInvalidArgument>
-    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
-      <code>$container</code>
-    </PossiblyInvalidPropertyAssignmentValue>
     <PossiblyNullArgument occurrences="1">
       <code>$page-&gt;getTitle()</code>
     </PossiblyNullArgument>
@@ -825,6 +812,9 @@
       <code>null !== $this-&gt;container</code>
       <code>static::$defaultAcl !== null</code>
     </RedundantConditionGivenDocblockType>
+    <ReferenceConstraintViolation occurrences="1">
+      <code>return;</code>
+    </ReferenceConstraintViolation>
     <UndefinedInterfaceMethod occurrences="1">
       <code>plugin</code>
     </UndefinedInterfaceMethod>
@@ -882,10 +872,6 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$container</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="2">
-      <code>$container</code>
-      <code>$container</code>
-    </PossiblyInvalidArgument>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>$partial</code>
     </PossiblyNullPropertyAssignmentValue>
@@ -900,6 +886,10 @@
       <code>is_array($partial)</code>
       <code>is_string($separator)</code>
     </RedundantConditionGivenDocblockType>
+    <TypeDoesNotContainNull occurrences="2">
+      <code>null === $container</code>
+      <code>null === $container</code>
+    </TypeDoesNotContainNull>
     <UndefinedInterfaceMethod occurrences="2">
       <code>plugin</code>
       <code>plugin</code>
@@ -949,21 +939,21 @@
       <code>count($result) === 1 ? $result[0] : $result</code>
       <code>count($result) === 1 ? $result[0] : $result</code>
     </MixedReturnStatement>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$container</code>
-    </PossiblyInvalidArgument>
-    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
-      <code>$container</code>
-    </PossiblyInvalidPropertyAssignmentValue>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
+    <PossiblyUndefinedArrayOffset occurrences="1">
+      <code>$found[0]</code>
+    </PossiblyUndefinedArrayOffset>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(int) $renderFlag</code>
     </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$this-&gt;root</code>
     </RedundantConditionGivenDocblockType>
+    <TypeDoesNotContainNull occurrences="1">
+      <code>null === $container</code>
+    </TypeDoesNotContainNull>
   </file>
   <file src="src/Helper/Navigation/Listener/AclListener.php">
     <MixedAssignment occurrences="5">
@@ -1062,10 +1052,6 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$container</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="2">
-      <code>$container</code>
-      <code>$container</code>
-    </PossiblyInvalidArgument>
     <PossiblyNullArgument occurrences="1">
       <code>$page-&gt;getTitle()</code>
     </PossiblyNullArgument>
@@ -1093,6 +1079,10 @@
       <code>is_string($liActiveClass)</code>
       <code>is_string($ulClass)</code>
     </RedundantConditionGivenDocblockType>
+    <TypeDoesNotContainNull occurrences="2">
+      <code>null === $container</code>
+      <code>null === $container</code>
+    </TypeDoesNotContainNull>
     <UndefinedInterfaceMethod occurrences="4">
       <code>plugin</code>
       <code>plugin</code>
@@ -2121,9 +2111,6 @@
       <code>ViewEvent</code>
       <code>ViewEvent</code>
     </ImplementedReturnTypeMismatch>
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$params</code>
-    </LessSpecificReturnStatement>
     <MixedArgument occurrences="4">
       <code>$value</code>
       <code>$value</code>
@@ -2137,26 +2124,8 @@
       <code>$name</code>
       <code>$name</code>
     </MoreSpecificImplementedParamType>
-    <MoreSpecificReturnType occurrences="1">
-      <code>array|ArrayAccess</code>
-    </MoreSpecificReturnType>
-    <PossiblyInvalidArrayAssignment occurrences="5">
-      <code>$params['model']</code>
-      <code>$params['renderer']</code>
-      <code>$params['request']</code>
-      <code>$params['response']</code>
-      <code>$params['result']</code>
-    </PossiblyInvalidArrayAssignment>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>ViewEvent</code>
-      <code>ViewEvent</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="test/Helper/CycleTest.php">
-    <InvalidArrayOffset occurrences="2">
-      <code>$expected2[$i]</code>
-      <code>$expected[$i]</code>
-    </InvalidArrayOffset>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $this-&gt;helper-&gt;toString()</code>
     </RedundantCastGivenDocblockType>
@@ -2247,7 +2216,6 @@
       <code>new FlashMessenger()</code>
       <code>new FlashMessenger()</code>
     </DeprecatedClass>
-    <InvalidArgument occurrences="1"/>
     <MixedAssignment occurrences="12">
       <code>$displayInfo</code>
       <code>$displayInfo</code>
@@ -2886,9 +2854,6 @@
       <code>$code</code>
     </UnusedClosureParam>
   </file>
-  <file src="test/Helper/Navigation/PluginManagerCompatibilityTest.php">
-    <InvalidArgument occurrences="1"/>
-  </file>
   <file src="test/Helper/Navigation/SitemapTest.php">
     <MixedArgument occurrences="2">
       <code>$acl['acl']</code>
@@ -2913,8 +2878,9 @@
     </UnevaluatedCode>
   </file>
   <file src="test/Helper/PaginationControlTest.php">
-    <InvalidArgument occurrences="2">
+    <InvalidArgument occurrences="3">
       <code>$all</code>
+      <code>$paginator</code>
       <code>['partial.phtml', 'test']</code>
     </InvalidArgument>
     <NullArgument occurrences="1">
@@ -3229,15 +3195,16 @@
     <DeprecatedClass occurrences="1">
       <code>Wildcard::class</code>
     </DeprecatedClass>
-    <InvalidArgument occurrences="4">
+    <InvalidArgument occurrences="6">
       <code>$it</code>
+      <code>$router</code>
+      <code>$router</code>
       <code>'invalid params'</code>
       <code>true</code>
       <code>true</code>
     </InvalidArgument>
   </file>
   <file src="test/HelperPluginManagerCompatibilityTest.php">
-    <InvalidArgument occurrences="1"/>
     <MixedArgument occurrences="2">
       <code>$target</code>
       <code>$target</code>
@@ -3252,7 +3219,6 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/HelperPluginManagerTest.php">
-    <InvalidArgument occurrences="2"/>
     <MissingClosureParamType occurrences="2">
       <code>$container</code>
       <code>$container</code>
@@ -3280,7 +3246,6 @@
     </PossiblyInvalidArrayAccess>
   </file>
   <file src="test/PhpRendererTest.php">
-    <InvalidArgument occurrences="4"/>
     <MixedArgument occurrences="1">
       <code>$content</code>
     </MixedArgument>
@@ -3398,6 +3363,12 @@
     </UnusedMethodCall>
   </file>
   <file src="test/Strategy/PhpRendererStrategyTest.php">
+    <InvalidArgument occurrences="4">
+      <code>$e</code>
+      <code>$event</code>
+      <code>$event</code>
+      <code>$event</code>
+    </InvalidArgument>
     <MixedAssignment occurrences="7">
       <code>$content</code>
       <code>$content</code>

--- a/src/Helper/Navigation/AbstractHelper.php
+++ b/src/Helper/Navigation/AbstractHelper.php
@@ -244,6 +244,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      *
      * @param AbstractContainer|string|null $container
      * @return void
+     * @param-out AbstractContainer $container
      * @throws Exception\InvalidArgumentException
      */
     protected function parseContainer(&$container = null)

--- a/src/ViewEvent.php
+++ b/src/ViewEvent.php
@@ -13,6 +13,18 @@ use Laminas\View\Renderer\RendererInterface as Renderer;
 
 use function is_array;
 
+/**
+ * @psalm-type EventParams = array{
+ *   model: Model|null,
+ *   renderer: Renderer|null,
+ *   request: Request|null,
+ *   response: Response|null,
+ *   result: mixed,
+ *   ...
+ * }
+ * @template TTarget of null|object|string
+ * @extends Event<TTarget, EventParams>
+ */
 class ViewEvent extends Event
 {
     /**#@+
@@ -169,11 +181,7 @@ class ViewEvent extends Event
         }
     }
 
-    /**
-     * Get all event parameters
-     *
-     * @return array|ArrayAccess
-     */
+    /** @inheritDoc */
     public function getParams()
     {
         $params             = parent::getParams();


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| QA            | yes

### Description

- Bump coding standard to 2.5
- Bump psalm to 5.4
- Update (some) locked deps

`laminas-console` is beginning to make it impossible to keep dependencies sane - Ignoring platform reqs is becoming more unsafe on PHP 8.0 for example.

Closes #192 