### PR TITLE
fix(php-doc): set good param-out typing to reflect code behavior

### DIFF
--- a/src/Helper/Navigation/AbstractHelper.php
+++ b/src/Helper/Navigation/AbstractHelper.php
@@ -55,7 +55,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     /**
      * AbstractContainer to operate on by default
      *
-     * @var AbstractContainer
+     * @var AbstractContainer|null
      */
     protected $container;
 
@@ -188,6 +188,10 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     public function findActive($container, $minDepth = null, $maxDepth = -1)
     {
         $this->parseContainer($container);
+        if (null === $container) {
+            return [];
+        }
+
         if (! is_int($minDepth)) {
             $minDepth = $this->getMinDepth();
         }
@@ -244,7 +248,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      *
      * @param AbstractContainer|string|null $container
      * @return void
-     * @param-out AbstractContainer $container
+     * @param-out AbstractContainer|null $container
      * @throws Exception\InvalidArgumentException
      */
     protected function parseContainer(&$container = null)


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

`Laminas\View\Helper\Navigation\AbstractHelper::parseContainer` method may set the `$container` param to  `AbstractContainer` or null.

But the PHPDoc says it set always to `AbstractContainer`.

It leads to code analyses issues. Example in `Breadcrumbs`:

```php
    public function renderStraight($container = null)
    {
        $this->parseContainer($container);
        if (null === $container) {
            $container = $this->getContainer();
        }
```

> Strict comparison using === between null and Laminas\Navigation\AbstractContainer will always evaluate to false.

