### PR TITLE
Fixed improper navigation semantics in accessibility contexts

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.4.0@62db5d4f6a7ae0a20f7cc5a4952d730272fc0863">
+<files psalm-version="5.6.0@e784128902dfe01d489c4123d69918a9f3c1eac5">
   <file src="bin/templatemap_generator.php">
-    <MissingParamType occurrences="1">
+    <MissingParamType>
       <code>$templatePath</code>
     </MissingParamType>
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$file</code>
       <code>$file-&gt;getExtension()</code>
       <code>$templatePath</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$file</code>
       <code>$files[]</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>getExtension</code>
       <code>getPathname</code>
     </MixedMethodCall>
   </file>
   <file src="src/Helper/AbstractHtmlElement.php">
-    <MissingConstructor occurrences="12">
+    <MissingConstructor>
       <code>$closingBracket</code>
       <code>$closingBracket</code>
       <code>$closingBracket</code>
@@ -33,202 +33,202 @@
       <code>$closingBracket</code>
       <code>$closingBracket</code>
     </MissingConstructor>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$val</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$val</code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$attribs</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference>
       <code>plugin</code>
       <code>plugin</code>
     </PossiblyNullReference>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(array) $attribs</code>
     </RedundantCastGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="2">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/Cycle.php">
-    <ImplementedReturnTypeMismatch occurrences="2">
+    <ImplementedReturnTypeMismatch>
       <code>Cycle</code>
       <code>Cycle</code>
     </ImplementedReturnTypeMismatch>
-    <MissingTemplateParam occurrences="1">
+    <MissingTemplateParam>
       <code>Iterator</code>
     </MissingTemplateParam>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$this-&gt;data[$this-&gt;name]</code>
       <code>$this-&gt;data[$this-&gt;name]</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="2">
+    <MixedArrayAccess>
       <code>$this-&gt;data[$this-&gt;name][$this-&gt;key()]</code>
       <code>$this-&gt;data[$this-&gt;name][$this-&gt;key()]</code>
     </MixedArrayAccess>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>array</code>
       <code>int</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="2">
+    <MixedOperand>
       <code>$this-&gt;pointers[$this-&gt;name]</code>
       <code>$this-&gt;pointers[$this-&gt;name]</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement>
       <code>$this-&gt;data[$this-&gt;name]</code>
       <code>$this-&gt;pointers[$this-&gt;name]</code>
     </MixedReturnStatement>
   </file>
   <file src="src/Helper/DeclareVars.php">
-    <MissingConstructor occurrences="1">
+    <MissingConstructor>
       <code>$view</code>
     </MissingConstructor>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$key</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$key</code>
       <code>$value</code>
       <code>$vars</code>
     </MixedAssignment>
-    <MixedPropertyFetch occurrences="1">
+    <MixedPropertyFetch>
       <code>$vars-&gt;$key</code>
     </MixedPropertyFetch>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <NonInvariantDocblockPropertyType>
       <code>$view</code>
     </NonInvariantDocblockPropertyType>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference>
       <code>vars</code>
       <code>vars</code>
     </PossiblyNullReference>
-    <UndefinedInterfaceMethod occurrences="2">
+    <UndefinedInterfaceMethod>
       <code>vars</code>
       <code>vars</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/Doctype.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>null === static::$registeredDoctypes</code>
     </DocblockTypeContradiction>
-    <MixedArrayAssignment occurrences="1">
+    <MixedArrayAssignment>
       <code>$this-&gt;registry['doctypes'][$type]</code>
     </MixedArrayAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>array</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="3">
+    <MixedReturnStatement>
       <code>$doctypes[$this-&gt;getDoctype()]</code>
       <code>$this-&gt;registry['doctype']</code>
       <code>$this-&gt;registry['doctypes']</code>
     </MixedReturnStatement>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$registry</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Helper/Escaper/AbstractHelper.php">
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$v</code>
       <code>$value[$k]</code>
     </MixedAssignment>
   </file>
   <file src="src/Helper/FlashMessenger.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>null === $this-&gt;pluginFlashMessenger</code>
     </DocblockTypeContradiction>
-    <MissingClosureParamType occurrences="1">
+    <MissingClosureParamType>
       <code>$item</code>
     </MissingClosureParamType>
-    <MissingConstructor occurrences="2">
+    <MissingConstructor>
       <code>$escapeHtmlHelper</code>
       <code>$pluginFlashMessenger</code>
     </MissingConstructor>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$item</code>
       <code>$messagesToPrint</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
+    <MixedArgumentTypeCoercion>
       <code>$classes</code>
       <code>$classes</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAssignment occurrences="2">
+    <MixedArrayAssignment>
       <code>$messagesToPrint[]</code>
       <code>$messagesToPrint[]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$classes</code>
       <code>$classes</code>
       <code>$messagesToPrint[]</code>
       <code>$messagesToPrint[]</code>
       <code>$this-&gt;escapeHtmlHelper</code>
     </MixedAssignment>
-    <RedundantCastGivenDocblockType occurrences="4">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $autoEscape</code>
       <code>(string) $messageCloseString</code>
       <code>(string) $messageOpenFormat</code>
       <code>(string) $messageSeparatorString</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>$this-&gt;escapeHtmlHelper</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/Gravatar.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>$flag === null</code>
     </DocblockTypeContradiction>
-    <MissingConstructor occurrences="3">
+    <MissingConstructor>
       <code>$attributes</code>
       <code>$email</code>
       <code>$emailIsHashed</code>
     </MissingConstructor>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$key</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="4">
+    <MixedInferredReturnType>
       <code>bool</code>
       <code>int</code>
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="4">
+    <MixedReturnStatement>
       <code>$this-&gt;options['default_img']</code>
       <code>$this-&gt;options['img_size']</code>
       <code>$this-&gt;options['rating']</code>
       <code>$this-&gt;options['secure']</code>
     </MixedReturnStatement>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $flag</code>
       <code>(int) $imgSize</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>(bool) $flag</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/HeadLink.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$item</code>
     </InvalidArgument>
-    <InvalidReturnStatement occurrences="1">
+    <InvalidReturnStatement>
       <code>$this-&gt;getContainer()-&gt;set($value)</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
+    <InvalidReturnType>
       <code>HeadLink</code>
     </InvalidReturnType>
-    <LessSpecificReturnStatement occurrences="1">
+    <LessSpecificReturnStatement>
       <code>(object) $attributes</code>
     </LessSpecificReturnStatement>
-    <MixedArgument occurrences="13">
+    <MixedArgument>
       <code>$args</code>
       <code>$args</code>
       <code>$args</code>
@@ -243,15 +243,15 @@
       <code>$this-&gt;getSeparator()</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
+    <MixedArgumentTypeCoercion>
       <code>$extras['media']</code>
       <code>$media</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="2">
+    <MixedArrayAccess>
       <code>$args[0]</code>
       <code>$args[0]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="14">
+    <MixedAssignment>
       <code>$conditionalStylesheet</code>
       <code>$extras</code>
       <code>$extras</code>
@@ -267,40 +267,40 @@
       <code>$type</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>HeadLink</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="2">
+    <MixedOperand>
       <code>$indent</code>
       <code>$indent</code>
     </MixedOperand>
-    <MixedPropertyFetch occurrences="2">
+    <MixedPropertyFetch>
       <code>$item-&gt;href</code>
       <code>$item-&gt;rel</code>
     </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>call_user_func_array([$this, '__invoke'], func_get_args())</code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>stdClass</code>
     </MoreSpecificReturnType>
-    <ParamNameMismatch occurrences="1">
+    <ParamNameMismatch>
       <code>$index</code>
     </ParamNameMismatch>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$item</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="2">
+    <PossiblyNullArgument>
       <code>$index</code>
       <code>$this-&gt;view</code>
     </PossiblyNullArgument>
-    <RedundantCast occurrences="1">
+    <RedundantCast>
       <code>(string) $conditionalStylesheet</code>
     </RedundantCast>
-    <UndefinedMagicMethod occurrences="4">
+    <UndefinedMagicMethod>
       <code>getIndent</code>
       <code>getSeparator</code>
       <code>getWhitespace</code>
@@ -308,17 +308,17 @@
     </UndefinedMagicMethod>
   </file>
   <file src="src/Helper/HeadMeta.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>! $item instanceof stdClass</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>$item</code>
       <code>$value</code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
+    <InvalidCast>
       <code>$item</code>
     </InvalidCast>
-    <MixedArgument occurrences="15">
+    <MixedArgument>
       <code>$args[0]</code>
       <code>$args[1]</code>
       <code>$args[2]</code>
@@ -335,7 +335,7 @@
       <code>$type</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment>
       <code>$doctype</code>
       <code>$indent</code>
       <code>$index</code>
@@ -345,10 +345,10 @@
       <code>$type</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>HeadMeta</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="6">
+    <MixedMethodCall>
       <code>isHtml5</code>
       <code>isHtml5</code>
       <code>isHtml5</code>
@@ -356,42 +356,42 @@
       <code>isRdfa</code>
       <code>isXhtml</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="2">
+    <MixedOperand>
       <code>$indent</code>
       <code>$indent</code>
     </MixedOperand>
-    <MixedPropertyFetch occurrences="2">
+    <MixedPropertyFetch>
       <code>$item-&gt;type</code>
       <code>$item-&gt;{$item-&gt;type}</code>
     </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement>
       <code>parent::__call($method, $args)</code>
       <code>parent::__call($method, $args)</code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <NullableReturnStatement occurrences="1">
+    <NullableReturnStatement>
       <code>$this-&gt;offsetSet($index, $item)</code>
     </NullableReturnStatement>
-    <ParamNameMismatch occurrences="2">
+    <ParamNameMismatch>
       <code>$index</code>
       <code>$index</code>
     </ParamNameMismatch>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$this-&gt;view</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="3">
+    <PossiblyNullReference>
       <code>plugin</code>
       <code>plugin</code>
       <code>plugin</code>
     </PossiblyNullReference>
-    <UndefinedInterfaceMethod occurrences="3">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
       <code>plugin</code>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
-    <UndefinedMagicMethod occurrences="4">
+    <UndefinedMagicMethod>
       <code>getIndent</code>
       <code>getSeparator</code>
       <code>getWhitespace</code>
@@ -399,10 +399,10 @@
     </UndefinedMagicMethod>
   </file>
   <file src="src/Helper/HeadScript.php">
-    <InvalidPropertyAssignmentValue occurrences="1">
+    <InvalidPropertyAssignmentValue>
       <code>['type']</code>
     </InvalidPropertyAssignmentValue>
-    <MixedArgument occurrences="13">
+    <MixedArgument>
       <code>$content</code>
       <code>$content</code>
       <code>$indent</code>
@@ -417,7 +417,7 @@
       <code>$this-&gt;getSeparator()</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedAssignment occurrences="11">
+    <MixedAssignment>
       <code>$attrs['src']</code>
       <code>$content</code>
       <code>$indent</code>
@@ -430,52 +430,52 @@
       <code>$useCdata</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>HeadScript</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>isHtml5</code>
       <code>isXhtml</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="3">
+    <MixedOperand>
       <code>$item-&gt;attributes['conditional']</code>
       <code>$item-&gt;source</code>
       <code>$type</code>
     </MixedOperand>
-    <MixedPropertyFetch occurrences="5">
+    <MixedPropertyFetch>
       <code>$item-&gt;attributes</code>
       <code>$item-&gt;attributes</code>
       <code>$item-&gt;source</code>
       <code>$item-&gt;source</code>
       <code>$item-&gt;type</code>
     </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement>
       <code>parent::__call($method, $args)</code>
       <code>parent::__call($method, $args)</code>
     </MixedReturnStatement>
-    <ParamNameMismatch occurrences="1">
+    <ParamNameMismatch>
       <code>$index</code>
     </ParamNameMismatch>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="3">
+    <PropertyNotSetInConstructor>
       <code>$captureLock</code>
       <code>$captureScriptType</code>
       <code>$captureType</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $flag</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType>
       <code>(null !== $spec) &amp;&amp; is_string($spec)</code>
       <code>is_string($spec)</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="2">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
-    <UndefinedMagicMethod occurrences="4">
+    <UndefinedMagicMethod>
       <code>getIndent</code>
       <code>getSeparator</code>
       <code>getWhitespace</code>
@@ -483,7 +483,7 @@
     </UndefinedMagicMethod>
   </file>
   <file src="src/Helper/HeadStyle.php">
-    <MixedArgument occurrences="10">
+    <MixedArgument>
       <code>$content</code>
       <code>$enc</code>
       <code>$escaper-&gt;escapeHtmlAttr($value)</code>
@@ -495,13 +495,13 @@
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$attributes['media']</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="1">
+    <MixedArrayAccess>
       <code>$item-&gt;attributes['conditional']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment>
       <code>$content</code>
       <code>$enc</code>
       <code>$escaper</code>
@@ -511,36 +511,36 @@
       <code>$key</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>escapeHtmlAttr</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="4">
+    <MixedOperand>
       <code>$indent</code>
       <code>$indent</code>
       <code>$item-&gt;attributes['conditional']</code>
       <code>$item-&gt;content</code>
     </MixedOperand>
-    <ParamNameMismatch occurrences="1">
+    <ParamNameMismatch>
       <code>$index</code>
     </ParamNameMismatch>
-    <PossiblyNullOperand occurrences="2">
+    <PossiblyNullOperand>
       <code>$escapeEnd</code>
       <code>$escapeStart</code>
     </PossiblyNullOperand>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
+    <PossiblyNullPropertyAssignmentValue>
       <code>$attrs</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="3">
+    <PropertyNotSetInConstructor>
       <code>$captureAttrs</code>
       <code>$captureLock</code>
       <code>$captureType</code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType>
       <code>(null !== $content) &amp;&amp; is_string($content)</code>
       <code>is_string($content)</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedMagicMethod occurrences="4">
+    <UndefinedMagicMethod>
       <code>getIndent</code>
       <code>getSeparator</code>
       <code>getWhitespace</code>
@@ -548,21 +548,21 @@
     </UndefinedMagicMethod>
   </file>
   <file src="src/Helper/HeadTitle.php">
-    <MissingClosureParamType occurrences="2">
+    <MissingClosureParamType>
       <code>$item</code>
       <code>$item</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="1">
+    <MissingClosureReturnType>
       <code>static fn($item) =&gt; $item</code>
     </MissingClosureReturnType>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$item</code>
       <code>$separator</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$items</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment>
       <code>$indent</code>
       <code>$item</code>
       <code>$items[]</code>
@@ -570,178 +570,178 @@
       <code>$prefix</code>
       <code>$separator</code>
     </MixedAssignment>
-    <MixedOperand occurrences="3">
+    <MixedOperand>
       <code>$indent</code>
       <code>$postfix</code>
       <code>$prefix</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>translate</code>
     </PossiblyNullReference>
   </file>
   <file src="src/Helper/HtmlFlash.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$htmlObject</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="1">
+    <MixedFunctionCall>
       <code>$htmlObject($data, self::TYPE, $attribs, $params, $content)</code>
     </MixedFunctionCall>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$htmlObject($data, self::TYPE, $attribs, $params, $content)</code>
     </MixedReturnStatement>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>plugin</code>
     </PossiblyNullReference>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/HtmlObject.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_array($content)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$content</code>
       <code>$options</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$options</code>
     </MixedAssignment>
   </file>
   <file src="src/Helper/HtmlPage.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$htmlObject</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="1">
+    <MixedFunctionCall>
       <code>$htmlObject($data, self::TYPE, $attribs, $params, $content)</code>
     </MixedFunctionCall>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$htmlObject($data, self::TYPE, $attribs, $params, $content)</code>
     </MixedReturnStatement>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>plugin</code>
     </PossiblyNullReference>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/HtmlQuicktime.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$htmlObject</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="1">
+    <MixedFunctionCall>
       <code>$htmlObject($data, self::TYPE, $attribs, $params, $content)</code>
     </MixedFunctionCall>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$htmlObject($data, self::TYPE, $attribs, $params, $content)</code>
     </MixedReturnStatement>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>plugin</code>
     </PossiblyNullReference>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/HtmlTag.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$this-&gt;view</code>
     </PossiblyNullArgument>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $useNamespaces</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Helper/InlineScript.php">
-    <LessSpecificReturnStatement occurrences="1">
+    <LessSpecificReturnStatement>
       <code>parent::__invoke($mode, $spec, $placement, $attrs, $type)</code>
     </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>InlineScript</code>
     </MoreSpecificReturnType>
-    <PropertyNotSetInConstructor occurrences="3">
+    <PropertyNotSetInConstructor>
       <code>InlineScript</code>
       <code>InlineScript</code>
       <code>InlineScript</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Helper/Json.php">
-    <MissingConstructor occurrences="1">
+    <MissingConstructor>
       <code>$response</code>
     </MissingConstructor>
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>null</code>
     </NullArgument>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>$this-&gt;response instanceof Response</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/Layout.php">
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>plugin</code>
     </PossiblyNullReference>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(string) $template</code>
     </RedundantCastGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/Navigation.php">
-    <InvalidFunctionCall occurrences="1">
+    <InvalidFunctionCall>
       <code>call_user_func_array($helper, $arguments)</code>
     </InvalidFunctionCall>
-    <InvalidThrow occurrences="1">
+    <InvalidThrow>
       <code>ExceptionInterface</code>
     </InvalidThrow>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$container</code>
     </MoreSpecificImplementedParamType>
-    <RedundantCastGivenDocblockType occurrences="4">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $injectAcl</code>
       <code>(bool) $injectContainer</code>
       <code>(bool) $injectTranslator</code>
       <code>(string) $proxy</code>
     </RedundantCastGivenDocblockType>
-    <RedundantCondition occurrences="1">
+    <RedundantCondition>
       <code>$view</code>
     </RedundantCondition>
-    <UndefinedInterfaceMethod occurrences="2">
+    <UndefinedInterfaceMethod>
       <code>hasTranslator</code>
       <code>setTranslator</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/Navigation/AbstractHelper.php">
-    <DocblockTypeContradiction occurrences="4">
+    <DocblockTypeContradiction>
       <code>! is_int($this-&gt;minDepth)</code>
       <code>! is_string($message)</code>
       <code>$container instanceof AbstractContainer</code>
       <code>null === $this-&gt;container</code>
     </DocblockTypeContradiction>
-    <ImplementedReturnTypeMismatch occurrences="2">
+    <ImplementedReturnTypeMismatch>
       <code>AbstractHelper</code>
       <code>null|EventManagerInterface</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidThrow occurrences="1">
+    <InvalidThrow>
       <code>Navigation\Exception\ExceptionInterface</code>
     </InvalidThrow>
-    <MissingConstructor occurrences="19">
+    <MissingConstructor>
       <code>$container</code>
       <code>$container</code>
       <code>$container</code>
@@ -762,147 +762,146 @@
       <code>$minDepth</code>
       <code>$minDepth</code>
     </MissingConstructor>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$page-&gt;getTextDomain()</code>
       <code>$page-&gt;getTextDomain()</code>
     </MixedArgument>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$container</code>
       <code>$container</code>
       <code>$label</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>bool</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$label</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$results-&gt;last()</code>
     </MixedReturnStatement>
-    <ParamNameMismatch occurrences="1">
+    <ParamNameMismatch>
       <code>$events</code>
     </ParamNameMismatch>
-    <PossiblyFalseArgument occurrences="1">
+    <PossiblyFalseArgument>
       <code>strrpos($prefix, '\\')</code>
     </PossiblyFalseArgument>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$page-&gt;getTitle()</code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
+    <PossiblyNullPropertyAssignmentValue>
       <code>$maxDepth</code>
       <code>$minDepth</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyNullReference occurrences="4">
+    <PossiblyNullReference>
       <code>attach</code>
       <code>getParent</code>
       <code>plugin</code>
       <code>translate</code>
     </PossiblyNullReference>
-    <RedundantCastGivenDocblockType occurrences="3">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $renderInvisible</code>
       <code>(bool) $useAcl</code>
       <code>(string) $indent</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="5">
+    <RedundantConditionGivenDocblockType>
       <code>$this-&gt;acl === null &amp;&amp; static::$defaultAcl !== null</code>
       <code>is_int($maxDepth)</code>
       <code>is_int($minDepth)</code>
       <code>null !== $this-&gt;container</code>
       <code>static::$defaultAcl !== null</code>
     </RedundantConditionGivenDocblockType>
-    <ReferenceConstraintViolation occurrences="1">
+    <ReferenceConstraintViolation>
       <code>return;</code>
     </ReferenceConstraintViolation>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
-    <UndefinedMethod occurrences="1">
+    <UndefinedMethod>
       <code>setSharedManager</code>
     </UndefinedMethod>
-    <UnevaluatedCode occurrences="1">
+    <UnevaluatedCode>
       <code>return '';</code>
     </UnevaluatedCode>
   </file>
   <file src="src/Helper/Navigation/Breadcrumbs.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>null === $partial</code>
     </DocblockTypeContradiction>
-    <InvalidReturnStatement occurrences="2">
+    <InvalidReturnStatement>
       <code>$this-&gt;renderPartialModel($params, $container, $partial)</code>
       <code>$this-&gt;renderPartialModel([], $container, $partial)</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="2">
+    <InvalidReturnType>
       <code>string</code>
       <code>string</code>
     </InvalidReturnType>
-    <MissingConstructor occurrences="1">
+    <MissingConstructor>
       <code>$partial</code>
     </MissingConstructor>
-    <MixedArgument occurrences="6">
+    <MixedArgument>
       <code>$active</code>
       <code>$active-&gt;getLabel()</code>
       <code>$active-&gt;getTextDomain()</code>
-      <code>$html</code>
       <code>$model['pages']</code>
       <code>$partial[0]</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="2">
+    <MixedArrayAssignment>
       <code>$model['pages'][]</code>
       <code>$model['pages'][]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment>
       <code>$active</code>
       <code>$active</code>
       <code>$active</code>
-      <code>$html</code>
+      <code>$label</code>
       <code>$model['pages'][]</code>
       <code>$parent</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="4">
+    <MixedMethodCall>
       <code>getLabel</code>
       <code>getParent</code>
       <code>getParent</code>
       <code>getTextDomain</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
-      <code>$html</code>
+    <MixedOperand>
+      <code>$label</code>
     </MixedOperand>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$container</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
+    <PossiblyNullPropertyAssignmentValue>
       <code>$partial</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference>
       <code>plugin</code>
       <code>plugin</code>
     </PossiblyNullReference>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $linkLast</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType>
       <code>is_array($partial)</code>
       <code>is_string($separator)</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainNull occurrences="2">
+    <TypeDoesNotContainNull>
       <code>null === $container</code>
       <code>null === $container</code>
     </TypeDoesNotContainNull>
-    <UndefinedInterfaceMethod occurrences="2">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/Navigation/Links.php">
-    <InvalidOperand occurrences="1">
+    <InvalidOperand>
       <code>$relFlag</code>
     </InvalidOperand>
-    <MissingConstructor occurrences="1">
+    <MissingConstructor>
       <code>$root</code>
     </MissingConstructor>
-    <MixedArgument occurrences="8">
+    <MixedArgument>
       <code>$active</code>
       <code>$arguments[0]</code>
       <code>$intermediate</code>
@@ -912,13 +911,13 @@
       <code>$page-&gt;$meth()</code>
       <code>$type</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$relation</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayOffset occurrences="1">
+    <MixedArrayOffset>
       <code>$result[$rel][$type]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment>
       <code>$active</code>
       <code>$found</code>
       <code>$intermediate</code>
@@ -929,68 +928,68 @@
       <code>$type</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>AbstractPage|array|null</code>
       <code>array|null</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="4">
+    <MixedReturnStatement>
       <code>$found</code>
       <code>$found</code>
       <code>count($result) === 1 ? $result[0] : $result</code>
       <code>count($result) === 1 ? $result[0] : $result</code>
     </MixedReturnStatement>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyUndefinedArrayOffset occurrences="1">
+    <PossiblyUndefinedArrayOffset>
       <code>$found[0]</code>
     </PossiblyUndefinedArrayOffset>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(int) $renderFlag</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>$this-&gt;root</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainNull occurrences="1">
+    <TypeDoesNotContainNull>
       <code>null === $container</code>
     </TypeDoesNotContainNull>
   </file>
   <file src="src/Helper/Navigation/Listener/AclListener.php">
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$acl</code>
       <code>$page</code>
       <code>$privilege</code>
       <code>$resource</code>
       <code>$role</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="4">
+    <MixedMethodCall>
       <code>getPrivilege</code>
       <code>getResource</code>
       <code>hasResource</code>
       <code>isAllowed</code>
     </MixedMethodCall>
-    <PossiblyInvalidArrayAccess occurrences="3">
+    <PossiblyInvalidArrayAccess>
       <code>$params['acl']</code>
       <code>$params['page']</code>
       <code>$params['role']</code>
     </PossiblyInvalidArrayAccess>
   </file>
   <file src="src/Helper/Navigation/Menu.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>null === $partial</code>
     </DocblockTypeContradiction>
-    <InvalidReturnStatement occurrences="2">
+    <InvalidReturnStatement>
       <code>$this-&gt;renderPartialModel($params, $container, $partial)</code>
       <code>$this-&gt;renderPartialModel([], $container, $partial)</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="2">
+    <InvalidReturnType>
       <code>string</code>
       <code>string</code>
     </InvalidReturnType>
-    <MissingConstructor occurrences="1">
+    <MissingConstructor>
       <code>$partial</code>
     </MissingConstructor>
-    <MixedArgument occurrences="22">
+    <MixedArgument>
       <code>$options['addClassToListItem']</code>
       <code>$options['addClassToListItem']</code>
       <code>$options['escapeLabels']</code>
@@ -1014,10 +1013,10 @@
       <code>$partial[0]</code>
       <code>$subPage</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$liClasses</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment>
       <code>$active['page']</code>
       <code>$active['page']</code>
       <code>$foundDepth</code>
@@ -1027,7 +1026,7 @@
       <code>$page</code>
       <code>$subPage</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="11">
+    <MixedMethodCall>
       <code>getClass</code>
       <code>getClass</code>
       <code>getParent</code>
@@ -1040,7 +1039,7 @@
       <code>hasPages</code>
       <code>isActive</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="7">
+    <MixedOperand>
       <code>$active['depth']</code>
       <code>$escaper($label)</code>
       <code>$escaper($ulClass)</code>
@@ -1049,41 +1048,41 @@
       <code>$escaper(implode(' ', $liClasses))</code>
       <code>$foundDepth</code>
     </MixedOperand>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$container</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$page-&gt;getTitle()</code>
     </PossiblyNullArgument>
-    <PossiblyNullOperand occurrences="2">
+    <PossiblyNullOperand>
       <code>$minDepth</code>
       <code>$minDepth</code>
     </PossiblyNullOperand>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
+    <PossiblyNullPropertyAssignmentValue>
       <code>$partial</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyNullReference occurrences="4">
+    <PossiblyNullReference>
       <code>plugin</code>
       <code>plugin</code>
       <code>plugin</code>
       <code>plugin</code>
     </PossiblyNullReference>
-    <RedundantCastGivenDocblockType occurrences="4">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $flag</code>
       <code>(bool) $flag</code>
       <code>(bool) $flag</code>
       <code>(bool) $flag</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="3">
+    <RedundantConditionGivenDocblockType>
       <code>is_array($partial)</code>
       <code>is_string($liActiveClass)</code>
       <code>is_string($ulClass)</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainNull occurrences="2">
+    <TypeDoesNotContainNull>
       <code>null === $container</code>
       <code>null === $container</code>
     </TypeDoesNotContainNull>
-    <UndefinedInterfaceMethod occurrences="4">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
       <code>plugin</code>
       <code>plugin</code>
@@ -1091,15 +1090,15 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/Navigation/PluginManager.php">
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <NonInvariantDocblockPropertyType>
       <code>$aliases</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/Helper/Navigation/Sitemap.php">
-    <MissingConstructor occurrences="1">
+    <MissingConstructor>
       <code>$serverUrl</code>
     </MissingConstructor>
-    <MixedArgument occurrences="7">
+    <MixedArgument>
       <code>$changefreq</code>
       <code>$changefreq</code>
       <code>$curDoc</code>
@@ -1108,7 +1107,7 @@
       <code>$priority</code>
       <code>$priority</code>
     </MixedArgument>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment>
       <code>$basePathHelper</code>
       <code>$changefreq</code>
       <code>$curDoc</code>
@@ -1118,27 +1117,27 @@
       <code>$serverUrlHelper</code>
       <code>$this-&gt;serverUrl</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="3">
+    <MixedFunctionCall>
       <code>$basePathHelper()</code>
       <code>$escaper($string)</code>
       <code>$serverUrlHelper()</code>
     </MixedFunctionCall>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="3">
+    <MixedReturnStatement>
       <code>$escaper($string)</code>
       <code>$this-&gt;serverUrl</code>
       <code>$this-&gt;serverUrl</code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$container</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyFalseArgument occurrences="1">
+    <PossiblyFalseArgument>
       <code>$lastmod</code>
     </PossiblyFalseArgument>
-    <PossiblyNullReference occurrences="7">
+    <PossiblyNullReference>
       <code>isValid</code>
       <code>isValid</code>
       <code>isValid</code>
@@ -1147,7 +1146,7 @@
       <code>plugin</code>
       <code>plugin</code>
     </PossiblyNullReference>
-    <RedundantCastGivenDocblockType occurrences="6">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $formatOutput</code>
       <code>(bool) $schemaValidation</code>
       <code>(bool) $useSitemapValidators</code>
@@ -1155,120 +1154,120 @@
       <code>(string) $href</code>
       <code>(string) $href</code>
     </RedundantCastGivenDocblockType>
-    <RedundantPropertyInitializationCheck occurrences="1">
+    <RedundantPropertyInitializationCheck>
       <code>isset($this-&gt;serverUrl)</code>
     </RedundantPropertyInitializationCheck>
-    <UndefinedInterfaceMethod occurrences="3">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
       <code>plugin</code>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/PaginationControl.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>static::$defaultViewPartial === null</code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$partial</code>
       <code>$partialHelper</code>
       <code>$partialHelper</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="2">
+    <MixedFunctionCall>
       <code>$partialHelper($partial, $pages)</code>
       <code>$partialHelper($partial[0], $pages)</code>
     </MixedFunctionCall>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement>
       <code>$partialHelper($partial, $pages)</code>
       <code>$partialHelper($partial[0], $pages)</code>
     </MixedReturnStatement>
-    <NoInterfaceProperties occurrences="1">
+    <NoInterfaceProperties>
       <code>$this-&gt;view-&gt;paginator</code>
     </NoInterfaceProperties>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference>
       <code>plugin</code>
       <code>plugin</code>
     </PossiblyNullReference>
-    <UndefinedInterfaceMethod occurrences="2">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/Partial.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_scalar($values)</code>
     </DocblockTypeContradiction>
-    <MissingConstructor occurrences="2">
+    <MissingConstructor>
       <code>$objectKey</code>
       <code>$objectKey</code>
     </MissingConstructor>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$values</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$values</code>
     </MixedAssignment>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$name</code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference>
       <code>render</code>
       <code>render</code>
     </PossiblyNullReference>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(string) $key</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Helper/PartialLoop.php">
-    <LessSpecificReturnStatement occurrences="1">
+    <LessSpecificReturnStatement>
       <code>parent::setObjectKey($key)</code>
     </LessSpecificReturnStatement>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$item</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$item</code>
       <code>$this-&gt;objectKey</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$values-&gt;toArray()</code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="2">
+    <MoreSpecificImplementedParamType>
       <code>$name</code>
       <code>$values</code>
     </MoreSpecificImplementedParamType>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>self</code>
     </MoreSpecificReturnType>
-    <PossiblyInvalidOperand occurrences="1">
+    <PossiblyInvalidOperand>
       <code>parent::__invoke($name, $item)</code>
     </PossiblyInvalidOperand>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(string) $key</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Helper/Placeholder.php">
-    <InvalidStringClass occurrences="1">
+    <InvalidStringClass>
       <code>new $this-&gt;containerClass($value)</code>
     </InvalidStringClass>
-    <LessSpecificReturnStatement occurrences="1">
+    <LessSpecificReturnStatement>
       <code>$this-&gt;items[$key]</code>
     </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>AbstractContainer</code>
     </MoreSpecificReturnType>
-    <PropertyTypeCoercion occurrences="1">
+    <PropertyTypeCoercion>
       <code>$this-&gt;items</code>
     </PropertyTypeCoercion>
-    <RedundantCastGivenDocblockType occurrences="5">
+    <RedundantCastGivenDocblockType>
       <code>(string) $key</code>
       <code>(string) $key</code>
       <code>(string) $key</code>
@@ -1277,308 +1276,308 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Helper/Placeholder/Container.php">
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>Container</code>
       <code>Container</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Helper/Placeholder/Container/AbstractContainer.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>self</code>
     </ImplementedReturnTypeMismatch>
-    <MissingTemplateParam occurrences="1">
+    <MissingTemplateParam>
       <code>AbstractContainer</code>
     </MissingTemplateParam>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$items</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayOffset occurrences="1">
+    <MixedArrayOffset>
       <code>$this[$key]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$key</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>int</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="2">
+    <MixedOperand>
       <code>$this[$key]</code>
       <code>max($keys)</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>max($keys) + 1</code>
     </MixedReturnStatement>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>$captureKey</code>
       <code>$captureType</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="4">
+    <RedundantCastGivenDocblockType>
       <code>(string) $indent</code>
       <code>(string) $postfix</code>
       <code>(string) $prefix</code>
       <code>(string) $separator</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>null !== $this-&gt;captureKey</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/Placeholder/Container/AbstractStandalone.php">
-    <InvalidStringClass occurrences="1">
+    <InvalidStringClass>
       <code>new $this-&gt;containerClass()</code>
     </InvalidStringClass>
-    <LessSpecificReturnStatement occurrences="1">
+    <LessSpecificReturnStatement>
       <code>$this-&gt;container</code>
     </LessSpecificReturnStatement>
-    <MissingTemplateParam occurrences="2">
+    <MissingTemplateParam>
       <code>ArrayAccess</code>
       <code>IteratorAggregate</code>
     </MissingTemplateParam>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$container[$key]</code>
       <code>$return</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>escapeHtml</code>
       <code>escapeHtmlAttr</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement>
       <code>$this-&gt;getEscaper()-&gt;escapeHtml((string) $string)</code>
       <code>$this-&gt;getEscaper()-&gt;escapeHtmlAttr((string) $string)</code>
     </MixedReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>AbstractContainer</code>
     </MoreSpecificReturnType>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$enc</code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PropertyTypeCoercion occurrences="1">
+    <PropertyTypeCoercion>
       <code>new $this-&gt;containerClass()</code>
     </PropertyTypeCoercion>
-    <RedundantCastGivenDocblockType occurrences="3">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $autoEscape</code>
       <code>(string) $string</code>
       <code>(string) $string</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>null !== $this-&gt;container</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/Placeholder/Registry.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>null === static::$instance</code>
     </DocblockTypeContradiction>
-    <InvalidStringClass occurrences="1">
+    <InvalidStringClass>
       <code>new $this-&gt;containerClass($value)</code>
     </InvalidStringClass>
-    <LessSpecificReturnStatement occurrences="1">
+    <LessSpecificReturnStatement>
       <code>$this-&gt;items[$key]</code>
     </LessSpecificReturnStatement>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>AbstractContainer</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$this-&gt;items[$key]</code>
     </MixedReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>AbstractContainer</code>
     </MoreSpecificReturnType>
-    <RedundantCastGivenDocblockType occurrences="5">
+    <RedundantCastGivenDocblockType>
       <code>(string) $key</code>
       <code>(string) $key</code>
       <code>(string) $key</code>
       <code>(string) $key</code>
       <code>(string) $key</code>
     </RedundantCastGivenDocblockType>
-    <UnsafeInstantiation occurrences="1">
+    <UnsafeInstantiation>
       <code>new static()</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Helper/RenderChildModel.php">
-    <MissingConstructor occurrences="2">
+    <MissingConstructor>
       <code>$current</code>
       <code>$viewModelHelper</code>
     </MissingConstructor>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$childModel</code>
       <code>$this-&gt;viewModelHelper</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>ViewModel</code>
       <code>false|Model</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>captureTo</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement>
       <code>$childModel</code>
       <code>$this-&gt;viewModelHelper</code>
     </MixedReturnStatement>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$this-&gt;getView()</code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
+    <PossiblyNullPropertyAssignmentValue>
       <code>$model = $this-&gt;getCurrent()</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyNullReference occurrences="3">
+    <PossiblyNullReference>
       <code>getChildren</code>
       <code>plugin</code>
       <code>render</code>
     </PossiblyNullReference>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>$this-&gt;viewModelHelper</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/RenderToPlaceholder.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$placeholderHelper</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="2">
+    <MixedFunctionCall>
       <code>$placeholderHelper($placeholder)</code>
       <code>$placeholderHelper($placeholder)</code>
     </MixedFunctionCall>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>captureEnd</code>
       <code>captureStart</code>
     </MixedMethodCall>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference>
       <code>plugin</code>
       <code>render</code>
     </PossiblyNullReference>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/ServerUrl.php">
-    <ArgumentTypeCoercion occurrences="2">
+    <ArgumentTypeCoercion>
       <code>$_SERVER['SERVER_PORT']</code>
       <code>$port</code>
     </ArgumentTypeCoercion>
-    <InvalidNullableReturnType occurrences="2">
+    <InvalidNullableReturnType>
       <code>string</code>
       <code>string</code>
     </InvalidNullableReturnType>
-    <NullableReturnStatement occurrences="2">
+    <NullableReturnStatement>
       <code>$this-&gt;host</code>
       <code>$this-&gt;scheme</code>
     </NullableReturnStatement>
-    <PossiblyUndefinedArrayOffset occurrences="1">
+    <PossiblyUndefinedArrayOffset>
       <code>$_SERVER['REQUEST_URI']</code>
     </PossiblyUndefinedArrayOffset>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $useProxy</code>
     </RedundantCastGivenDocblockType>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>$_SERVER['HTTPS'] === true</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Helper/Service/AssetFactory.php">
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$cName</code>
     </PossiblyNullArgument>
   </file>
   <file src="src/Helper/Service/DoctypeFactory.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$config['view_helper_config']['doctype']</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="2">
+    <MixedArrayAccess>
       <code>$config['view_helper_config']</code>
       <code>$config['view_helper_config']['doctype']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$config</code>
     </MixedAssignment>
   </file>
   <file src="src/Helper/Service/FlashMessengerFactory.php">
-    <DeprecatedClass occurrences="3">
+    <DeprecatedClass>
       <code>FlashMessenger</code>
       <code>FlashMessenger</code>
       <code>new FlashMessenger()</code>
     </DeprecatedClass>
-    <DeprecatedInterface occurrences="1">
+    <DeprecatedInterface>
       <code>FlashMessengerFactory</code>
     </DeprecatedInterface>
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$configHelper['message_close_string']</code>
       <code>$configHelper['message_open_format']</code>
       <code>$configHelper['message_separator_string']</code>
       <code>$flashMessenger</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="5">
+    <MixedArrayAccess>
       <code>$configHelper['message_close_string']</code>
       <code>$configHelper['message_open_format']</code>
       <code>$configHelper['message_separator_string']</code>
       <code>$config['view_helper_config']</code>
       <code>$config['view_helper_config']['flashmessenger']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$config</code>
       <code>$configHelper</code>
       <code>$controllerPluginManager</code>
       <code>$flashMessenger</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>get</code>
     </MixedMethodCall>
-    <ParamNameMismatch occurrences="1">
+    <ParamNameMismatch>
       <code>$container</code>
     </ParamNameMismatch>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$requestedName</code>
     </PossiblyNullArgument>
   </file>
   <file src="src/Helper/TranslatorAwareTrait.php">
-    <DeprecatedClass occurrences="3">
+    <DeprecatedClass>
       <code>$this</code>
       <code>$this</code>
       <code>$this</code>
     </DeprecatedClass>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $enabled</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Helper/Url.php">
-    <DocblockTypeContradiction occurrences="3">
+    <DocblockTypeContradiction>
       <code>3 === func_num_args() &amp;&amp; is_bool($options)</code>
       <code>is_array($params)</code>
       <code>is_bool($options)</code>
     </DocblockTypeContradiction>
-    <InvalidArrayAssignment occurrences="1">
+    <InvalidArrayAssignment>
       <code>$options['name']</code>
     </InvalidArrayAssignment>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$reuseMatchedParams</code>
       <code>$routeMatchParams['controller']</code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/HelperPluginManager.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>! $events</code>
       <code>! $events</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$container-&gt;get('EventManager')</code>
       <code>$container-&gt;get('MvcTranslator')</code>
       <code>$container-&gt;get('Translator')</code>
       <code>$container-&gt;get(TranslatorInterface::class)</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$container</code>
       <code>$container</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>($name is class-string ? T : HelperInterface|callable)</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="8">
+    <MixedMethodCall>
       <code>get</code>
       <code>get</code>
       <code>get</code>
@@ -1588,121 +1587,121 @@
       <code>has</code>
       <code>has</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>parent::get($name, $options)</code>
     </MixedReturnStatement>
-    <PropertyTypeCoercion occurrences="2">
+    <PropertyTypeCoercion>
       <code>$this-&gt;initializers</code>
       <code>$this-&gt;initializers</code>
     </PropertyTypeCoercion>
-    <UndefinedInterfaceMethod occurrences="2">
+    <UndefinedInterfaceMethod>
       <code>getServiceLocator</code>
       <code>getServiceLocator</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/HtmlAttributesSet.php">
-    <MissingTemplateParam occurrences="1">
+    <MissingTemplateParam>
       <code>HtmlAttributesSet</code>
     </MissingTemplateParam>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$value</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$storeValue</code>
       <code>$value</code>
     </MixedAssignment>
   </file>
   <file src="src/Model/ClearableModelInterface.php">
-    <MissingReturnType occurrences="3">
+    <MissingReturnType>
       <code>clearChildren</code>
       <code>clearOptions</code>
       <code>clearVariables</code>
     </MissingReturnType>
   </file>
   <file src="src/Model/ConsoleModel.php">
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>int</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$this-&gt;options['errorLevel']</code>
     </MixedReturnStatement>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <NonInvariantDocblockPropertyType>
       <code>$captureTo</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/Model/FeedModel.php">
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$this-&gt;type</code>
       <code>$this-&gt;type</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>false|string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement>
       <code>$this-&gt;type</code>
       <code>$this-&gt;type</code>
     </MixedReturnStatement>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$variables</code>
     </PossiblyInvalidArgument>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$feed</code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>$this-&gt;feed instanceof Feed</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Model/JsonModel.php">
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <NonInvariantDocblockPropertyType>
       <code>$captureTo</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/Model/ModelInterface.php">
-    <MissingTemplateParam occurrences="1">
+    <MissingTemplateParam>
       <code>IteratorAggregate</code>
     </MissingTemplateParam>
   </file>
   <file src="src/Model/ViewModel.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>gettype($variables)</code>
       <code>is_array($options)</code>
     </DocblockTypeContradiction>
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>array|ArrayAccess|Traversable</code>
     </ImplementedReturnTypeMismatch>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$key</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAssignment occurrences="1">
+    <MixedArrayAssignment>
       <code>$children[]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$child</code>
       <code>$children</code>
       <code>$children[]</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>captureTo</code>
       <code>getChildrenByCaptureTo</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$child-&gt;getChildrenByCaptureTo($capture)</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement>
       <code>$children</code>
       <code>$children</code>
     </MixedReturnStatement>
-    <PossiblyInvalidArrayAccess occurrences="1">
+    <PossiblyInvalidArrayAccess>
       <code>$variables[$name]</code>
     </PossiblyInvalidArrayAccess>
-    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+    <PossiblyInvalidPropertyAssignmentValue>
       <code>$variables</code>
     </PossiblyInvalidPropertyAssignmentValue>
-    <RedundantCastGivenDocblockType occurrences="8">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $append</code>
       <code>(bool) $terminate</code>
       <code>(string) $capture</code>
@@ -1712,115 +1711,115 @@
       <code>(string) $name</code>
       <code>(string) $template</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>is_object($variables)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Renderer/ConsoleRenderer.php">
-    <ImplementedParamTypeMismatch occurrences="1">
+    <ImplementedParamTypeMismatch>
       <code>$values</code>
     </ImplementedParamTypeMismatch>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$child</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$child</code>
       <code>$setting</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedOperand occurrences="2">
+    <MixedOperand>
       <code>$setting</code>
       <code>$this-&gt;getFilterChain()-&gt;filter($values['result'])</code>
     </MixedOperand>
-    <ParamNameMismatch occurrences="1">
+    <ParamNameMismatch>
       <code>$model</code>
     </ParamNameMismatch>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$values</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Renderer/FeedRenderer.php">
-    <InvalidArrayAccess occurrences="1">
+    <InvalidArrayAccess>
       <code>$options['feed_type']</code>
     </InvalidArrayAccess>
-    <MissingConstructor occurrences="1">
+    <MissingConstructor>
       <code>$resolver</code>
     </MissingConstructor>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$type</code>
     </MixedAssignment>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>is_string($nameOrModel)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Renderer/JsonRenderer.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>void</code>
     </ImplementedReturnTypeMismatch>
-    <MissingConstructor occurrences="1">
+    <MissingConstructor>
       <code>$jsonpCallback</code>
     </MissingConstructor>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$child</code>
       <code>$nameOrModel</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$child</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayOffset occurrences="1">
+    <MixedArrayOffset>
       <code>$values[$captureTo]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$captureTo</code>
       <code>$child</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>captureTo</code>
     </MixedMethodCall>
-    <PossiblyInvalidArgument occurrences="3">
+    <PossiblyInvalidArgument>
       <code>$childValues</code>
       <code>$children</code>
       <code>$values</code>
     </PossiblyInvalidArgument>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $mergeUnnamedChildren</code>
       <code>(string) $callback</code>
     </RedundantCastGivenDocblockType>
-    <RedundantCondition occurrences="1">
+    <RedundantCondition>
       <code>$mergeChildren</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType>
       <code>! is_object($nameOrModel)</code>
       <code>null !== $this-&gt;jsonpCallback</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Renderer/PhpRenderer.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>gettype($helpers)</code>
       <code>gettype($variables)</code>
     </DocblockTypeContradiction>
-    <ImplementedParamTypeMismatch occurrences="1">
+    <ImplementedParamTypeMismatch>
       <code>$values</code>
     </ImplementedParamTypeMismatch>
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$__vars</code>
       <code>$this-&gt;__template</code>
       <code>$this-&gt;__template</code>
       <code>array_pop($this-&gt;__varsCache)</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="2">
+    <MixedArrayAccess>
       <code>$vars[$name]</code>
       <code>$vars[$name]</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="1">
+    <MixedArrayAssignment>
       <code>$vars[$name]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="2">
+    <MixedArrayOffset>
       <code>$this-&gt;__vars[$key]</code>
       <code>$this-&gt;__vars[$key]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="12">
+    <MixedAssignment>
       <code>$includeReturn</code>
       <code>$setting</code>
       <code>$this-&gt;__template</code>
@@ -1834,230 +1833,230 @@
       <code>$vars</code>
       <code>$vars[$name]</code>
     </MixedAssignment>
-    <MixedClone occurrences="1">
+    <MixedClone>
       <code>clone $this-&gt;vars()</code>
     </MixedClone>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>string</code>
       <code>string|Resolver</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>getArrayCopy</code>
       <code>new $helpers(new ServiceManager())</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$setting</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement>
       <code>$this-&gt;__filterChain-&gt;filter($this-&gt;__content)</code>
       <code>$this-&gt;__templateResolver-&gt;resolve($name, $this)</code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="1">
+    <NullableReturnStatement>
       <code>$this-&gt;__templateResolver</code>
     </NullableReturnStatement>
-    <PossibleRawObjectIteration occurrences="1">
+    <PossibleRawObjectIteration>
       <code>$variables</code>
     </PossibleRawObjectIteration>
-    <PossiblyInvalidArgument occurrences="2">
+    <PossiblyInvalidArgument>
       <code>$this-&gt;__file</code>
       <code>$values</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+    <PossiblyInvalidPropertyAssignmentValue>
       <code>$this-&gt;resolver($this-&gt;__template)</code>
     </PossiblyInvalidPropertyAssignmentValue>
-    <PossiblyNullArrayAccess occurrences="2">
+    <PossiblyNullArrayAccess>
       <code>$this-&gt;__vars[$key]</code>
       <code>$this-&gt;__vars[$key]</code>
     </PossiblyNullArrayAccess>
-    <PossiblyNullReference occurrences="3">
+    <PossiblyNullReference>
       <code>$this-&gt;__vars</code>
       <code>$this-&gt;__vars</code>
       <code>resolve</code>
     </PossiblyNullReference>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $renderTrees</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType>
       <code>is_object($helpers)</code>
       <code>is_object($variables)</code>
     </RedundantConditionGivenDocblockType>
-    <UnresolvableInclude occurrences="1">
+    <UnresolvableInclude>
       <code>include $this-&gt;__file</code>
     </UnresolvableInclude>
   </file>
   <file src="src/Resolver/AggregateResolver.php">
-    <MissingTemplateParam occurrences="1">
+    <MissingTemplateParam>
       <code>IteratorAggregate</code>
     </MissingTemplateParam>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$resolver</code>
       <code>$resource</code>
       <code>$this-&gt;lastLookupFailure</code>
       <code>$this-&gt;lastLookupFailure</code>
       <code>$this-&gt;lastSuccessfulResolver</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>false|string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>resolve</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$resource</code>
     </MixedReturnStatement>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$lastSuccessfulResolver</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Resolver/PrefixPathStackResolver.php">
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$prefix</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$result</code>
     </MixedAssignment>
   </file>
   <file src="src/Resolver/TemplateMapResolver.php">
-    <DocblockTypeContradiction occurrences="3">
+    <DocblockTypeContradiction>
       <code>! is_array($map) &amp;&amp; ! $map instanceof Traversable</code>
       <code>! is_array($map) &amp;&amp; ! $map instanceof Traversable</code>
       <code>is_string($nameOrMap)</code>
     </DocblockTypeContradiction>
-    <MissingTemplateParam occurrences="1">
+    <MissingTemplateParam>
       <code>IteratorAggregate</code>
     </MissingTemplateParam>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>false|string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$this-&gt;map[$name]</code>
     </MixedReturnStatement>
   </file>
   <file src="src/Resolver/TemplatePathStack.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_string($path)</code>
     </DocblockTypeContradiction>
-    <FalsableReturnStatement occurrences="2">
+    <FalsableReturnStatement>
       <code>false</code>
       <code>false</code>
     </FalsableReturnStatement>
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$this-&gt;lastLookupFailure</code>
       <code>$this-&gt;lastLookupFailure</code>
       <code>$value</code>
     </MixedAssignment>
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>$this-&gt;paths</code>
     </NullArgument>
-    <RedundantCastGivenDocblockType occurrences="3">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $flag</code>
       <code>(bool) $flag</code>
       <code>(string) $defaultSuffix</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Strategy/FeedStrategy.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$headers</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>addHeaderLine</code>
     </MixedMethodCall>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>setContent</code>
     </PossiblyNullReference>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>getHeaders</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Strategy/JsonStrategy.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$headers</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>addHeaderLine</code>
       <code>addHeaderLine</code>
     </MixedMethodCall>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>setContent</code>
     </PossiblyNullReference>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(string) $charset</code>
     </RedundantCastGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>getHeaders</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Strategy/PhpRendererStrategy.php">
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$placeholders</code>
       <code>$result</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>containerExists</code>
       <code>getContainer</code>
     </MixedMethodCall>
-    <MixedPropertyTypeCoercion occurrences="1">
+    <MixedPropertyTypeCoercion>
       <code>$contentPlaceholders</code>
     </MixedPropertyTypeCoercion>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>plugin</code>
     </PossiblyNullReference>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Stream.php">
-    <MissingConstructor occurrences="2">
+    <MissingConstructor>
       <code>$data</code>
       <code>$stat</code>
     </MissingConstructor>
-    <MissingParamType occurrences="5">
+    <MissingParamType>
       <code>$mode</code>
       <code>$offset</code>
       <code>$opened_path</code>
       <code>$options</code>
       <code>$whence</code>
     </MissingParamType>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$this-&gt;pos</code>
       <code>$this-&gt;pos</code>
       <code>$this-&gt;pos</code>
     </MixedAssignment>
-    <MixedOperand occurrences="3">
+    <MixedOperand>
       <code>$offset</code>
       <code>$offset</code>
       <code>$offset</code>
     </MixedOperand>
-    <UnevaluatedCode occurrences="3">
+    <UnevaluatedCode>
       <code>break;</code>
       <code>break;</code>
       <code>break;</code>
     </UnevaluatedCode>
   </file>
   <file src="src/Variables.php">
-    <InvalidCast occurrences="1">
+    <InvalidCast>
       <code>ArrayIterator::class</code>
     </InvalidCast>
-    <MissingTemplateParam occurrences="1">
+    <MissingTemplateParam>
       <code>Variables</code>
     </MissingTemplateParam>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$key</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$key</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment>
       <code>$return</code>
       <code>$return</code>
       <code>$spec</code>
@@ -2066,84 +2065,84 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $flag</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/View.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>View</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$options</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="1">
+    <MissingClosureParamType>
       <code>$result</code>
     </MissingClosureParamType>
-    <MissingConstructor occurrences="3">
+    <MissingConstructor>
       <code>$events</code>
       <code>$request</code>
       <code>$response</code>
     </MissingConstructor>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$child</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$child</code>
       <code>$oldResult</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>setOption</code>
       <code>terminate</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$oldResult</code>
     </MixedOperand>
-    <ParamNameMismatch occurrences="1">
+    <ParamNameMismatch>
       <code>$events</code>
     </ParamNameMismatch>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>hasChildren</code>
     </PossiblyNullReference>
   </file>
   <file src="src/ViewEvent.php">
-    <ImplementedReturnTypeMismatch occurrences="2">
+    <ImplementedReturnTypeMismatch>
       <code>ViewEvent</code>
       <code>ViewEvent</code>
     </ImplementedReturnTypeMismatch>
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$params['result']</code>
     </MixedAssignment>
-    <MoreSpecificImplementedParamType occurrences="2">
+    <MoreSpecificImplementedParamType>
       <code>$name</code>
       <code>$name</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="test/Helper/CycleTest.php">
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(string) $this-&gt;helper-&gt;toString()</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="test/Helper/DeclareVarsTest.php">
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$vars</code>
       <code>$vars</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>setStrictVars</code>
     </MixedMethodCall>
-    <MixedPropertyAssignment occurrences="3">
+    <MixedPropertyAssignment>
       <code>$vars</code>
       <code>$vars</code>
       <code>$vars</code>
     </MixedPropertyAssignment>
-    <MixedPropertyFetch occurrences="9">
+    <MixedPropertyFetch>
       <code>$vars-&gt;varName1</code>
       <code>$vars-&gt;varName1</code>
       <code>$vars-&gt;varName2</code>
@@ -2154,15 +2153,15 @@
       <code>$vars-&gt;varName4</code>
       <code>$vars-&gt;varName5</code>
     </MixedPropertyFetch>
-    <PossiblyInvalidMethodCall occurrences="1">
+    <PossiblyInvalidMethodCall>
       <code>addPath</code>
     </PossiblyInvalidMethodCall>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>addPath</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Helper/EscapeCssTest.php">
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$test</code>
       <code>$test</code>
       <code>$test</code>
@@ -2170,7 +2169,7 @@
     </MixedAssignment>
   </file>
   <file src="test/Helper/EscapeHtmlAttrTest.php">
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$test</code>
       <code>$test</code>
       <code>$test</code>
@@ -2178,7 +2177,7 @@
     </MixedAssignment>
   </file>
   <file src="test/Helper/EscapeHtmlTest.php">
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$test</code>
       <code>$test</code>
       <code>$test</code>
@@ -2186,7 +2185,7 @@
     </MixedAssignment>
   </file>
   <file src="test/Helper/EscapeJsTest.php">
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$test</code>
       <code>$test</code>
       <code>$test</code>
@@ -2194,7 +2193,7 @@
     </MixedAssignment>
   </file>
   <file src="test/Helper/EscapeUrlTest.php">
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$test</code>
       <code>$test</code>
       <code>$test</code>
@@ -2202,12 +2201,12 @@
     </MixedAssignment>
   </file>
   <file src="test/Helper/FlashMessengerTest.php">
-    <ArgumentTypeCoercion occurrences="3">
+    <ArgumentTypeCoercion>
       <code>$plugin</code>
       <code>$plugin</code>
       <code>$this-&gt;mvcPluginClass</code>
     </ArgumentTypeCoercion>
-    <DeprecatedClass occurrences="7">
+    <DeprecatedClass>
       <code>FlashMessenger</code>
       <code>new FlashMessenger()</code>
       <code>new FlashMessenger()</code>
@@ -2216,7 +2215,7 @@
       <code>new FlashMessenger()</code>
       <code>new FlashMessenger()</code>
     </DeprecatedClass>
-    <MixedAssignment occurrences="12">
+    <MixedAssignment>
       <code>$displayInfo</code>
       <code>$displayInfo</code>
       <code>$displayInfo</code>
@@ -2230,7 +2229,7 @@
       <code>$helperPluginManager</code>
       <code>$helperPluginManager</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="8">
+    <MixedMethodCall>
       <code>get</code>
       <code>get</code>
       <code>get</code>
@@ -2240,7 +2239,7 @@
       <code>renderCurrent</code>
       <code>renderCurrent</code>
     </MixedMethodCall>
-    <PossiblyInvalidMethodCall occurrences="13">
+    <PossiblyInvalidMethodCall>
       <code>hasCurrentErrorMessages</code>
       <code>hasCurrentInfoMessages</code>
       <code>hasCurrentMessages</code>
@@ -2257,21 +2256,21 @@
     </PossiblyInvalidMethodCall>
   </file>
   <file src="test/Helper/GravatarTest.php">
-    <PossiblyInvalidArgument occurrences="3">
+    <PossiblyInvalidArgument>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </PossiblyInvalidArgument>
-    <UndefinedMethod occurrences="1">
+    <UndefinedMethod>
       <code>gravatar</code>
     </UndefinedMethod>
   </file>
   <file src="test/Helper/HeadLinkTest.php">
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>'foo'</code>
       <code>'foo'</code>
     </InvalidArgument>
-    <MixedArgument occurrences="15">
+    <MixedArgument>
       <code>$attributeEscaper('/styles.css')</code>
       <code>$attributeEscaper('/styles.css')</code>
       <code>$attributeEscaper('/styles.css')</code>
@@ -2288,12 +2287,12 @@
       <code>$item</code>
       <code>$item</code>
     </MixedArgument>
-    <MixedArrayOffset occurrences="3">
+    <MixedArrayOffset>
       <code>$order[$key]</code>
       <code>$order[$key]</code>
       <code>$order[$key]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="16">
+    <MixedAssignment>
       <code>$item</code>
       <code>$item</code>
       <code>$item</code>
@@ -2311,10 +2310,10 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>iterable</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="11">
+    <MixedOperand>
       <code>$attributeEscaper($link['href'])</code>
       <code>$attributeEscaper($link['href'])</code>
       <code>$attributeEscaper($link['href'])</code>
@@ -2327,7 +2326,7 @@
       <code>$attributeEscaper('/foo/bar')</code>
       <code>$attributeEscaper('/foo/bar')</code>
     </MixedOperand>
-    <MixedPropertyFetch occurrences="11">
+    <MixedPropertyFetch>
       <code>$item-&gt;conditionalStylesheet</code>
       <code>$item-&gt;conditionalStylesheet</code>
       <code>$item-&gt;conditionalStylesheet</code>
@@ -2340,7 +2339,7 @@
       <code>$value-&gt;href</code>
       <code>$value-&gt;href</code>
     </MixedPropertyFetch>
-    <UndefinedMagicMethod occurrences="11">
+    <UndefinedMagicMethod>
       <code>appendNext</code>
       <code>appendPrev</code>
       <code>bogusMethod</code>
@@ -2355,13 +2354,13 @@
     </UndefinedMagicMethod>
   </file>
   <file src="test/Helper/HeadMetaTest.php">
-    <InvalidArgument occurrences="4">
+    <InvalidArgument>
       <code>'foo'</code>
       <code>'foo'</code>
       <code>'foo'</code>
       <code>[$this, 'handleErrors']</code>
     </InvalidArgument>
-    <MixedArgument occurrences="31">
+    <MixedArgument>
       <code>$attributeEscaper('HeadMeta with Microdata')</code>
       <code>$attributeEscaper('og:title')</code>
       <code>$attributeEscaper('some content')</code>
@@ -2394,13 +2393,13 @@
       <code>$values</code>
       <code>$values</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="4">
+    <MixedArrayAccess>
       <code>$modifiers['lang']</code>
       <code>$modifiers['scheme']</code>
       <code>$values[$i]</code>
       <code>$values[100]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="12">
+    <MixedAssignment>
       <code>$item</code>
       <code>$item</code>
       <code>$item</code>
@@ -2414,11 +2413,11 @@
       <code>$values</code>
       <code>$values</code>
     </MixedAssignment>
-    <MixedOperand occurrences="2">
+    <MixedOperand>
       <code>$attributeEscaper('boo bah')</code>
       <code>$attributeEscaper('foo bar')</code>
     </MixedOperand>
-    <MixedPropertyFetch occurrences="16">
+    <MixedPropertyFetch>
       <code>$item-&gt;content</code>
       <code>$item-&gt;content</code>
       <code>$item-&gt;content</code>
@@ -2436,7 +2435,7 @@
       <code>$item-&gt;{$item-&gt;type}</code>
       <code>$value-&gt;modifiers</code>
     </MixedPropertyFetch>
-    <UndefinedMagicMethod occurrences="12">
+    <UndefinedMagicMethod>
       <code>getArrayCopy</code>
       <code>getArrayCopy</code>
       <code>getArrayCopy</code>
@@ -2452,10 +2451,10 @@
     </UndefinedMagicMethod>
   </file>
   <file src="test/Helper/HeadScriptTest.php">
-    <InvalidDocblock occurrences="1">
+    <InvalidDocblock>
       <code>public function booleanAttributeDataProvider(): Generator</code>
     </InvalidDocblock>
-    <MixedArgument occurrences="16">
+    <MixedArgument>
       <code>$attributeEscaper('test1.js')</code>
       <code>$attributeEscaper('test2.js')</code>
       <code>$attributeEscaper('test3.js')</code>
@@ -2473,7 +2472,7 @@
       <code>$values</code>
       <code>$values</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="14">
+    <MixedArrayAccess>
       <code>$first-&gt;attributes['src']</code>
       <code>$items[$i]</code>
       <code>$values[$i]</code>
@@ -2489,7 +2488,7 @@
       <code>$values[5]</code>
       <code>$values[5]-&gt;attributes['src']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment>
       <code>$first</code>
       <code>$item</code>
       <code>$item</code>
@@ -2500,10 +2499,10 @@
       <code>$values</code>
       <code>$values</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>Generator&lt;string, array&lt;int, string&gt;</code>
     </MixedInferredReturnType>
-    <MixedPropertyFetch occurrences="16">
+    <MixedPropertyFetch>
       <code>$first-&gt;attributes</code>
       <code>$first-&gt;source</code>
       <code>$first-&gt;type</code>
@@ -2521,7 +2520,7 @@
       <code>$values[5]-&gt;source</code>
       <code>$values[5]-&gt;type</code>
     </MixedPropertyFetch>
-    <UndefinedMagicMethod occurrences="8">
+    <UndefinedMagicMethod>
       <code>getArrayCopy</code>
       <code>getArrayCopy</code>
       <code>getArrayCopy</code>
@@ -2533,7 +2532,7 @@
     </UndefinedMagicMethod>
   </file>
   <file src="test/Helper/HeadStyleTest.php">
-    <MixedArgument occurrences="14">
+    <MixedArgument>
       <code>$item-&gt;content</code>
       <code>$item-&gt;content</code>
       <code>$value</code>
@@ -2549,13 +2548,13 @@
       <code>$values[1]-&gt;content</code>
       <code>$values[2]-&gt;content</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="4">
+    <MixedArrayAccess>
       <code>$values[$i]</code>
       <code>$values[0]</code>
       <code>$values[1]</code>
       <code>$values[2]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment>
       <code>$item</code>
       <code>$item</code>
       <code>$value</code>
@@ -2565,7 +2564,7 @@
       <code>$values</code>
       <code>$values</code>
     </MixedAssignment>
-    <MixedPropertyFetch occurrences="6">
+    <MixedPropertyFetch>
       <code>$item-&gt;content</code>
       <code>$item-&gt;content</code>
       <code>$value-&gt;attributes</code>
@@ -2573,7 +2572,7 @@
       <code>$values[1]-&gt;content</code>
       <code>$values[2]-&gt;content</code>
     </MixedPropertyFetch>
-    <UndefinedMagicMethod occurrences="11">
+    <UndefinedMagicMethod>
       <code>bogusMethod</code>
       <code>getArrayCopy</code>
       <code>getArrayCopy</code>
@@ -2588,77 +2587,77 @@
     </UndefinedMagicMethod>
   </file>
   <file src="test/Helper/HeadTitleTest.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$placeholder</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>renderTitle</code>
     </MixedMethodCall>
   </file>
   <file src="test/Helper/HtmlFlashTest.php">
-    <DeprecatedClass occurrences="1">
+    <DeprecatedClass>
       <code>HtmlFlash</code>
     </DeprecatedClass>
   </file>
   <file src="test/Helper/HtmlTagTest.php">
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$escape($value)</code>
       <code>$escape($value)</code>
       <code>$escape('http://www.w3.org/1999/xhtml')</code>
     </MixedArgument>
   </file>
   <file src="test/Helper/Navigation/AbstractHelperTest.php">
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$acl</code>
       <code>$acl</code>
       <code>$this-&gt;serviceManager-&gt;get('Navigation')</code>
     </MixedArgument>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$acl</code>
       <code>$acl</code>
       <code>$role</code>
       <code>$role</code>
     </MixedAssignment>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <NonInvariantDocblockPropertyType>
       <code>$_helper</code>
     </NonInvariantDocblockPropertyType>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>$this-&gt;_helper</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/Helper/Navigation/AbstractTest.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$app</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="4">
+    <MixedMethodCall>
       <code>bootstrap</code>
       <code>getMvcEvent</code>
       <code>loadModules</code>
       <code>setRouteMatch</code>
     </MixedMethodCall>
-    <NullArgument occurrences="3">
+    <NullArgument>
       <code>null</code>
       <code>null</code>
       <code>null</code>
     </NullArgument>
-    <TooManyArguments occurrences="1">
+    <TooManyArguments>
       <code>new GenericResource('admin_foo', 'member_foo')</code>
     </TooManyArguments>
   </file>
   <file src="test/Helper/Navigation/BreadcrumbsTest.php">
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>'Navigation'</code>
       <code>'Navigation'</code>
     </InvalidArgument>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$acl['acl']</code>
     </MixedArgument>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <NonInvariantDocblockPropertyType>
       <code>$_helper</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="test/Helper/Navigation/LinksTest.php">
-    <MixedArgument occurrences="10">
+    <MixedArgument>
       <code>$active</code>
       <code>$active</code>
       <code>$active</code>
@@ -2670,7 +2669,7 @@
       <code>$found</code>
       <code>$found</code>
     </MixedArgument>
-    <MixedAssignment occurrences="63">
+    <MixedAssignment>
       <code>$active</code>
       <code>$active</code>
       <code>$active</code>
@@ -2735,7 +2734,7 @@
       <code>$page</code>
       <code>$page</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="36">
+    <MixedMethodCall>
       <code>addRel</code>
       <code>addRel</code>
       <code>addRel</code>
@@ -2773,122 +2772,142 @@
       <code>setActive</code>
       <code>setActive</code>
     </MixedMethodCall>
-    <MixedPropertyAssignment occurrences="5">
+    <MixedPropertyAssignment>
       <code>$active</code>
       <code>$active</code>
       <code>$active</code>
       <code>$page</code>
       <code>$page</code>
     </MixedPropertyAssignment>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <NonInvariantDocblockPropertyType>
       <code>$_helper</code>
     </NonInvariantDocblockPropertyType>
-    <PossiblyInvalidMethodCall occurrences="3">
+    <PossiblyInvalidMethodCall>
       <code>getHref</code>
       <code>getLabel</code>
       <code>getLabel</code>
     </PossiblyInvalidMethodCall>
-    <PossiblyNullReference occurrences="3">
+    <PossiblyNullReference>
       <code>getHref</code>
       <code>getLabel</code>
       <code>getLabel</code>
     </PossiblyNullReference>
-    <UnusedForeachValue occurrences="2">
+    <UnusedForeachValue>
       <code>$discard</code>
       <code>$discard</code>
     </UnusedForeachValue>
   </file>
   <file src="test/Helper/Navigation/MenuTest.php">
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>'Navigation'</code>
       <code>'Navigation'</code>
     </InvalidArgument>
-    <MixedArgument occurrences="5">
+    <MixedArgument>
       <code>$acl['acl']</code>
       <code>$acl['acl']</code>
       <code>$acl['acl']</code>
       <code>$acl['acl']</code>
       <code>$acl['acl']</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$p</code>
       <code>$page</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall>
       <code>getRole</code>
       <code>setActive</code>
       <code>setActive</code>
     </MixedMethodCall>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <NonInvariantDocblockPropertyType>
       <code>$_helper</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="test/Helper/Navigation/NavigationTest.php">
-    <InvalidArgument occurrences="1"/>
-    <MixedArgument occurrences="3">
+    <InvalidArgument>
+      <code>function (int $code, string $message) {
+            $this-&gt;errorHandlerMessage = $message;
+        }</code>
+    </InvalidArgument>
+    <MixedArgument>
       <code>$acl['acl']</code>
       <code>$acl['acl']</code>
       <code>$acl['acl']</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$actual</code>
       <code>$creationContextValue</code>
       <code>$expected</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall>
       <code>getContainer</code>
       <code>getContainer</code>
       <code>getContainer</code>
     </MixedMethodCall>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <NonInvariantDocblockPropertyType>
       <code>$_helper</code>
     </NonInvariantDocblockPropertyType>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$this-&gt;errorHandlerMessage</code>
     </PossiblyNullArgument>
-    <TooManyArguments occurrences="1"/>
-    <UndefinedClass occurrences="1">
+    <TooManyArguments>
+      <code>new Page\Uri([
+                'resource'  =&gt; 'unknownresource',
+                'privilege' =&gt; 'someprivilege',
+            ], false)</code>
+    </TooManyArguments>
+    <UndefinedClass>
       <code>PsrContainerDecorator</code>
     </UndefinedClass>
-    <UnusedClosureParam occurrences="1">
+    <UnusedClosureParam>
       <code>$code</code>
     </UnusedClosureParam>
   </file>
   <file src="test/Helper/Navigation/SitemapTest.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$acl['acl']</code>
       <code>$acl['acl']</code>
     </MixedArgument>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>setBasePath</code>
     </MixedMethodCall>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <NonInvariantDocblockPropertyType>
       <code>$_helper</code>
     </NonInvariantDocblockPropertyType>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>plugin</code>
     </PossiblyNullReference>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
-    <UnevaluatedCode occurrences="4">
+    <UnevaluatedCode>
       <code>$nav = clone $this-&gt;nav2;</code>
       <code>$nav-&gt;addPage(['label' =&gt; 'Invalid', 'uri' =&gt; 'http://w.']);</code>
       <code>static::fail('A Laminas\View\Exception\InvalidArgumentException was not thrown on invalid &lt;loc /&gt;');</code>
+      <code>try {
+            $this-&gt;_helper-&gt;render($nav);
+        } catch (View\Exception\ExceptionInterface $e) {
+            $expected = sprintf(
+                'Encountered an invalid URL for Sitemap XML: "%s"',
+                'http://w.'
+            );
+            $actual   = $e-&gt;getMessage();
+            static::assertEquals($expected, $actual);
+            return;
+        }</code>
     </UnevaluatedCode>
   </file>
   <file src="test/Helper/PaginationControlTest.php">
-    <InvalidArgument occurrences="3">
+    <InvalidArgument>
       <code>$all</code>
       <code>$paginator</code>
       <code>['partial.phtml', 'test']</code>
     </InvalidArgument>
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>null</code>
     </NullArgument>
   </file>
   <file src="test/Helper/PartialLoopTest.php">
-    <InvalidArgument occurrences="18">
+    <InvalidArgument>
       <code>$o</code>
       <code>$o</code>
       <code>$o</code>
@@ -2908,11 +2927,11 @@
       <code>new stdClass()</code>
       <code>new stdClass()</code>
     </InvalidArgument>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment>
       <code>$key</code>
       <code>$key</code>
       <code>$key</code>
@@ -2922,7 +2941,7 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedOperand occurrences="6">
+    <MixedOperand>
       <code>$item-&gt;message</code>
       <code>$item-&gt;message</code>
       <code>$item-&gt;objectKey</code>
@@ -2930,13 +2949,13 @@
       <code>$value</code>
       <code>$value</code>
     </MixedOperand>
-    <PossiblyFalseIterator occurrences="4">
+    <PossiblyFalseIterator>
       <code>$item</code>
       <code>$item</code>
       <code>$item</code>
       <code>$item</code>
     </PossiblyFalseIterator>
-    <PossiblyInvalidArgument occurrences="15">
+    <PossiblyInvalidArgument>
       <code>$result</code>
       <code>$result</code>
       <code>$result</code>
@@ -2953,7 +2972,7 @@
       <code>$result</code>
       <code>$result</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="15">
+    <PossiblyInvalidCast>
       <code>$result</code>
       <code>$result</code>
       <code>$result</code>
@@ -2970,7 +2989,7 @@
       <code>$result</code>
       <code>$result</code>
     </PossiblyInvalidCast>
-    <PossiblyInvalidMethodCall occurrences="28">
+    <PossiblyInvalidMethodCall>
       <code>addPath</code>
       <code>addPath</code>
       <code>addPath</code>
@@ -3000,11 +3019,11 @@
       <code>addPath</code>
       <code>addPath</code>
     </PossiblyInvalidMethodCall>
-    <TooManyArguments occurrences="2">
+    <TooManyArguments>
       <code>new TestAsset\BogusIteratorTest($data)</code>
       <code>new TestAsset\BogusIteratorTest($data)</code>
     </TooManyArguments>
-    <UndefinedInterfaceMethod occurrences="28">
+    <UndefinedInterfaceMethod>
       <code>addPath</code>
       <code>addPath</code>
       <code>addPath</code>
@@ -3034,11 +3053,11 @@
       <code>addPath</code>
       <code>addPath</code>
     </UndefinedInterfaceMethod>
-    <UndefinedPropertyFetch occurrences="2">
+    <UndefinedPropertyFetch>
       <code>$item-&gt;message</code>
       <code>$item-&gt;message</code>
     </UndefinedPropertyFetch>
-    <UnusedVariable occurrences="6">
+    <UnusedVariable>
       <code>$data</code>
       <code>$data</code>
       <code>$key</code>
@@ -3048,28 +3067,28 @@
     </UnusedVariable>
   </file>
   <file src="test/Helper/PartialTest.php">
-    <MixedArgument occurrences="5">
+    <MixedArgument>
       <code>$key</code>
       <code>$key</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$key</code>
       <code>$key</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedPropertyAssignment occurrences="1">
+    <MixedPropertyAssignment>
       <code>$view-&gt;vars()</code>
     </MixedPropertyAssignment>
-    <PossibleRawObjectIteration occurrences="2">
+    <PossibleRawObjectIteration>
       <code>$model-&gt;getVariables()</code>
       <code>$model-&gt;getVariables()</code>
     </PossibleRawObjectIteration>
-    <PossiblyInvalidArgument occurrences="9">
+    <PossiblyInvalidArgument>
       <code>$return</code>
       <code>$return</code>
       <code>$return</code>
@@ -3080,7 +3099,7 @@
       <code>$return</code>
       <code>$return</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="9">
+    <PossiblyInvalidCast>
       <code>$return</code>
       <code>$return</code>
       <code>$return</code>
@@ -3091,7 +3110,7 @@
       <code>$return</code>
       <code>$return</code>
     </PossiblyInvalidCast>
-    <PossiblyInvalidMethodCall occurrences="7">
+    <PossiblyInvalidMethodCall>
       <code>addPath</code>
       <code>addPath</code>
       <code>addPath</code>
@@ -3100,7 +3119,7 @@
       <code>addPath</code>
       <code>addPath</code>
     </PossiblyInvalidMethodCall>
-    <UndefinedInterfaceMethod occurrences="7">
+    <UndefinedInterfaceMethod>
       <code>addPath</code>
       <code>addPath</code>
       <code>addPath</code>
@@ -3111,91 +3130,85 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Helper/Placeholder/RegistryTest.php">
-    <UndefinedPropertyFetch occurrences="1">
+    <UndefinedPropertyFetch>
       <code>$container-&gt;data</code>
     </UndefinedPropertyFetch>
   </file>
   <file src="test/Helper/ServerUrlTest.php">
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>1337</code>
       <code>new stdClass()</code>
     </InvalidArgument>
   </file>
   <file src="test/Helper/TestAsset/ArrayTranslator.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$this-&gt;translations</code>
     </InvalidArgument>
   </file>
   <file src="test/Helper/TestAsset/Bar.php">
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>Bar</code>
       <code>Bar</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/Helper/TestAsset/IteratorTest.php">
-    <MissingTemplateParam occurrences="1">
+    <MissingTemplateParam>
       <code>Iterator</code>
     </MissingTemplateParam>
   </file>
   <file src="test/Helper/TestAsset/IteratorWithToArrayTest.php">
-    <MissingTemplateParam occurrences="1">
+    <MissingTemplateParam>
       <code>Iterator</code>
     </MissingTemplateParam>
   </file>
   <file src="test/Helper/TestAsset/IteratorWithToArrayTestContainer.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
   </file>
   <file src="test/Helper/TestAsset/MockContainer.php">
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>MockContainer</code>
       <code>MockContainer</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/Helper/TestAsset/RecursiveIteratorTest.php">
-    <MissingTemplateParam occurrences="1">
+    <MissingTemplateParam>
       <code>Iterator</code>
     </MissingTemplateParam>
   </file>
   <file src="test/Helper/UrlIntegrationTest.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$serviceConfig</code>
       <code>$test</code>
     </MixedArgument>
-    <MixedAssignment occurrences="11">
+    <MixedAssignment>
       <code>$router</code>
       <code>$serviceConfig</code>
       <code>$test</code>
       <code>$test</code>
-      <code>$test</code>
       <code>$urlHelper</code>
       <code>$urlHelper</code>
-      <code>$urlHelper</code>
-      <code>$viewHelpers</code>
       <code>$viewHelpers</code>
       <code>$viewHelpers</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="3">
-      <code>$urlHelper('test')</code>
+    <MixedFunctionCall>
       <code>$urlHelper('test')</code>
       <code>$urlHelper('test', [], ['force_canonical' =&gt; true])</code>
     </MixedFunctionCall>
-    <MixedMethodCall occurrences="7">
+    <MixedMethodCall>
       <code>bootstrap</code>
       <code>bootstrap</code>
-      <code>bootstrap</code>
-      <code>get</code>
       <code>get</code>
       <code>get</code>
       <code>setRequestUri</code>
     </MixedMethodCall>
   </file>
   <file src="test/Helper/UrlTest.php">
-    <DeprecatedClass occurrences="1">
+    <DeprecatedClass>
       <code>Wildcard::class</code>
     </DeprecatedClass>
-    <InvalidArgument occurrences="6">
+    <InvalidArgument>
       <code>$it</code>
       <code>$router</code>
       <code>$router</code>
@@ -3205,55 +3218,81 @@
     </InvalidArgument>
   </file>
   <file src="test/HelperPluginManagerCompatibilityTest.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$target</code>
       <code>$target</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$alias</code>
       <code>$aliases</code>
       <code>$target</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>Generator&lt;mixed, array{0: mixed, 1: mixed}, mixed, void&gt;</code>
     </MixedInferredReturnType>
   </file>
   <file src="test/HelperPluginManagerTest.php">
-    <MissingClosureParamType occurrences="2">
+    <MissingClosureParamType>
       <code>$container</code>
       <code>$container</code>
     </MissingClosureParamType>
-    <UnusedClosureParam occurrences="2">
+    <UnusedClosureParam>
       <code>$container</code>
       <code>$container</code>
     </UnusedClosureParam>
   </file>
   <file src="test/Model/TestAsset/Variable.php">
-    <MissingTemplateParam occurrences="1">
+    <MissingTemplateParam>
       <code>Iterator</code>
     </MissingTemplateParam>
   </file>
   <file src="test/Model/ViewModelTest.php">
-    <InvalidArgument occurrences="3">
+    <InvalidArgument>
       <code>$vars</code>
       <code>new stdClass()</code>
       <code>new stdClass()</code>
     </InvalidArgument>
-    <LessSpecificReturnStatement occurrences="1"/>
-    <MoreSpecificReturnType occurrences="1"/>
-    <PossiblyInvalidArrayAccess occurrences="1">
+    <LessSpecificReturnStatement>
+      <code>[
+            // variables                     default   expected
+
+            // if it is set always get the value
+            [['foo' =&gt; 'bar'], 'baz', 'bar'],
+            [['foo' =&gt; 'bar'], null, 'bar'],
+            [new ArrayObject(['foo' =&gt; 'bar']), 'baz', 'bar'],
+            [new ArrayObject(['foo' =&gt; 'bar']), null, 'bar'],
+
+            // if it is null always get null value
+            [['foo' =&gt; null], null, null],
+            [['foo' =&gt; null], 'baz', null],
+            [new ArrayObject(['foo' =&gt; null]), null, null],
+            [new ArrayObject(['foo' =&gt; null]), 'baz', null],
+
+            // when it is not set always get default value
+            [[], 'baz', 'baz'],
+            [new ArrayObject(),                 'baz', 'baz'],
+        ]</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType>
+      <code>array&lt;array-key, array{
+     *     0: array&lt;string, null|string&gt;|ArrayObject&lt;string, null|string&gt;,
+     *     1: null|string,
+     *     2: null|string
+     * }&gt;</code>
+    </MoreSpecificReturnType>
+    <PossiblyInvalidArrayAccess>
       <code>$variables['foo']</code>
     </PossiblyInvalidArrayAccess>
   </file>
   <file src="test/PhpRendererTest.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$content</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$foo</code>
       <code>$return</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="7">
+    <MixedMethodCall>
       <code>assign</code>
       <code>assign</code>
       <code>assign</code>
@@ -3262,19 +3301,19 @@
       <code>getArrayCopy</code>
       <code>getArrayCopy</code>
     </MixedMethodCall>
-    <MixedPropertyFetch occurrences="1">
+    <MixedPropertyFetch>
       <code>$this-&gt;renderer-&gt;vars()-&gt;foo</code>
     </MixedPropertyFetch>
-    <PossiblyInvalidArrayAssignment occurrences="1">
+    <PossiblyInvalidArrayAssignment>
       <code>$vars['foo']</code>
     </PossiblyInvalidArrayAssignment>
-    <UnusedClosureParam occurrences="2">
+    <UnusedClosureParam>
       <code>$errno</code>
       <code>$errstr</code>
     </UnusedClosureParam>
   </file>
   <file src="test/Renderer/JsonRendererTest.php">
-    <InvalidArgument occurrences="9">
+    <InvalidArgument>
       <code>$model</code>
       <code>$model</code>
       <code>$model</code>
@@ -3285,36 +3324,36 @@
       <code>false</code>
       <code>false</code>
     </InvalidArgument>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$model</code>
     </MixedArgument>
   </file>
   <file src="test/Resolver/RelativeFallbackResolverTest.php">
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$test</code>
       <code>$test</code>
     </MixedAssignment>
   </file>
   <file src="test/Strategy/FeedStrategyTest.php">
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$listener</code>
       <code>$listener</code>
       <code>$priority</code>
       <code>$priority</code>
     </MixedAssignment>
-    <PossiblyInvalidMethodCall occurrences="3">
+    <PossiblyInvalidMethodCall>
       <code>addHeaderLine</code>
       <code>addHeaderLine</code>
       <code>addHeaderLine</code>
     </PossiblyInvalidMethodCall>
-    <PossiblyUndefinedMethod occurrences="3">
+    <PossiblyUndefinedMethod>
       <code>addHeaderLine</code>
       <code>addHeaderLine</code>
       <code>addHeaderLine</code>
     </PossiblyUndefinedMethod>
   </file>
   <file src="test/Strategy/JsonStrategyTest.php">
-    <MixedArgument occurrences="6">
+    <MixedArgument>
       <code>$headers-&gt;get('content-type')-&gt;getFieldValue()</code>
       <code>$headers-&gt;get('content-type')-&gt;getFieldValue()</code>
       <code>$headers-&gt;get('content-type')-&gt;getFieldValue()</code>
@@ -3322,7 +3361,7 @@
       <code>$headers-&gt;get('content-type')-&gt;getFieldValue()</code>
       <code>$headers-&gt;get('content-type')-&gt;getFieldValue()</code>
     </MixedArgument>
-    <MixedAssignment occurrences="10">
+    <MixedAssignment>
       <code>$content</code>
       <code>$content</code>
       <code>$content</code>
@@ -3334,7 +3373,7 @@
       <code>$priority</code>
       <code>$priority</code>
     </MixedAssignment>
-    <PossiblyInvalidMethodCall occurrences="10">
+    <PossiblyInvalidMethodCall>
       <code>addHeaderLine</code>
       <code>addHeaderLine</code>
       <code>addHeaderLine</code>
@@ -3346,7 +3385,7 @@
       <code>getFieldValue</code>
       <code>getFieldValue</code>
     </PossiblyInvalidMethodCall>
-    <PossiblyUndefinedMethod occurrences="10">
+    <PossiblyUndefinedMethod>
       <code>addHeaderLine</code>
       <code>addHeaderLine</code>
       <code>addHeaderLine</code>
@@ -3358,18 +3397,18 @@
       <code>getFieldValue</code>
       <code>getFieldValue</code>
     </PossiblyUndefinedMethod>
-    <UnusedMethodCall occurrences="1">
+    <UnusedMethodCall>
       <code>getContent</code>
     </UnusedMethodCall>
   </file>
   <file src="test/Strategy/PhpRendererStrategyTest.php">
-    <InvalidArgument occurrences="4">
+    <InvalidArgument>
       <code>$e</code>
       <code>$event</code>
       <code>$event</code>
       <code>$event</code>
     </InvalidArgument>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment>
       <code>$content</code>
       <code>$content</code>
       <code>$content</code>
@@ -3380,7 +3419,7 @@
     </MixedAssignment>
   </file>
   <file src="test/ViewTest.php">
-    <MissingClosureParamType occurrences="11">
+    <MissingClosureParamType>
       <code>$e</code>
       <code>$e</code>
       <code>$e</code>
@@ -3393,14 +3432,14 @@
       <code>$e</code>
       <code>$e</code>
     </MissingClosureParamType>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$result-&gt;content</code>
       <code>$this-&gt;result-&gt;content</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$result[]</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="7">
+    <MixedMethodCall>
       <code>getModel</code>
       <code>getModel</code>
       <code>getResult</code>
@@ -3409,10 +3448,10 @@
       <code>getResult</code>
       <code>getResult</code>
     </MixedMethodCall>
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>null</code>
     </NullArgument>
-    <UnusedClosureParam occurrences="4">
+    <UnusedClosureParam>
       <code>$e</code>
       <code>$e</code>
       <code>$e</code>

--- a/src/Helper/Navigation/AbstractHelper.php
+++ b/src/Helper/Navigation/AbstractHelper.php
@@ -411,6 +411,10 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
             'target' => $page->getTarget(),
         ];
 
+        if ($page->isActive()) {
+            $attribs['aria-current'] = 'page';
+        }
+
         /** @var View\Helper\EscapeHtml $escaper */
         $escaper = $this->view->plugin('escapeHtml');
         $label   = $escaper($label);

--- a/src/Helper/Navigation/Breadcrumbs.php
+++ b/src/Helper/Navigation/Breadcrumbs.php
@@ -111,9 +111,13 @@ class Breadcrumbs extends AbstractHelper
         } else {
             /** @var View\Helper\EscapeHtml $escaper */
             $escaper = $this->view->plugin('escapeHtml');
-            $html    = $escaper(
+            $label   = $escaper(
                 $this->translate($active->getLabel(), $active->getTextDomain())
             );
+            $attribs = [
+                'aria-current' => 'page',
+            ];
+            $html    = '<span' . $this->htmlAttribs($attribs) . '>' . $label . '</span>';
         }
 
         // walk back to root

--- a/src/Helper/Navigation/Menu.php
+++ b/src/Helper/Navigation/Menu.php
@@ -507,6 +507,10 @@ class Menu extends AbstractHelper
             $element = 'span';
         }
 
+        if ($page->isActive()) {
+            $attribs['aria-current'] = 'page';
+        }
+
         $html  = '<' . $element . $this->htmlAttribs($attribs) . '>';
         $label = $this->translate($page->getLabel(), $page->getTextDomain());
 

--- a/test/Helper/Navigation/BreadcrumbsTest.php
+++ b/test/Helper/Navigation/BreadcrumbsTest.php
@@ -124,7 +124,7 @@ class BreadcrumbsTest extends AbstractTest
         $this->_helper->setMinDepth(0);
 
         $rendered1 = $this->getExpectedFileContents('bc/default.html');
-        $rendered2 = 'Site 2';
+        $rendered2 = '<span aria-current="page">Site 2</span>';
 
         $expected = [
             'registered'       => $rendered1,
@@ -249,7 +249,7 @@ class BreadcrumbsTest extends AbstractTest
             ],
         ]);
 
-        $expected = 'Live &amp; Learn';
+        $expected = '<span aria-current="page">Live &amp; Learn</span>';
         $actual   = $this->_helper->setMinDepth(0)->render($container);
 
         $this->assertEquals($expected, $actual);

--- a/test/Helper/Navigation/_files/expected/bc/acl.html
+++ b/test/Helper/Navigation/_files/expected/bc/acl.html
@@ -1,1 +1,1 @@
-<a href="page2">Page 2</a> &gt; <a href="page2&#x2F;page2_2">Page 2.2</a> &gt; Page 2.2.2
+<a href="page2">Page 2</a> &gt; <a href="page2&#x2F;page2_2">Page 2.2</a> &gt; <span aria-current="page">Page 2.2.2</span>

--- a/test/Helper/Navigation/_files/expected/bc/default.html
+++ b/test/Helper/Navigation/_files/expected/bc/default.html
@@ -1,1 +1,1 @@
-<a href="page2">Page 2</a> &gt; <a href="page2&#x2F;page2_3">Page 2.3</a> &gt; <a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a> &gt; Page 2.3.3.1
+<a href="page2">Page 2</a> &gt; <a href="page2&#x2F;page2_3">Page 2.3</a> &gt; <a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a> &gt; <span aria-current="page">Page 2.3.3.1</span>

--- a/test/Helper/Navigation/_files/expected/bc/linklast.html
+++ b/test/Helper/Navigation/_files/expected/bc/linklast.html
@@ -1,1 +1,1 @@
-<a href="page2">Page 2</a> &gt; <a href="page2&#x2F;page2_3">Page 2.3</a> &gt; <a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a> &gt; <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1">Page 2.3.3.1</a>
+<a href="page2">Page 2</a> &gt; <a href="page2&#x2F;page2_3">Page 2.3</a> &gt; <a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a> &gt; <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1" aria-current="page">Page 2.3.3.1</a>

--- a/test/Helper/Navigation/_files/expected/bc/maxdepth.html
+++ b/test/Helper/Navigation/_files/expected/bc/maxdepth.html
@@ -1,1 +1,1 @@
-<a href="page2">Page 2</a> &gt; Page 2.3
+<a href="page2">Page 2</a> &gt; <span aria-current="page">Page 2.3</span>

--- a/test/Helper/Navigation/_files/expected/bc/separator.html
+++ b/test/Helper/Navigation/_files/expected/bc/separator.html
@@ -1,1 +1,1 @@
-<a href="page2">Page 2</a>foo<a href="page2&#x2F;page2_3">Page 2.3</a>foo<a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a>fooPage 2.3.3.1
+<a href="page2">Page 2</a>foo<a href="page2&#x2F;page2_3">Page 2.3</a>foo<a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a>foo<span aria-current="page">Page 2.3.3.1</span>

--- a/test/Helper/Navigation/_files/expected/bc/textdomain.html
+++ b/test/Helper/Navigation/_files/expected/bc/textdomain.html
@@ -1,1 +1,1 @@
-<a href="page2">TextDomain1 2</a> &gt; <a href="page2&#x2F;page2_3">Page 2.3</a> &gt; <a href="page2&#x2F;page2_3&#x2F;page2_3_3">TextDomain1 2.3.3</a> &gt; TextDomain2 2.3.3.1
+<a href="page2">TextDomain1 2</a> &gt; <a href="page2&#x2F;page2_3">Page 2.3</a> &gt; <a href="page2&#x2F;page2_3&#x2F;page2_3_3">TextDomain1 2.3.3</a> &gt; <span aria-current="page">TextDomain2 2.3.3.1</span>

--- a/test/Helper/Navigation/_files/expected/bc/translated.html
+++ b/test/Helper/Navigation/_files/expected/bc/translated.html
@@ -1,1 +1,1 @@
-<a href="page2">Side 2</a> &gt; <a href="page2&#x2F;page2_3">Side 2.3</a> &gt; <a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a> &gt; Side 2.3.3.1
+<a href="page2">Side 2</a> &gt; <a href="page2&#x2F;page2_3">Side 2.3</a> &gt; <a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a> &gt; <span aria-current="page">Side 2.3.3.1</span>

--- a/test/Helper/Navigation/_files/expected/menu/acl.html
+++ b/test/Helper/Navigation/_files/expected/menu/acl.html
@@ -23,7 +23,7 @@
                         <a href="page2&#x2F;page2_2&#x2F;page2_2_1">Page 2.2.1</a>
                     </li>
                     <li class="active">
-                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2">Page 2.2.2</a>
+                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2" aria-current="page">Page 2.2.2</a>
                     </li>
                 </ul>
             </li>

--- a/test/Helper/Navigation/_files/expected/menu/acl_role_interface.html
+++ b/test/Helper/Navigation/_files/expected/menu/acl_role_interface.html
@@ -23,7 +23,7 @@
                         <a href="page2&#x2F;page2_2&#x2F;page2_2_1">Page 2.2.1</a>
                     </li>
                     <li class="active">
-                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2">Page 2.2.2</a>
+                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2" aria-current="page">Page 2.2.2</a>
                     </li>
                 </ul>
             </li>

--- a/test/Helper/Navigation/_files/expected/menu/acl_string.html
+++ b/test/Helper/Navigation/_files/expected/menu/acl_string.html
@@ -23,7 +23,7 @@
                         <a href="page2&#x2F;page2_2&#x2F;page2_2_1">Page 2.2.1</a>
                     </li>
                     <li class="active">
-                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2">Page 2.2.2</a>
+                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2" aria-current="page">Page 2.2.2</a>
                     </li>
                 </ul>
             </li>

--- a/test/Helper/Navigation/_files/expected/menu/addclasstolistitem_as_false.html
+++ b/test/Helper/Navigation/_files/expected/menu/addclasstolistitem_as_false.html
@@ -3,7 +3,7 @@
         <a href="site1">Site 1</a>
     </li>
     <li class="active">
-        <a href="site2">Site 2</a>
+        <a href="site2" aria-current="page">Site 2</a>
     </li>
     <li>
         <a href="site3">Site 3</a>

--- a/test/Helper/Navigation/_files/expected/menu/addclasstolistitem_as_true.html
+++ b/test/Helper/Navigation/_files/expected/menu/addclasstolistitem_as_true.html
@@ -3,7 +3,7 @@
         <a href="site1">Site 1</a>
     </li>
     <li class="active">
-        <a href="site2">Site 2</a>
+        <a href="site2" aria-current="page">Site 2</a>
     </li>
     <li>
         <a href="site3">Site 3</a>

--- a/test/Helper/Navigation/_files/expected/menu/bothdepts.html
+++ b/test/Helper/Navigation/_files/expected/menu/bothdepts.html
@@ -12,7 +12,7 @@
                 <a href="page2&#x2F;page2_2&#x2F;page2_2_1">Page 2.2.1</a>
             </li>
             <li class="active">
-                <a href="page2&#x2F;page2_2&#x2F;page2_2_2">Page 2.2.2</a>
+                <a href="page2&#x2F;page2_2&#x2F;page2_2_2" aria-current="page">Page 2.2.2</a>
             </li>
         </ul>
     </li>

--- a/test/Helper/Navigation/_files/expected/menu/css.html
+++ b/test/Helper/Navigation/_files/expected/menu/css.html
@@ -3,7 +3,7 @@
         <a href="site1">Site 1</a>
     </li>
     <li class="active">
-        <a href="site2">Site 2</a>
+        <a href="site2" aria-current="page">Site 2</a>
     </li>
     <li>
         <a href="site3">Site 3</a>

--- a/test/Helper/Navigation/_files/expected/menu/css2.html
+++ b/test/Helper/Navigation/_files/expected/menu/css2.html
@@ -3,7 +3,7 @@
         <a href="site1">Site 1</a>
     </li>
     <li class="activated">
-        <a href="site2">Site 2</a>
+        <a href="site2" aria-current="page">Site 2</a>
     </li>
     <li>
         <a href="site3">Site 3</a>

--- a/test/Helper/Navigation/_files/expected/menu/default1.html
+++ b/test/Helper/Navigation/_files/expected/menu/default1.html
@@ -23,7 +23,7 @@
                         <a href="page2&#x2F;page2_2&#x2F;page2_2_1">Page 2.2.1</a>
                     </li>
                     <li class="active">
-                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2">Page 2.2.2</a>
+                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2" aria-current="page">Page 2.2.2</a>
                     </li>
                 </ul>
             </li>
@@ -37,10 +37,10 @@
                         <a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a>
                         <ul>
                             <li class="active">
-                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1">Page 2.3.3.1</a>
+                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1" aria-current="page">Page 2.3.3.1</a>
                             </li>
                             <li class="active">
-                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2">Page 2.3.3.2</a>
+                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2" aria-current="page">Page 2.3.3.2</a>
                             </li>
                         </ul>
                     </li>

--- a/test/Helper/Navigation/_files/expected/menu/default2.html
+++ b/test/Helper/Navigation/_files/expected/menu/default2.html
@@ -3,7 +3,7 @@
         <a href="site1">Site 1</a>
     </li>
     <li class="active">
-        <a href="site2">Site 2</a>
+        <a href="site2" aria-current="page">Site 2</a>
     </li>
     <li>
         <a href="site3">Site 3</a>

--- a/test/Helper/Navigation/_files/expected/menu/escapelabels_as_false.html
+++ b/test/Helper/Navigation/_files/expected/menu/escapelabels_as_false.html
@@ -3,7 +3,7 @@
         <a href="site1">Site 1</a>
     </li>
     <li class="active">
-        <a href="site2">Site 2</a>
+        <a href="site2" aria-current="page">Site 2</a>
     </li>
     <li>
         <a href="site3">Site 3</a>

--- a/test/Helper/Navigation/_files/expected/menu/escapelabels_as_true.html
+++ b/test/Helper/Navigation/_files/expected/menu/escapelabels_as_true.html
@@ -3,7 +3,7 @@
         <a href="site1">Site 1</a>
     </li>
     <li class="active">
-        <a href="site2">Site 2</a>
+        <a href="site2" aria-current="page">Site 2</a>
     </li>
     <li>
         <a href="site3">Site 3</a>

--- a/test/Helper/Navigation/_files/expected/menu/indent4.html
+++ b/test/Helper/Navigation/_files/expected/menu/indent4.html
@@ -23,7 +23,7 @@
                             <a href="page2&#x2F;page2_2&#x2F;page2_2_1">Page 2.2.1</a>
                         </li>
                         <li class="active">
-                            <a href="page2&#x2F;page2_2&#x2F;page2_2_2">Page 2.2.2</a>
+                            <a href="page2&#x2F;page2_2&#x2F;page2_2_2" aria-current="page">Page 2.2.2</a>
                         </li>
                     </ul>
                 </li>
@@ -37,10 +37,10 @@
                             <a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a>
                             <ul>
                                 <li class="active">
-                                    <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1">Page 2.3.3.1</a>
+                                    <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1" aria-current="page">Page 2.3.3.1</a>
                                 </li>
                                 <li class="active">
-                                    <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2">Page 2.3.3.2</a>
+                                    <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2" aria-current="page">Page 2.3.3.2</a>
                                 </li>
                             </ul>
                         </li>

--- a/test/Helper/Navigation/_files/expected/menu/indent8.html
+++ b/test/Helper/Navigation/_files/expected/menu/indent8.html
@@ -23,7 +23,7 @@
                                 <a href="page2&#x2F;page2_2&#x2F;page2_2_1">Page 2.2.1</a>
                             </li>
                             <li class="active">
-                                <a href="page2&#x2F;page2_2&#x2F;page2_2_2">Page 2.2.2</a>
+                                <a href="page2&#x2F;page2_2&#x2F;page2_2_2" aria-current="page">Page 2.2.2</a>
                             </li>
                         </ul>
                     </li>
@@ -37,10 +37,10 @@
                                 <a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a>
                                 <ul>
                                     <li class="active">
-                                        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1">Page 2.3.3.1</a>
+                                        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1" aria-current="page">Page 2.3.3.1</a>
                                     </li>
                                     <li class="active">
-                                        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2">Page 2.3.3.2</a>
+                                        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2" aria-current="page">Page 2.3.3.2</a>
                                     </li>
                                 </ul>
                             </li>

--- a/test/Helper/Navigation/_files/expected/menu/mindepth.html
+++ b/test/Helper/Navigation/_files/expected/menu/mindepth.html
@@ -12,7 +12,7 @@
                 <a href="page2&#x2F;page2_2&#x2F;page2_2_1">Page 2.2.1</a>
             </li>
             <li class="active">
-                <a href="page2&#x2F;page2_2&#x2F;page2_2_2">Page 2.2.2</a>
+                <a href="page2&#x2F;page2_2&#x2F;page2_2_2" aria-current="page">Page 2.2.2</a>
             </li>
         </ul>
     </li>
@@ -26,10 +26,10 @@
                 <a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a>
                 <ul>
                     <li class="active">
-                        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1">Page 2.3.3.1</a>
+                        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1" aria-current="page">Page 2.3.3.1</a>
                     </li>
                     <li class="active">
-                        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2">Page 2.3.3.2</a>
+                        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2" aria-current="page">Page 2.3.3.2</a>
                     </li>
                 </ul>
             </li>

--- a/test/Helper/Navigation/_files/expected/menu/onlyactivebranch.html
+++ b/test/Helper/Navigation/_files/expected/menu/onlyactivebranch.html
@@ -6,7 +6,7 @@
                 <a href="page2&#x2F;page2_2">Page 2.2</a>
                 <ul>
                     <li class="active">
-                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2">Page 2.2.2</a>
+                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2" aria-current="page">Page 2.2.2</a>
                     </li>
                 </ul>
             </li>
@@ -17,10 +17,10 @@
                         <a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a>
                         <ul>
                             <li class="active">
-                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1">Page 2.3.3.1</a>
+                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1" aria-current="page">Page 2.3.3.1</a>
                             </li>
                             <li class="active">
-                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2">Page 2.3.3.2</a>
+                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2" aria-current="page">Page 2.3.3.2</a>
                             </li>
                         </ul>
                     </li>

--- a/test/Helper/Navigation/_files/expected/menu/onlyactivebranch_addclasstolistitem.html
+++ b/test/Helper/Navigation/_files/expected/menu/onlyactivebranch_addclasstolistitem.html
@@ -3,7 +3,7 @@
         <a href="site1">Site 1</a>
     </li>
     <li class="active&#x20;foobar">
-        <a href="site2">Site 2</a>
+        <a href="site2" aria-current="page">Site 2</a>
     </li>
     <li>
         <a href="site3">Site 3</a>

--- a/test/Helper/Navigation/_files/expected/menu/onlyactivebranch_bothdepts.html
+++ b/test/Helper/Navigation/_files/expected/menu/onlyactivebranch_bothdepts.html
@@ -3,7 +3,7 @@
         <a href="page2&#x2F;page2_2">Page 2.2</a>
         <ul>
             <li class="active">
-                <a href="page2&#x2F;page2_2&#x2F;page2_2_2">Page 2.2.2</a>
+                <a href="page2&#x2F;page2_2&#x2F;page2_2_2" aria-current="page">Page 2.2.2</a>
             </li>
         </ul>
     </li>

--- a/test/Helper/Navigation/_files/expected/menu/onlyactivebranch_maxdepth.html
+++ b/test/Helper/Navigation/_files/expected/menu/onlyactivebranch_maxdepth.html
@@ -6,7 +6,7 @@
                 <a href="page2&#x2F;page2_2">Page 2.2</a>
                 <ul>
                     <li class="active">
-                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2">Page 2.2.2</a>
+                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2" aria-current="page">Page 2.2.2</a>
                     </li>
                 </ul>
             </li>

--- a/test/Helper/Navigation/_files/expected/menu/onlyactivebranch_mindepth.html
+++ b/test/Helper/Navigation/_files/expected/menu/onlyactivebranch_mindepth.html
@@ -3,7 +3,7 @@
         <a href="page2&#x2F;page2_2">Page 2.2</a>
         <ul>
             <li class="active">
-                <a href="page2&#x2F;page2_2&#x2F;page2_2_2">Page 2.2.2</a>
+                <a href="page2&#x2F;page2_2&#x2F;page2_2_2" aria-current="page">Page 2.2.2</a>
             </li>
         </ul>
     </li>
@@ -14,10 +14,10 @@
                 <a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a>
                 <ul>
                     <li class="active">
-                        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1">Page 2.3.3.1</a>
+                        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1" aria-current="page">Page 2.3.3.1</a>
                     </li>
                     <li class="active">
-                        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2">Page 2.3.3.2</a>
+                        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2" aria-current="page">Page 2.3.3.2</a>
                     </li>
                 </ul>
             </li>

--- a/test/Helper/Navigation/_files/expected/menu/onlyactivebranch_noparents.html
+++ b/test/Helper/Navigation/_files/expected/menu/onlyactivebranch_noparents.html
@@ -1,8 +1,8 @@
 <ul class="navigation">
     <li class="active">
-        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1">Page 2.3.3.1</a>
+        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1" aria-current="page">Page 2.3.3.1</a>
     </li>
     <li class="active">
-        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2">Page 2.3.3.2</a>
+        <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2" aria-current="page">Page 2.3.3.2</a>
     </li>
 </ul>

--- a/test/Helper/Navigation/_files/expected/menu/textdomain.html
+++ b/test/Helper/Navigation/_files/expected/menu/textdomain.html
@@ -20,7 +20,7 @@
                         <a href="page2&#x2F;page2_2&#x2F;page2_2_1">Page 2.2.1</a>
                     </li>
                     <li class="active">
-                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2">Page 2.2.2</a>
+                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2" aria-current="page">Page 2.2.2</a>
                     </li>
                 </ul>
             </li>
@@ -34,10 +34,10 @@
                         <a href="page2&#x2F;page2_3&#x2F;page2_3_3">TextDomain1 2.3.3</a>
                         <ul>
                             <li class="active">
-                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1">TextDomain2 2.3.3.1</a>
+                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1" aria-current="page">TextDomain2 2.3.3.1</a>
                             </li>
                             <li class="active">
-                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2">Page 2.3.3.2</a>
+                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2" aria-current="page">Page 2.3.3.2</a>
                             </li>
                         </ul>
                     </li>

--- a/test/Helper/Navigation/_files/expected/menu/translated.html
+++ b/test/Helper/Navigation/_files/expected/menu/translated.html
@@ -23,7 +23,7 @@
                         <a href="page2&#x2F;page2_2&#x2F;page2_2_1">Page 2.2.1</a>
                     </li>
                     <li class="active">
-                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2">Page 2.2.2</a>
+                        <a href="page2&#x2F;page2_2&#x2F;page2_2_2" aria-current="page">Page 2.2.2</a>
                     </li>
                 </ul>
             </li>
@@ -37,10 +37,10 @@
                         <a href="page2&#x2F;page2_3&#x2F;page2_3_3">Page 2.3.3</a>
                         <ul>
                             <li class="active">
-                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1">Side 2.3.3.1</a>
+                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;1" aria-current="page">Side 2.3.3.1</a>
                             </li>
                             <li class="active">
-                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2">Page 2.3.3.2</a>
+                                <a href="page2&#x2F;page2_3&#x2F;page2_3_3&#x2F;2" aria-current="page">Page 2.3.3.2</a>
                             </li>
                         </ul>
                     </li>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Adds an `aria-current="page"` to active menu links and breadcrumb segments, resolving #197.

The menu tests as previously designed have more than one page marked as active, which means `aria-current` is being used improperly in those test scenarios. I'm assuming that in real-world use, this would not be the case?