### PR TITLE
Remove support for PHP 8.0. Bump ServiceManager to 3.21.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,21 +18,21 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "8.0.99"
+            "php": "8.1.99"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0",
         "ext-dom": "*",
         "ext-filter": "*",
         "ext-json": "*",
         "laminas/laminas-escaper": "^2.5",
         "laminas/laminas-eventmanager": "^3.4",
         "laminas/laminas-json": "^3.3",
-        "laminas/laminas-servicemanager": "^3.14.0",
+        "laminas/laminas-servicemanager": "^3.21.0",
         "laminas/laminas-stdlib": "^3.10.1",
         "psr/container": "^1 || ^2"
     },

--- a/composer.json
+++ b/composer.json
@@ -40,11 +40,11 @@
         "laminas/laminas-authentication": "^2.13",
         "laminas/laminas-coding-standard": "~2.5.0",
         "laminas/laminas-feed": "^2.20",
-        "laminas/laminas-filter": "^2.31",
+        "laminas/laminas-filter": "^2.32",
         "laminas/laminas-http": "^2.18",
-        "laminas/laminas-i18n": "^2.21",
+        "laminas/laminas-i18n": "^2.23",
         "laminas/laminas-modulemanager": "^2.14",
-        "laminas/laminas-mvc": "^3.6",
+        "laminas/laminas-mvc": "^3.6.1",
         "laminas/laminas-mvc-i18n": "^1.7",
         "laminas/laminas-mvc-plugin-flashmessenger": "^1.9",
         "laminas/laminas-navigation": "^2.18.1",
@@ -52,9 +52,9 @@
         "laminas/laminas-permissions-acl": "^2.14",
         "laminas/laminas-router": "^3.11.1",
         "laminas/laminas-uri": "^2.10",
-        "phpunit/phpunit": "^9.6.3",
+        "phpunit/phpunit": "^9.6.8",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.7.1"
+        "vimeo/psalm": "^5.12"
     },
     "conflict": {
         "container-interop/container-interop": "<1.2",

--- a/composer.json
+++ b/composer.json
@@ -49,12 +49,12 @@
         "laminas/laminas-mvc-plugin-flashmessenger": "^1.9",
         "laminas/laminas-navigation": "^2.18.1",
         "laminas/laminas-paginator": "^2.17",
-        "laminas/laminas-permissions-acl": "^2.13",
+        "laminas/laminas-permissions-acl": "^2.14",
         "laminas/laminas-router": "^3.11.1",
         "laminas/laminas-uri": "^2.10",
-        "phpunit/phpunit": "^9.5.28",
+        "phpunit/phpunit": "^9.6.3",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.4"
+        "vimeo/psalm": "^5.7.1"
     },
     "conflict": {
         "container-interop/container-interop": "<1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -1187,16 +1187,16 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "0.4.1",
+            "version": "0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2"
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/79261cc280aded96d098e1b0e0ba0c4881b432c2",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
                 "shasum": ""
             },
             "require": {
@@ -1236,7 +1236,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.1"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.5.1"
             },
             "funding": [
                 {
@@ -1244,7 +1244,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-16T22:01:02+00:00"
+            "time": "2022-12-24T12:35:10+00:00"
         },
         {
             "name": "laminas/laminas-authentication",
@@ -4728,26 +4728,25 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "2.17.1",
+            "version": "3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46"
+                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/13f76acef5362d15c71ae1ac6350cc3df5e25e43",
+                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "php": "^7.4|^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.2",
                 "pestphp/pest": "^1.21",
-                "phpunit/phpunit": "^9.0",
                 "spatie/pest-plugin-snapshots": "^1.1"
             },
             "type": "library",
@@ -4776,7 +4775,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/2.17.1"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.1.5"
             },
             "funding": [
                 {
@@ -4788,7 +4787,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-26T08:22:07+00:00"
+            "time": "2022-12-24T13:43:51+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -5621,16 +5620,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.6.0",
+            "version": "5.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "e784128902dfe01d489c4123d69918a9f3c1eac5"
+                "reference": "8e0fd880141f236847ab49a06f94f788d41a4292"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e784128902dfe01d489c4123d69918a9f3c1eac5",
-                "reference": "e784128902dfe01d489c4123d69918a9f3c1eac5",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/8e0fd880141f236847ab49a06f94f788d41a4292",
+                "reference": "8e0fd880141f236847ab49a06f94f788d41a4292",
                 "shasum": ""
             },
             "require": {
@@ -5649,12 +5648,12 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.2",
-                "fidry/cpu-core-counter": "^0.4.0",
+                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
                 "nikic/php-parser": "^4.13",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
                 "sebastian/diff": "^4.0 || ^5.0",
-                "spatie/array-to-xml": "^2.17.0",
+                "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
                 "symfony/filesystem": "^5.4 || ^6.0"
             },
@@ -5663,13 +5662,13 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.4",
-                "brianium/paratest": "^6.0",
+                "brianium/paratest": "^6.9",
                 "ext-curl": "*",
                 "mockery/mockery": "^1.5",
                 "nunomaduro/mock-final-classes": "^1.1",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/phpdoc-parser": "^1.6",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^9.6",
                 "psalm/plugin-mockery": "^1.1",
                 "psalm/plugin-phpunit": "^0.18",
                 "slevomat/coding-standard": "^8.4",
@@ -5715,13 +5714,14 @@
             "keywords": [
                 "code",
                 "inspection",
-                "php"
+                "php",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.6.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.7.1"
             },
-            "time": "2023-01-23T20:32:47+00:00"
+            "time": "2023-02-20T00:48:41+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4e79f4cfb9afcc71764a7bdca4c30b8",
+    "content-hash": "48efa4a94478314d01d12cf284062b41",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -199,26 +199,26 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.20.0",
+            "version": "3.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59"
+                "reference": "625f2aa3bc6dd02688b2da5155b3a69870812bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
-                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/625f2aa3bc6dd02688b2da5155b3a69870812bda",
+                "reference": "625f2aa3bc6dd02688b2da5155b3a69870812bda",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-stdlib": "^3.2.1",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "laminas/laminas-stdlib": "^3.17",
+                "php": "~8.1.0 || ~8.2.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
                 "ext-psr": "*",
-                "laminas/laminas-code": "<3.3.1",
+                "laminas/laminas-code": "<4.10.0",
                 "zendframework/zend-code": "<3.3.1",
                 "zendframework/zend-servicemanager": "*"
             },
@@ -230,18 +230,19 @@
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.11.99.5",
-                "laminas/laminas-coding-standard": "~2.4.0",
+                "friendsofphp/proxy-manager-lts": "^1.0.14",
+                "laminas/laminas-code": "^4.10.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
                 "laminas/laminas-container-config-test": "^0.8",
                 "laminas/laminas-dependency-plugin": "^2.2",
-                "mikey179/vfsstream": "^1.6.11@alpha",
-                "ocramius/proxy-manager": "^2.14.1",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "mikey179/vfsstream": "^1.6.11",
+                "phpbench/phpbench": "^1.2.9",
+                "phpunit/phpunit": "^10.0.17",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.8.0"
             },
             "suggest": {
-                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
             },
             "bin": [
                 "bin/generate-deps-for-config-factory",
@@ -285,34 +286,34 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-01T17:03:38+00:00"
+            "time": "2023-05-14T12:24:54+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.16.1",
+            "version": "3.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17"
+                "reference": "dd35c868075bad80b6718959740913e178eb4274"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/dd35c868075bad80b6718959740913e178eb4274",
+                "reference": "dd35c868075bad80b6718959740913e178eb4274",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "laminas/laminas-coding-standard": "^2.5",
+                "phpbench/phpbench": "^1.2.9",
+                "phpunit/phpunit": "^10.0.16",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.8"
             },
             "type": "library",
             "autoload": {
@@ -344,7 +345,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-03T18:48:01+00:00"
+            "time": "2023-03-20T13:51:37+00:00"
         },
         {
             "name": "psr/container",
@@ -1016,30 +1017,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -1066,7 +1067,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -1082,7 +1083,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1528,23 +1529,23 @@
         },
         {
             "name": "laminas/laminas-filter",
-            "version": "2.31.0",
+            "version": "2.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "548a6597d357b0b0b139cc7bffea4dfbc50eb5a8"
+                "reference": "2b7e6b2b26a92412c38336ee3089251164edf141"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/548a6597d357b0b0b139cc7bffea4dfbc50eb5a8",
-                "reference": "548a6597d357b0b0b139cc7bffea4dfbc50eb5a8",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/2b7e6b2b26a92412c38336ee3089251164edf141",
+                "reference": "2b7e6b2b26a92412c38336ee3089251164edf141",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "laminas/laminas-servicemanager": "^3.14.0",
+                "laminas/laminas-servicemanager": "^3.21.0",
                 "laminas/laminas-stdlib": "^3.13.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "laminas/laminas-validator": "<2.10.1",
@@ -1552,13 +1553,13 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-crypt": "^3.9",
+                "laminas/laminas-crypt": "^3.10",
                 "laminas/laminas-uri": "^2.10",
                 "pear/archive_tar": "^1.4.14",
-                "phpunit/phpunit": "^9.5.27",
+                "phpunit/phpunit": "^10.1.3",
                 "psalm/plugin-phpunit": "^0.18.4",
-                "psr/http-factory": "^1.0.1",
-                "vimeo/psalm": "^5.3"
+                "psr/http-factory": "^1.0.2",
+                "vimeo/psalm": "^5.11"
             },
             "suggest": {
                 "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
@@ -1602,7 +1603,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-01-12T06:17:48+00:00"
+            "time": "2023-05-16T23:25:05+00:00"
         },
         {
             "name": "laminas/laminas-http",
@@ -1671,42 +1672,41 @@
         },
         {
             "name": "laminas/laminas-i18n",
-            "version": "2.22.1",
+            "version": "2.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-i18n.git",
-                "reference": "075bec49f777698c6fc229eecefbe7a2364cd18e"
+                "reference": "bb844a1141bb6e65d8889f5a08383f761a8270b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/075bec49f777698c6fc229eecefbe7a2364cd18e",
-                "reference": "075bec49f777698c6fc229eecefbe7a2364cd18e",
+                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/bb844a1141bb6e65d8889f5a08383f761a8270b2",
+                "reference": "bb844a1141bb6e65d8889f5a08383f761a8270b2",
                 "shasum": ""
             },
             "require": {
                 "ext-intl": "*",
-                "laminas/laminas-servicemanager": "^3.14.0",
-                "laminas/laminas-stdlib": "^2.7 || ^3.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "laminas/laminas-servicemanager": "^3.21.0",
+                "laminas/laminas-stdlib": "^3.0",
+                "php": "~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "laminas/laminas-view": "<2.20.0",
-                "phpspec/prophecy": "<1.9.0",
                 "zendframework/zend-i18n": "*"
             },
             "require-dev": {
-                "laminas/laminas-cache": "^3.8",
+                "laminas/laminas-cache": "^3.10.1",
                 "laminas/laminas-cache-storage-adapter-memory": "^2.2.0",
-                "laminas/laminas-cache-storage-deprecated-factory": "^1.0.1",
+                "laminas/laminas-cache-storage-deprecated-factory": "^1.1",
                 "laminas/laminas-coding-standard": "~2.5.0",
                 "laminas/laminas-config": "^3.8.0",
-                "laminas/laminas-eventmanager": "^3.7",
-                "laminas/laminas-filter": "^2.28.1",
-                "laminas/laminas-validator": "^2.28",
-                "laminas/laminas-view": "^2.25",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.3",
-                "vimeo/psalm": "^5.0.0"
+                "laminas/laminas-eventmanager": "^3.10",
+                "laminas/laminas-filter": "^2.31",
+                "laminas/laminas-validator": "^2.30.1",
+                "laminas/laminas-view": "^2.27",
+                "phpunit/phpunit": "^10.1.3",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.11"
             },
             "suggest": {
                 "laminas/laminas-cache": "You should install this package to cache the translations",
@@ -1753,7 +1753,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-03-31T12:31:38+00:00"
+            "time": "2023-05-16T23:22:24+00:00"
         },
         {
             "name": "laminas/laminas-loader",
@@ -2547,40 +2547,40 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.30.1",
+            "version": "2.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "b7d217b5e4951955fda9a3a5ada91b717b5c8d5c"
+                "reference": "7dc274aa5afd5e23be0dbea13363e3d66ba5808b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/b7d217b5e4951955fda9a3a5ada91b717b5c8d5c",
-                "reference": "b7d217b5e4951955fda9a3a5ada91b717b5c8d5c",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/7dc274aa5afd5e23be0dbea13363e3d66ba5808b",
+                "reference": "7dc274aa5afd5e23be0dbea13363e3d66ba5808b",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-servicemanager": "^3.12.0",
+                "laminas/laminas-servicemanager": "^3.21.0",
                 "laminas/laminas-stdlib": "^3.13",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-                "psr/http-message": "^1.0.1"
+                "php": "~8.1.0 || ~8.2.0",
+                "psr/http-message": "^1.0.1 || ^2.0.0"
             },
             "conflict": {
                 "zendframework/zend-validator": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "laminas/laminas-db": "^2.16",
-                "laminas/laminas-filter": "^2.28.1",
+                "laminas/laminas-coding-standard": "^2.5",
+                "laminas/laminas-db": "^2.18",
+                "laminas/laminas-filter": "^2.32",
                 "laminas/laminas-http": "^2.18",
-                "laminas/laminas-i18n": "^2.19",
-                "laminas/laminas-session": "^2.15",
+                "laminas/laminas-i18n": "^2.23",
+                "laminas/laminas-session": "^2.16",
                 "laminas/laminas-uri": "^2.10.0",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.3",
-                "psr/http-client": "^1.0.1",
-                "psr/http-factory": "^1.0.1",
-                "vimeo/psalm": "^5.0"
+                "phpunit/phpunit": "^10.1.3",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "psr/http-client": "^1.0.2",
+                "psr/http-factory": "^1.0.2",
+                "vimeo/psalm": "^5.11"
             },
             "suggest": {
                 "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
@@ -2628,7 +2628,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-01-30T22:41:19+00:00"
+            "time": "2023-05-19T09:42:26+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3599,16 +3599,16 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.1",
+            "version": "2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
-                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
                 "shasum": ""
             },
             "require": {
@@ -3617,7 +3617,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -3632,7 +3632,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for HTTP messages",
@@ -3646,9 +3646,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/1.1"
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
-            "time": "2023-04-04T09:50:52+00:00"
+            "time": "2023-04-04T09:54:51+00:00"
         },
         {
             "name": "psr/log",
@@ -4847,20 +4847,21 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.19",
+            "version": "v6.2.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed"
+                "reference": "5aa03db8ef0a5457c316ec580e69562d97734c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5aa03db8ef0a5457c316ec580e69562d97734c77",
+                "reference": "5aa03db8ef0a5457c316ec580e69562d97734c77",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^1.1|^2|^3",
                 "symfony/string": "^5.4|^6.0"
@@ -4917,12 +4918,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.19"
+                "source": "https://github.com/symfony/console/tree/v6.2.11"
             },
             "funding": [
                 {
@@ -4938,29 +4939,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-05-26T08:16:21+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.0.2",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.3-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4989,7 +4990,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.1"
             },
             "funding": [
                 {
@@ -5005,24 +5006,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2023-03-01T10:25:55+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.0.19",
+            "version": "v6.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214"
+                "reference": "fd588debf7d1bc16a2c84b4b3b71145d9946b894"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/fd588debf7d1bc16a2c84b4b3b71145d9946b894",
+                "reference": "fd588debf7d1bc16a2c84b4b3b71145d9946b894",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
@@ -5052,7 +5053,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.19"
+                "source": "https://github.com/symfony/filesystem/tree/v6.2.10"
             },
             "funding": [
                 {
@@ -5068,7 +5069,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:44:14+00:00"
+            "time": "2023-04-18T13:46:08+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -5485,20 +5486,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.19",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a"
+                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d9e72497367c23e08bf94176d2be45b00a9d232a",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a",
+                "url": "https://api.github.com/repos/symfony/string/zipball/193e83bbd6617d6b2151c37fff10fa7168ebddef",
+                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
@@ -5510,6 +5511,7 @@
             "require-dev": {
                 "symfony/error-handler": "^5.4|^6.0",
                 "symfony/http-client": "^5.4|^6.0",
+                "symfony/intl": "^6.2",
                 "symfony/translation-contracts": "^2.0|^3.0",
                 "symfony/var-exporter": "^5.4|^6.0"
             },
@@ -5550,7 +5552,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.19"
+                "source": "https://github.com/symfony/string/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -5566,7 +5568,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-03-20T16:06:02+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5903,14 +5905,14 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0",
         "ext-dom": "*",
         "ext-filter": "*",
         "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.0.99"
+        "php": "8.1.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd2ee7c1a95d1b511f67a0eda4ea68ce",
+    "content-hash": "c4e79f4cfb9afcc71764a7bdca4c30b8",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -1671,16 +1671,16 @@
         },
         {
             "name": "laminas/laminas-i18n",
-            "version": "2.21.0",
+            "version": "2.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-i18n.git",
-                "reference": "fbd2d0373aaced4769cba2bf3d1425d55f68abb1"
+                "reference": "075bec49f777698c6fc229eecefbe7a2364cd18e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/fbd2d0373aaced4769cba2bf3d1425d55f68abb1",
-                "reference": "fbd2d0373aaced4769cba2bf3d1425d55f68abb1",
+                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/075bec49f777698c6fc229eecefbe7a2364cd18e",
+                "reference": "075bec49f777698c6fc229eecefbe7a2364cd18e",
                 "shasum": ""
             },
             "require": {
@@ -1698,7 +1698,7 @@
                 "laminas/laminas-cache": "^3.8",
                 "laminas/laminas-cache-storage-adapter-memory": "^2.2.0",
                 "laminas/laminas-cache-storage-deprecated-factory": "^1.0.1",
-                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
                 "laminas/laminas-config": "^3.8.0",
                 "laminas/laminas-eventmanager": "^3.7",
                 "laminas/laminas-filter": "^2.28.1",
@@ -1753,7 +1753,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-02T17:15:52+00:00"
+            "time": "2023-03-31T12:31:38+00:00"
         },
         {
             "name": "laminas/laminas-loader",
@@ -1885,16 +1885,16 @@
         },
         {
             "name": "laminas/laminas-mvc",
-            "version": "3.6.0",
+            "version": "3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-mvc.git",
-                "reference": "c54eaebe3810feaca834cc38ef0a962c89ff2431"
+                "reference": "f12e801c31c04a4b35017354ff84070f5573879f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-mvc/zipball/c54eaebe3810feaca834cc38ef0a962c89ff2431",
-                "reference": "c54eaebe3810feaca834cc38ef0a962c89ff2431",
+                "url": "https://api.github.com/repos/laminas/laminas-mvc/zipball/f12e801c31c04a4b35017354ff84070f5573879f",
+                "reference": "f12e801c31c04a4b35017354ff84070f5573879f",
                 "shasum": ""
             },
             "require": {
@@ -1902,8 +1902,8 @@
                 "laminas/laminas-eventmanager": "^3.4",
                 "laminas/laminas-http": "^2.15",
                 "laminas/laminas-modulemanager": "^2.8",
-                "laminas/laminas-router": "^3.5",
-                "laminas/laminas-servicemanager": "^3.7",
+                "laminas/laminas-router": "^3.11.1",
+                "laminas/laminas-servicemanager": "^3.20.0",
                 "laminas/laminas-stdlib": "^3.6",
                 "laminas/laminas-view": "^2.14",
                 "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
@@ -1912,14 +1912,12 @@
                 "zendframework/zend-mvc": "*"
             },
             "require-dev": {
-                "http-interop/http-middleware": "^0.4.1",
                 "laminas/laminas-coding-standard": "^2.4.0",
                 "laminas/laminas-json": "^3.3",
-                "laminas/laminas-psr7bridge": "^1.8",
-                "laminas/laminas-stratigility": ">=2.0.1 <2.2",
                 "phpspec/prophecy": "^1.15.0",
                 "phpspec/prophecy-phpunit": "^2.0.1",
-                "phpunit/phpunit": "^9.5.25"
+                "phpunit/phpunit": "^9.5.25",
+                "webmozart/assert": "^1.11"
             },
             "suggest": {
                 "laminas/laminas-json": "(^2.6.1 || ^3.0) To auto-deserialize JSON body content in AbstractRestfulController extensions, when json_decode is unavailable",
@@ -1964,7 +1962,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-05T14:02:56+00:00"
+            "time": "2023-03-15T10:21:03+00:00"
         },
         {
             "name": "laminas/laminas-mvc-i18n",
@@ -2634,16 +2632,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
@@ -2681,7 +2679,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -2689,20 +2687,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v4.1.0",
+            "version": "v4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f"
+                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
-                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/f60565f8c0566a31acf06884cdaa591867ecc956",
+                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956",
                 "shasum": ""
             },
             "require": {
@@ -2738,22 +2736,22 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v4.1.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.2.0"
             },
-            "time": "2022-12-08T20:46:14+00:00"
+            "time": "2023-04-09T17:37:40+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.3",
+            "version": "v4.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039"
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/570e980a201d8ed0236b0a62ddf2c9cbb2034039",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/11e2663a5bc9db5d714eedb4277ee300403b4a9e",
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e",
                 "shasum": ""
             },
             "require": {
@@ -2794,9 +2792,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.3"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.5"
             },
-            "time": "2023-01-16T22:05:37+00:00"
+            "time": "2023-05-19T20:20:00+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3120,23 +3118,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.24",
+            "version": "9.2.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed"
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2cf940ebc6355a9d430462811b5aaa308b174bed",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.14",
+                "nikic/php-parser": "^4.15",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -3151,8 +3149,8 @@
                 "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
@@ -3185,7 +3183,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.24"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
             },
             "funding": [
                 {
@@ -3193,7 +3191,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-26T08:26:55+00:00"
+            "time": "2023-03-06T12:58:08+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3438,16 +3436,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.3",
+            "version": "9.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e7b1615e3e887d6c719121c6d4a44b0ab9645555"
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e7b1615e3e887d6c719121c6d4a44b0ab9645555",
-                "reference": "e7b1615e3e887d6c719121c6d4a44b0ab9645555",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
                 "shasum": ""
             },
             "require": {
@@ -3480,8 +3478,8 @@
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -3520,7 +3518,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.3"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
             },
             "funding": [
                 {
@@ -3536,7 +3535,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-04T13:37:15+00:00"
+            "time": "2023-05-11T05:14:45+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3600,25 +3599,25 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -3647,9 +3646,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         },
         {
             "name": "psr/log",
@@ -4001,16 +4000,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -4055,7 +4054,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -4063,7 +4062,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -4728,16 +4727,16 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "3.1.5",
+            "version": "3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43"
+                "reference": "e210b98957987c755372465be105d32113f339a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/13f76acef5362d15c71ae1ac6350cc3df5e25e43",
-                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/e210b98957987c755372465be105d32113f339a4",
+                "reference": "e210b98957987c755372465be105d32113f339a4",
                 "shasum": ""
             },
             "require": {
@@ -4775,7 +4774,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/3.1.5"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.1.6"
             },
             "funding": [
                 {
@@ -4787,20 +4786,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-24T13:43:51+00:00"
+            "time": "2023-05-11T14:04:07+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -4836,14 +4835,15 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "symfony/console",
@@ -5620,22 +5620,22 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.7.1",
+            "version": "5.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "8e0fd880141f236847ab49a06f94f788d41a4292"
+                "reference": "f90118cdeacd0088e7215e64c0c99ceca819e176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/8e0fd880141f236847ab49a06f94f788d41a4292",
-                "reference": "8e0fd880141f236847ab49a06f94f788d41a4292",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f90118cdeacd0088e7215e64c0c99ceca819e176",
+                "reference": "f90118cdeacd0088e7215e64c0c99ceca819e176",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^2.4.2",
                 "amphp/byte-stream": "^1.5",
-                "composer/package-versions-deprecated": "^1.10.0",
+                "composer-runtime-api": "^2",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^2.0 || ^3.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
@@ -5650,7 +5650,7 @@
                 "felixfbecker/language-server-protocol": "^1.5.2",
                 "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.13",
+                "nikic/php-parser": "^4.14",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
                 "sebastian/diff": "^4.0 || ^5.0",
                 "spatie/array-to-xml": "^2.17.0 || ^3.0",
@@ -5661,6 +5661,7 @@
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
+                "amphp/phpunit-util": "^2.0",
                 "bamarni/composer-bin-plugin": "^1.4",
                 "brianium/paratest": "^6.9",
                 "ext-curl": "*",
@@ -5719,30 +5720,30 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.7.1"
+                "source": "https://github.com/vimeo/psalm/tree/5.12.0"
             },
-            "time": "2023-02-20T00:48:41+00:00"
+            "time": "2023-05-22T21:19:03+00:00"
         },
         {
             "name": "webimpress/coding-standard",
-            "version": "1.2.4",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/coding-standard.git",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9"
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/b26557e2386711ecb74f22718f4b4bde5ddbc899",
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8.0",
-                "squizlabs/php_codesniffer": "^3.6.2"
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5.13"
+                "phpunit/phpunit": "^9.6.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -5768,7 +5769,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webimpress/coding-standard/issues",
-                "source": "https://github.com/webimpress/coding-standard/tree/1.2.4"
+                "source": "https://github.com/webimpress/coding-standard/tree/1.3.1"
             },
             "funding": [
                 {
@@ -5776,7 +5777,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-15T19:52:12+00:00"
+            "time": "2023-03-09T15:05:18+00:00"
         },
         {
             "name": "webimpress/safe-writer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48efa4a94478314d01d12cf284062b41",
+    "content-hash": "8196e88e34920255fc335907afd446ce",
     "packages": [
         {
             "name": "laminas/laminas-escaper",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,7 +7,7 @@
     <arg name="colors"/>
     <arg name="extensions" value="php"/>
     <arg name="parallel" value="80"/>
-    <arg value="s" />
+    <arg value="ps" />
 
     <file>src</file>
     <file>test</file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -59,6 +59,9 @@
       <code>Cycle</code>
       <code>Cycle</code>
     </ImplementedReturnTypeMismatch>
+    <MethodSignatureMustProvideReturnType>
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
     <MissingTemplateParam>
       <code>Iterator</code>
     </MissingTemplateParam>
@@ -118,6 +121,9 @@
     <DocblockTypeContradiction>
       <code>null === static::$registeredDoctypes</code>
     </DocblockTypeContradiction>
+    <MethodSignatureMustProvideReturnType>
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
     <MixedArrayAssignment>
       <code><![CDATA[$this->registry['doctypes'][$type]]]></code>
     </MixedArrayAssignment>
@@ -184,6 +190,9 @@
     <DocblockTypeContradiction>
       <code>$flag === null</code>
     </DocblockTypeContradiction>
+    <MethodSignatureMustProvideReturnType>
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
     <MissingConstructor>
       <code>$attributes</code>
       <code>$email</code>
@@ -228,6 +237,9 @@
     <LessSpecificReturnStatement>
       <code>(object) $attributes</code>
     </LessSpecificReturnStatement>
+    <MethodSignatureMustProvideReturnType>
+      <code>offsetSet</code>
+    </MethodSignatureMustProvideReturnType>
     <MixedArgument>
       <code>$args</code>
       <code>$args</code>
@@ -244,7 +256,7 @@
       <code>$value</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
-      <code>$extras['media']</code>
+      <code><![CDATA[$extras['media']]]></code>
       <code>$media</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
@@ -279,7 +291,7 @@
       <code><![CDATA[$item->rel]]></code>
     </MixedPropertyFetch>
     <MixedReturnStatement>
-      <code>call_user_func_array([$this, '__invoke'], func_get_args())</code>
+      <code><![CDATA[call_user_func_array([$this, '__invoke'], func_get_args())]]></code>
     </MixedReturnStatement>
     <MoreSpecificImplementedParamType>
       <code>$value</code>
@@ -318,6 +330,10 @@
     <InvalidCast>
       <code>$item</code>
     </InvalidCast>
+    <MethodSignatureMustProvideReturnType>
+      <code>offsetSet</code>
+      <code>offsetUnset</code>
+    </MethodSignatureMustProvideReturnType>
     <MixedArgument>
       <code>$args[0]</code>
       <code>$args[1]</code>
@@ -400,8 +416,11 @@
   </file>
   <file src="src/Helper/HeadScript.php">
     <InvalidPropertyAssignmentValue>
-      <code>['type']</code>
+      <code><![CDATA[['type']]]></code>
     </InvalidPropertyAssignmentValue>
+    <MethodSignatureMustProvideReturnType>
+      <code>offsetSet</code>
+    </MethodSignatureMustProvideReturnType>
     <MixedArgument>
       <code>$content</code>
       <code>$content</code>
@@ -418,7 +437,7 @@
       <code>$value</code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$attrs['src']</code>
+      <code><![CDATA[$attrs['src']]]></code>
       <code>$content</code>
       <code>$indent</code>
       <code>$index</code>
@@ -483,6 +502,9 @@
     </UndefinedMagicMethod>
   </file>
   <file src="src/Helper/HeadStyle.php">
+    <MethodSignatureMustProvideReturnType>
+      <code>offsetSet</code>
+    </MethodSignatureMustProvideReturnType>
     <MixedArgument>
       <code>$content</code>
       <code>$enc</code>
@@ -495,7 +517,7 @@
       <code>$value</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
-      <code>$attributes['media']</code>
+      <code><![CDATA[$attributes['media']]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code><![CDATA[$item->attributes['conditional']]]></code>
@@ -740,6 +762,9 @@
     <InvalidThrow>
       <code>Navigation\Exception\ExceptionInterface</code>
     </InvalidThrow>
+    <MethodSignatureMustProvideReturnType>
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
     <MissingConstructor>
       <code>$container</code>
       <code>$container</code>
@@ -784,7 +809,7 @@
       <code>$events</code>
     </ParamNameMismatch>
     <PossiblyFalseArgument>
-      <code>strrpos($prefix, '\\')</code>
+      <code><![CDATA[strrpos($prefix, '\\')]]></code>
     </PossiblyFalseArgument>
     <PossiblyNullArgument>
       <code><![CDATA[$page->getTitle()]]></code>
@@ -820,7 +845,7 @@
       <code>setSharedManager</code>
     </UndefinedMethod>
     <UnevaluatedCode>
-      <code>return '';</code>
+      <code><![CDATA[return '';]]></code>
     </UnevaluatedCode>
   </file>
   <file src="src/Helper/Navigation/Breadcrumbs.php">
@@ -842,19 +867,19 @@
       <code>$active</code>
       <code><![CDATA[$active->getLabel()]]></code>
       <code><![CDATA[$active->getTextDomain()]]></code>
-      <code>$model['pages']</code>
+      <code><![CDATA[$model['pages']]]></code>
       <code>$partial[0]</code>
     </MixedArgument>
     <MixedArrayAssignment>
-      <code>$model['pages'][]</code>
-      <code>$model['pages'][]</code>
+      <code><![CDATA[$model['pages'][]]]></code>
+      <code><![CDATA[$model['pages'][]]]></code>
     </MixedArrayAssignment>
     <MixedAssignment>
       <code>$active</code>
       <code>$active</code>
       <code>$active</code>
       <code>$label</code>
-      <code>$model['pages'][]</code>
+      <code><![CDATA[$model['pages'][]]]></code>
       <code>$parent</code>
     </MixedAssignment>
     <MixedMethodCall>
@@ -967,9 +992,9 @@
       <code>isAllowed</code>
     </MixedMethodCall>
     <PossiblyInvalidArrayAccess>
-      <code>$params['acl']</code>
-      <code>$params['page']</code>
-      <code>$params['role']</code>
+      <code><![CDATA[$params['acl']]]></code>
+      <code><![CDATA[$params['page']]]></code>
+      <code><![CDATA[$params['role']]]></code>
     </PossiblyInvalidArrayAccess>
   </file>
   <file src="src/Helper/Navigation/Menu.php">
@@ -988,22 +1013,22 @@
       <code>$partial</code>
     </MissingConstructor>
     <MixedArgument>
-      <code>$options['addClassToListItem']</code>
-      <code>$options['addClassToListItem']</code>
-      <code>$options['escapeLabels']</code>
-      <code>$options['escapeLabels']</code>
-      <code>$options['indent']</code>
-      <code>$options['indent']</code>
-      <code>$options['indent']</code>
-      <code>$options['liActiveClass']</code>
-      <code>$options['liActiveClass']</code>
-      <code>$options['maxDepth']</code>
-      <code>$options['maxDepth']</code>
-      <code>$options['minDepth']</code>
-      <code>$options['minDepth']</code>
-      <code>$options['onlyActiveBranch']</code>
-      <code>$options['ulClass']</code>
-      <code>$options['ulClass']</code>
+      <code><![CDATA[$options['addClassToListItem']]]></code>
+      <code><![CDATA[$options['addClassToListItem']]]></code>
+      <code><![CDATA[$options['escapeLabels']]]></code>
+      <code><![CDATA[$options['escapeLabels']]]></code>
+      <code><![CDATA[$options['indent']]]></code>
+      <code><![CDATA[$options['indent']]]></code>
+      <code><![CDATA[$options['indent']]]></code>
+      <code><![CDATA[$options['liActiveClass']]]></code>
+      <code><![CDATA[$options['liActiveClass']]]></code>
+      <code><![CDATA[$options['maxDepth']]]></code>
+      <code><![CDATA[$options['maxDepth']]]></code>
+      <code><![CDATA[$options['minDepth']]]></code>
+      <code><![CDATA[$options['minDepth']]]></code>
+      <code><![CDATA[$options['onlyActiveBranch']]]></code>
+      <code><![CDATA[$options['ulClass']]]></code>
+      <code><![CDATA[$options['ulClass']]]></code>
       <code>$page</code>
       <code>$page</code>
       <code><![CDATA[$page->getTextDomain()]]></code>
@@ -1015,8 +1040,8 @@
       <code>$liClasses</code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment>
-      <code>$active['page']</code>
-      <code>$active['page']</code>
+      <code><![CDATA[$active['page']]]></code>
+      <code><![CDATA[$active['page']]]></code>
       <code>$foundDepth</code>
       <code>$foundPage</code>
       <code>$isActive</code>
@@ -1038,12 +1063,12 @@
       <code>isActive</code>
     </MixedMethodCall>
     <MixedOperand>
-      <code>$active['depth']</code>
+      <code><![CDATA[$active['depth']]]></code>
       <code>$escaper($label)</code>
       <code>$escaper($ulClass)</code>
       <code>$escaper($ulClass)</code>
-      <code>$escaper(implode(' ', $liClasses))</code>
-      <code>$escaper(implode(' ', $liClasses))</code>
+      <code><![CDATA[$escaper(implode(' ', $liClasses))]]></code>
+      <code><![CDATA[$escaper(implode(' ', $liClasses))]]></code>
       <code>$foundDepth</code>
     </MixedOperand>
     <MoreSpecificImplementedParamType>
@@ -1283,6 +1308,9 @@
     <ImplementedReturnTypeMismatch>
       <code>self</code>
     </ImplementedReturnTypeMismatch>
+    <MethodSignatureMustProvideReturnType>
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
     <MissingTemplateParam>
       <code>AbstractContainer</code>
     </MissingTemplateParam>
@@ -1326,6 +1354,9 @@
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->container]]></code>
     </LessSpecificReturnStatement>
+    <MethodSignatureMustProvideReturnType>
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
     <MissingTemplateParam>
       <code>ArrayAccess</code>
       <code>IteratorAggregate</code>
@@ -1454,7 +1485,7 @@
   </file>
   <file src="src/Helper/ServerUrl.php">
     <ArgumentTypeCoercion>
-      <code>$_SERVER['SERVER_PORT']</code>
+      <code><![CDATA[$_SERVER['SERVER_PORT']]]></code>
       <code>$port</code>
     </ArgumentTypeCoercion>
     <InvalidNullableReturnType>
@@ -1466,13 +1497,13 @@
       <code><![CDATA[$this->scheme]]></code>
     </NullableReturnStatement>
     <PossiblyUndefinedArrayOffset>
-      <code>$_SERVER['REQUEST_URI']</code>
+      <code><![CDATA[$_SERVER['REQUEST_URI']]]></code>
     </PossiblyUndefinedArrayOffset>
     <RedundantCastGivenDocblockType>
       <code>(bool) $useProxy</code>
     </RedundantCastGivenDocblockType>
     <TypeDoesNotContainType>
-      <code>$_SERVER['HTTPS'] === true</code>
+      <code><![CDATA[$_SERVER['HTTPS'] === true]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Helper/Service/AssetFactory.php">
@@ -1482,11 +1513,11 @@
   </file>
   <file src="src/Helper/Service/DoctypeFactory.php">
     <MixedArgument>
-      <code>$config['view_helper_config']['doctype']</code>
+      <code><![CDATA[$config['view_helper_config']['doctype']]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$config['view_helper_config']</code>
-      <code>$config['view_helper_config']['doctype']</code>
+      <code><![CDATA[$config['view_helper_config']]]></code>
+      <code><![CDATA[$config['view_helper_config']['doctype']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$config</code>
@@ -1502,17 +1533,17 @@
       <code>FlashMessengerFactory</code>
     </DeprecatedInterface>
     <MixedArgument>
-      <code>$configHelper['message_close_string']</code>
-      <code>$configHelper['message_open_format']</code>
-      <code>$configHelper['message_separator_string']</code>
+      <code><![CDATA[$configHelper['message_close_string']]]></code>
+      <code><![CDATA[$configHelper['message_open_format']]]></code>
+      <code><![CDATA[$configHelper['message_separator_string']]]></code>
       <code>$flashMessenger</code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$configHelper['message_close_string']</code>
-      <code>$configHelper['message_open_format']</code>
-      <code>$configHelper['message_separator_string']</code>
-      <code>$config['view_helper_config']</code>
-      <code>$config['view_helper_config']['flashmessenger']</code>
+      <code><![CDATA[$configHelper['message_close_string']]]></code>
+      <code><![CDATA[$configHelper['message_open_format']]]></code>
+      <code><![CDATA[$configHelper['message_separator_string']]]></code>
+      <code><![CDATA[$config['view_helper_config']]]></code>
+      <code><![CDATA[$config['view_helper_config']['flashmessenger']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$config</code>
@@ -1547,21 +1578,27 @@
       <code>is_bool($options)</code>
     </DocblockTypeContradiction>
     <InvalidArrayAssignment>
-      <code>$options['name']</code>
+      <code><![CDATA[$options['name']]]></code>
     </InvalidArrayAssignment>
     <MixedAssignment>
       <code>$reuseMatchedParams</code>
-      <code>$routeMatchParams['controller']</code>
+      <code><![CDATA[$routeMatchParams['controller']]]></code>
     </MixedAssignment>
     <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/HelperPluginManager.php">
+    <DeprecatedInterface>
+      <code>null|ConfigInterface|ContainerInterface</code>
+    </DeprecatedInterface>
     <DocblockTypeContradiction>
       <code>! $events</code>
       <code>! $events</code>
     </DocblockTypeContradiction>
+    <MethodSignatureMustProvideReturnType>
+      <code>get</code>
+    </MethodSignatureMustProvideReturnType>
     <MixedArgument>
       <code><![CDATA[$container->get('EventManager')]]></code>
       <code><![CDATA[$container->get('MvcTranslator')]]></code>
@@ -1735,7 +1772,7 @@
   </file>
   <file src="src/Renderer/FeedRenderer.php">
     <InvalidArrayAccess>
-      <code>$options['feed_type']</code>
+      <code><![CDATA[$options['feed_type']]]></code>
     </InvalidArrayAccess>
     <MissingConstructor>
       <code>$resolver</code>
@@ -2109,7 +2146,7 @@
       <code>$value</code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$params['result']</code>
+      <code><![CDATA[$params['result']]]></code>
     </MixedAssignment>
     <MoreSpecificImplementedParamType>
       <code>$name</code>
@@ -2200,6 +2237,20 @@
     </ArgumentTypeCoercion>
     <DeprecatedClass>
       <code>FlashMessenger</code>
+      <code><![CDATA[new Config([
+            'services'  => [
+                'config' => $config,
+            ],
+            'factories' => [
+                'ControllerPluginManager' => fn(ContainerInterface $services) => new PluginManager($services, [
+                    'invokables' => [
+                        'flashmessenger' => $this->mvcPluginClass,
+                    ],
+                ]),
+                'ViewHelperManager'       => static fn(ContainerInterface $services)
+                    => new HelperPluginManager($services),
+            ],
+        ])]]></code>
       <code>new FlashMessenger()</code>
       <code>new FlashMessenger()</code>
       <code>new FlashMessenger()</code>
@@ -2259,19 +2310,19 @@
   </file>
   <file src="test/Helper/HeadLinkTest.php">
     <InvalidArgument>
-      <code>'foo'</code>
-      <code>'foo'</code>
+      <code><![CDATA['foo']]></code>
+      <code><![CDATA['foo']]></code>
     </InvalidArgument>
     <MixedArgument>
-      <code>$attributeEscaper('/styles.css')</code>
-      <code>$attributeEscaper('/styles.css')</code>
-      <code>$attributeEscaper('/styles.css')</code>
-      <code>$attributeEscaper('/styles.css')</code>
-      <code>$attributeEscaper('/test1.css')</code>
-      <code>$attributeEscaper('/test2.css')</code>
-      <code>$attributeEscaper('/test3.css')</code>
-      <code>$attributeEscaper('/test4.css')</code>
-      <code>$attributeEscaper('text/css')</code>
+      <code><![CDATA[$attributeEscaper('/styles.css')]]></code>
+      <code><![CDATA[$attributeEscaper('/styles.css')]]></code>
+      <code><![CDATA[$attributeEscaper('/styles.css')]]></code>
+      <code><![CDATA[$attributeEscaper('/styles.css')]]></code>
+      <code><![CDATA[$attributeEscaper('/test1.css')]]></code>
+      <code><![CDATA[$attributeEscaper('/test2.css')]]></code>
+      <code><![CDATA[$attributeEscaper('/test3.css')]]></code>
+      <code><![CDATA[$attributeEscaper('/test4.css')]]></code>
+      <code><![CDATA[$attributeEscaper('text/css')]]></code>
       <code>$item</code>
       <code>$item</code>
       <code>$item</code>
@@ -2306,17 +2357,17 @@
       <code>iterable</code>
     </MixedInferredReturnType>
     <MixedOperand>
-      <code>$attributeEscaper($link['href'])</code>
-      <code>$attributeEscaper($link['href'])</code>
-      <code>$attributeEscaper($link['href'])</code>
-      <code>$attributeEscaper($link['rel'])</code>
-      <code>$attributeEscaper($link['rel'])</code>
-      <code>$attributeEscaper($link['title'])</code>
-      <code>$attributeEscaper($link['type'])</code>
-      <code>$attributeEscaper($link['type'])</code>
-      <code>$attributeEscaper($link['type'])</code>
-      <code>$attributeEscaper('/foo/bar')</code>
-      <code>$attributeEscaper('/foo/bar')</code>
+      <code><![CDATA[$attributeEscaper($link['href'])]]></code>
+      <code><![CDATA[$attributeEscaper($link['href'])]]></code>
+      <code><![CDATA[$attributeEscaper($link['href'])]]></code>
+      <code><![CDATA[$attributeEscaper($link['rel'])]]></code>
+      <code><![CDATA[$attributeEscaper($link['rel'])]]></code>
+      <code><![CDATA[$attributeEscaper($link['title'])]]></code>
+      <code><![CDATA[$attributeEscaper($link['type'])]]></code>
+      <code><![CDATA[$attributeEscaper($link['type'])]]></code>
+      <code><![CDATA[$attributeEscaper($link['type'])]]></code>
+      <code><![CDATA[$attributeEscaper('/foo/bar')]]></code>
+      <code><![CDATA[$attributeEscaper('/foo/bar')]]></code>
     </MixedOperand>
     <MixedPropertyFetch>
       <code><![CDATA[$item->conditionalStylesheet]]></code>
@@ -2347,16 +2398,16 @@
   </file>
   <file src="test/Helper/HeadMetaTest.php">
     <InvalidArgument>
-      <code>'foo'</code>
-      <code>'foo'</code>
-      <code>'foo'</code>
-      <code>[$this, 'handleErrors']</code>
+      <code><![CDATA['foo']]></code>
+      <code><![CDATA['foo']]></code>
+      <code><![CDATA['foo']]></code>
+      <code><![CDATA[[$this, 'handleErrors']]]></code>
     </InvalidArgument>
     <MixedArgument>
-      <code>$attributeEscaper('HeadMeta with Microdata')</code>
-      <code>$attributeEscaper('og:title')</code>
-      <code>$attributeEscaper('some content')</code>
-      <code>$attributeEscaper('some content')</code>
+      <code><![CDATA[$attributeEscaper('HeadMeta with Microdata')]]></code>
+      <code><![CDATA[$attributeEscaper('og:title')]]></code>
+      <code><![CDATA[$attributeEscaper('some content')]]></code>
+      <code><![CDATA[$attributeEscaper('some content')]]></code>
       <code>$item</code>
       <code>$item</code>
       <code>$item</code>
@@ -2386,8 +2437,8 @@
       <code>$values</code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$modifiers['lang']</code>
-      <code>$modifiers['scheme']</code>
+      <code><![CDATA[$modifiers['lang']]]></code>
+      <code><![CDATA[$modifiers['scheme']]]></code>
       <code>$values[$i]</code>
       <code>$values[100]</code>
     </MixedArrayAccess>
@@ -2406,8 +2457,8 @@
       <code>$values</code>
     </MixedAssignment>
     <MixedOperand>
-      <code>$attributeEscaper('boo bah')</code>
-      <code>$attributeEscaper('foo bar')</code>
+      <code><![CDATA[$attributeEscaper('boo bah')]]></code>
+      <code><![CDATA[$attributeEscaper('foo bar')]]></code>
     </MixedOperand>
     <MixedPropertyFetch>
       <code><![CDATA[$item->content]]></code>
@@ -2447,11 +2498,11 @@
       <code>public function booleanAttributeDataProvider(): Generator</code>
     </InvalidDocblock>
     <MixedArgument>
-      <code>$attributeEscaper('test1.js')</code>
-      <code>$attributeEscaper('test2.js')</code>
-      <code>$attributeEscaper('test3.js')</code>
-      <code>$attributeEscaper('test4.js')</code>
-      <code>$attributeEscaper('text/javascript')</code>
+      <code><![CDATA[$attributeEscaper('test1.js')]]></code>
+      <code><![CDATA[$attributeEscaper('test2.js')]]></code>
+      <code><![CDATA[$attributeEscaper('test3.js')]]></code>
+      <code><![CDATA[$attributeEscaper('test4.js')]]></code>
+      <code><![CDATA[$attributeEscaper('text/javascript')]]></code>
       <code>$item</code>
       <code>$item</code>
       <code>$item</code>
@@ -2595,7 +2646,7 @@
     <MixedArgument>
       <code>$escape($value)</code>
       <code>$escape($value)</code>
-      <code>$escape('http://www.w3.org/1999/xhtml')</code>
+      <code><![CDATA[$escape('http://www.w3.org/1999/xhtml')]]></code>
     </MixedArgument>
   </file>
   <file src="test/Helper/Navigation/AbstractHelperTest.php">
@@ -2618,6 +2669,9 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/Helper/Navigation/AbstractTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[new Config((new RouterConfigProvider())->getDependencyConfig())]]></code>
+    </DeprecatedClass>
     <MixedAssignment>
       <code>$app</code>
     </MixedAssignment>
@@ -2633,16 +2687,16 @@
       <code>null</code>
     </NullArgument>
     <TooManyArguments>
-      <code>new GenericResource('admin_foo', 'member_foo')</code>
+      <code><![CDATA[new GenericResource('admin_foo', 'member_foo')]]></code>
     </TooManyArguments>
   </file>
   <file src="test/Helper/Navigation/BreadcrumbsTest.php">
     <InvalidArgument>
-      <code>'Navigation'</code>
-      <code>'Navigation'</code>
+      <code><![CDATA['Navigation']]></code>
+      <code><![CDATA['Navigation']]></code>
     </InvalidArgument>
     <MixedArgument>
-      <code>$acl['acl']</code>
+      <code><![CDATA[$acl['acl']]]></code>
     </MixedArgument>
     <NonInvariantDocblockPropertyType>
       <code>$_helper</code>
@@ -2791,15 +2845,15 @@
   </file>
   <file src="test/Helper/Navigation/MenuTest.php">
     <InvalidArgument>
-      <code>'Navigation'</code>
-      <code>'Navigation'</code>
+      <code><![CDATA['Navigation']]></code>
+      <code><![CDATA['Navigation']]></code>
     </InvalidArgument>
     <MixedArgument>
-      <code>$acl['acl']</code>
-      <code>$acl['acl']</code>
-      <code>$acl['acl']</code>
-      <code>$acl['acl']</code>
-      <code>$acl['acl']</code>
+      <code><![CDATA[$acl['acl']]]></code>
+      <code><![CDATA[$acl['acl']]]></code>
+      <code><![CDATA[$acl['acl']]]></code>
+      <code><![CDATA[$acl['acl']]]></code>
+      <code><![CDATA[$acl['acl']]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code>$p</code>
@@ -2821,9 +2875,9 @@
         }]]></code>
     </InvalidArgument>
     <MixedArgument>
-      <code>$acl['acl']</code>
-      <code>$acl['acl']</code>
-      <code>$acl['acl']</code>
+      <code><![CDATA[$acl['acl']]]></code>
+      <code><![CDATA[$acl['acl']]]></code>
+      <code><![CDATA[$acl['acl']]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code>$actual</code>
@@ -2851,10 +2905,19 @@
       <code>PsrContainerDecorator</code>
     </UndefinedClass>
   </file>
+  <file src="test/Helper/Navigation/PluginManagerCompatibilityTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[new Config([
+            'navigation' => [
+                'default' => [],
+            ],
+        ])]]></code>
+    </DeprecatedClass>
+  </file>
   <file src="test/Helper/Navigation/SitemapTest.php">
     <MixedArgument>
-      <code>$acl['acl']</code>
-      <code>$acl['acl']</code>
+      <code><![CDATA[$acl['acl']]]></code>
+      <code><![CDATA[$acl['acl']]]></code>
     </MixedArgument>
     <MixedMethodCall>
       <code>setBasePath</code>
@@ -2889,7 +2952,7 @@
     <InvalidArgument>
       <code>$all</code>
       <code>$paginator</code>
-      <code>['partial.phtml', 'test']</code>
+      <code><![CDATA[['partial.phtml', 'test']]]></code>
     </InvalidArgument>
     <NullArgument>
       <code>null</code>
@@ -2911,8 +2974,8 @@
       <code>$rIterator</code>
       <code>$rIterator</code>
       <code>$rIterator</code>
-      <code>'foo'</code>
-      <code>'foo'</code>
+      <code><![CDATA['foo']]></code>
+      <code><![CDATA['foo']]></code>
       <code>new stdClass()</code>
       <code>new stdClass()</code>
     </InvalidArgument>
@@ -3170,6 +3233,9 @@
     </MissingTemplateParam>
   </file>
   <file src="test/Helper/UrlIntegrationTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[new Config((new RouterConfigProvider())->getDependencyConfig())]]></code>
+    </DeprecatedClass>
     <MixedArgument>
       <code>$serviceConfig</code>
       <code>$test</code>
@@ -3185,7 +3251,7 @@
       <code>$viewHelpers</code>
     </MixedAssignment>
     <MixedFunctionCall>
-      <code>$urlHelper('test')</code>
+      <code><![CDATA[$urlHelper('test')]]></code>
       <code><![CDATA[$urlHelper('test', [], ['force_canonical' => true])]]></code>
     </MixedFunctionCall>
     <MixedMethodCall>
@@ -3204,12 +3270,20 @@
       <code>$it</code>
       <code>$router</code>
       <code>$router</code>
-      <code>'invalid params'</code>
+      <code><![CDATA['invalid params']]></code>
       <code>true</code>
       <code>true</code>
     </InvalidArgument>
   </file>
   <file src="test/HelperPluginManagerCompatibilityTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[new Config([
+            'services'  => [
+                'config' => [],
+            ],
+            'factories' => $factories,
+        ])]]></code>
+    </DeprecatedClass>
     <MixedArgument>
       <code>$target</code>
       <code>$target</code>
@@ -3224,6 +3298,42 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/HelperPluginManagerTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[new Config(
+            [
+                'factories' => [
+                    'foo' => static fn($container) => $helper,
+                ],
+            ]
+        )]]></code>
+      <code><![CDATA[new Config(
+            [
+                'factories' => [
+                    Url::class => static fn($container) => $helper,
+                ],
+            ]
+        )]]></code>
+      <code><![CDATA[new Config([
+            'services' => [
+                'MvcTranslator' => $translator,
+            ],
+        ])]]></code>
+      <code><![CDATA[new Config([
+            'services' => [
+                'Translator' => $translator,
+            ],
+        ])]]></code>
+      <code><![CDATA[new Config([
+            'services' => [
+                'Translator' => $translatorB,
+            ],
+        ])]]></code>
+      <code><![CDATA[new Config([
+            'services' => [
+                TranslatorInterface::class => $translator,
+            ],
+        ])]]></code>
+    </DeprecatedClass>
     <MissingClosureParamType>
       <code>$container</code>
       <code>$container</code>
@@ -3245,7 +3355,7 @@
       <code>new stdClass()</code>
     </InvalidArgument>
     <PossiblyInvalidArrayAccess>
-      <code>$variables['foo']</code>
+      <code><![CDATA[$variables['foo']]]></code>
     </PossiblyInvalidArrayAccess>
   </file>
   <file src="test/PhpRendererTest.php">
@@ -3269,7 +3379,7 @@
       <code><![CDATA[$this->renderer->vars()->foo]]></code>
     </MixedPropertyFetch>
     <PossiblyInvalidArrayAssignment>
-      <code>$vars['foo']</code>
+      <code><![CDATA[$vars['foo']]]></code>
     </PossiblyInvalidArrayAssignment>
     <UnusedClosureParam>
       <code>$errno</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.6.0@e784128902dfe01d489c4123d69918a9f3c1eac5">
+<files psalm-version="5.12.0@f90118cdeacd0088e7215e64c0c99ceca819e176">
   <file src="bin/templatemap_generator.php">
     <MissingParamType>
       <code>$templatePath</code>
     </MissingParamType>
     <MixedArgument>
       <code>$file</code>
-      <code>$file-&gt;getExtension()</code>
+      <code><![CDATA[$file->getExtension()]]></code>
       <code>$templatePath</code>
     </MixedArgument>
     <MixedAssignment>
@@ -63,24 +63,24 @@
       <code>Iterator</code>
     </MissingTemplateParam>
     <MixedArgument>
-      <code>$this-&gt;data[$this-&gt;name]</code>
-      <code>$this-&gt;data[$this-&gt;name]</code>
+      <code><![CDATA[$this->data[$this->name]]]></code>
+      <code><![CDATA[$this->data[$this->name]]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$this-&gt;data[$this-&gt;name][$this-&gt;key()]</code>
-      <code>$this-&gt;data[$this-&gt;name][$this-&gt;key()]</code>
+      <code><![CDATA[$this->data[$this->name][$this->key()]]]></code>
+      <code><![CDATA[$this->data[$this->name][$this->key()]]]></code>
     </MixedArrayAccess>
     <MixedInferredReturnType>
       <code>array</code>
       <code>int</code>
     </MixedInferredReturnType>
     <MixedOperand>
-      <code>$this-&gt;pointers[$this-&gt;name]</code>
-      <code>$this-&gt;pointers[$this-&gt;name]</code>
+      <code><![CDATA[$this->pointers[$this->name]]]></code>
+      <code><![CDATA[$this->pointers[$this->name]]]></code>
     </MixedOperand>
     <MixedReturnStatement>
-      <code>$this-&gt;data[$this-&gt;name]</code>
-      <code>$this-&gt;pointers[$this-&gt;name]</code>
+      <code><![CDATA[$this->data[$this->name]]]></code>
+      <code><![CDATA[$this->pointers[$this->name]]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Helper/DeclareVars.php">
@@ -100,7 +100,7 @@
       <code>$vars</code>
     </MixedAssignment>
     <MixedPropertyFetch>
-      <code>$vars-&gt;$key</code>
+      <code><![CDATA[$vars->$key]]></code>
     </MixedPropertyFetch>
     <NonInvariantDocblockPropertyType>
       <code>$view</code>
@@ -119,16 +119,16 @@
       <code>null === static::$registeredDoctypes</code>
     </DocblockTypeContradiction>
     <MixedArrayAssignment>
-      <code>$this-&gt;registry['doctypes'][$type]</code>
+      <code><![CDATA[$this->registry['doctypes'][$type]]]></code>
     </MixedArrayAssignment>
     <MixedInferredReturnType>
       <code>array</code>
       <code>string</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$doctypes[$this-&gt;getDoctype()]</code>
-      <code>$this-&gt;registry['doctype']</code>
-      <code>$this-&gt;registry['doctypes']</code>
+      <code><![CDATA[$doctypes[$this->getDoctype()]]]></code>
+      <code><![CDATA[$this->registry['doctype']]]></code>
+      <code><![CDATA[$this->registry['doctypes']]]></code>
     </MixedReturnStatement>
     <PropertyNotSetInConstructor>
       <code>$registry</code>
@@ -142,7 +142,7 @@
   </file>
   <file src="src/Helper/FlashMessenger.php">
     <DocblockTypeContradiction>
-      <code>null === $this-&gt;pluginFlashMessenger</code>
+      <code><![CDATA[null === $this->pluginFlashMessenger]]></code>
     </DocblockTypeContradiction>
     <MissingClosureParamType>
       <code>$item</code>
@@ -168,7 +168,7 @@
       <code>$classes</code>
       <code>$messagesToPrint[]</code>
       <code>$messagesToPrint[]</code>
-      <code>$this-&gt;escapeHtmlHelper</code>
+      <code><![CDATA[$this->escapeHtmlHelper]]></code>
     </MixedAssignment>
     <RedundantCastGivenDocblockType>
       <code>(bool) $autoEscape</code>
@@ -177,7 +177,7 @@
       <code>(string) $messageSeparatorString</code>
     </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType>
-      <code>$this-&gt;escapeHtmlHelper</code>
+      <code><![CDATA[$this->escapeHtmlHelper]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/Gravatar.php">
@@ -202,10 +202,10 @@
       <code>string</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$this-&gt;options['default_img']</code>
-      <code>$this-&gt;options['img_size']</code>
-      <code>$this-&gt;options['rating']</code>
-      <code>$this-&gt;options['secure']</code>
+      <code><![CDATA[$this->options['default_img']]]></code>
+      <code><![CDATA[$this->options['img_size']]]></code>
+      <code><![CDATA[$this->options['rating']]]></code>
+      <code><![CDATA[$this->options['secure']]]></code>
     </MixedReturnStatement>
     <RedundantCastGivenDocblockType>
       <code>(bool) $flag</code>
@@ -220,7 +220,7 @@
       <code>$item</code>
     </InvalidArgument>
     <InvalidReturnStatement>
-      <code>$this-&gt;getContainer()-&gt;set($value)</code>
+      <code><![CDATA[$this->getContainer()->set($value)]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code>HeadLink</code>
@@ -238,9 +238,9 @@
       <code>$index</code>
       <code>$item</code>
       <code>$item</code>
-      <code>$this-&gt;autoEscape ? $this-&gt;escapeAttribute($attributes[$itemKey]) : $attributes[$itemKey]</code>
-      <code>$this-&gt;autoEscape ? $this-&gt;escapeAttribute($value) : $value</code>
-      <code>$this-&gt;getSeparator()</code>
+      <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($attributes[$itemKey]) : $attributes[$itemKey]]]></code>
+      <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($value) : $value]]></code>
+      <code><![CDATA[$this->getSeparator()]]></code>
       <code>$value</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
@@ -275,8 +275,8 @@
       <code>$indent</code>
     </MixedOperand>
     <MixedPropertyFetch>
-      <code>$item-&gt;href</code>
-      <code>$item-&gt;rel</code>
+      <code><![CDATA[$item->href]]></code>
+      <code><![CDATA[$item->rel]]></code>
     </MixedPropertyFetch>
     <MixedReturnStatement>
       <code>call_user_func_array([$this, '__invoke'], func_get_args())</code>
@@ -295,7 +295,7 @@
     </PossiblyInvalidArgument>
     <PossiblyNullArgument>
       <code>$index</code>
-      <code>$this-&gt;view</code>
+      <code><![CDATA[$this->view]]></code>
     </PossiblyNullArgument>
     <RedundantCast>
       <code>(string) $conditionalStylesheet</code>
@@ -324,14 +324,14 @@
       <code>$args[2]</code>
       <code>$index</code>
       <code>$item</code>
-      <code>$item-&gt;$type</code>
-      <code>$item-&gt;content</code>
-      <code>$item-&gt;type</code>
+      <code><![CDATA[$item->$type]]></code>
+      <code><![CDATA[$item->content]]></code>
+      <code><![CDATA[$item->type]]></code>
       <code>$key</code>
-      <code>$this-&gt;autoEscape ? $this-&gt;escapeAttribute($item-&gt;$type) : $item-&gt;$type</code>
-      <code>$this-&gt;autoEscape ? $this-&gt;escapeAttribute($item-&gt;content) : $item-&gt;content</code>
-      <code>$this-&gt;autoEscape ? $this-&gt;escapeAttribute($value) : $value</code>
-      <code>$this-&gt;getSeparator()</code>
+      <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($item->$type) : $item->$type]]></code>
+      <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($item->content) : $item->content]]></code>
+      <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($value) : $value]]></code>
+      <code><![CDATA[$this->getSeparator()]]></code>
       <code>$type</code>
       <code>$value</code>
     </MixedArgument>
@@ -361,8 +361,8 @@
       <code>$indent</code>
     </MixedOperand>
     <MixedPropertyFetch>
-      <code>$item-&gt;type</code>
-      <code>$item-&gt;{$item-&gt;type}</code>
+      <code><![CDATA[$item->type]]></code>
+      <code><![CDATA[$item->{$item->type}]]></code>
     </MixedPropertyFetch>
     <MixedReturnStatement>
       <code>parent::__call($method, $args)</code>
@@ -372,14 +372,14 @@
       <code>$value</code>
     </MoreSpecificImplementedParamType>
     <NullableReturnStatement>
-      <code>$this-&gt;offsetSet($index, $item)</code>
+      <code><![CDATA[$this->offsetSet($index, $item)]]></code>
     </NullableReturnStatement>
     <ParamNameMismatch>
       <code>$index</code>
       <code>$index</code>
     </ParamNameMismatch>
     <PossiblyNullArgument>
-      <code>$this-&gt;view</code>
+      <code><![CDATA[$this->view]]></code>
     </PossiblyNullArgument>
     <PossiblyNullReference>
       <code>plugin</code>
@@ -408,13 +408,13 @@
       <code>$indent</code>
       <code>$index</code>
       <code>$index</code>
-      <code>$item-&gt;attributes</code>
-      <code>$item-&gt;attributes['conditional']</code>
-      <code>$item-&gt;type</code>
-      <code>$item-&gt;type</code>
+      <code><![CDATA[$item->attributes]]></code>
+      <code><![CDATA[$item->attributes['conditional']]]></code>
+      <code><![CDATA[$item->type]]></code>
+      <code><![CDATA[$item->type]]></code>
       <code>$key</code>
-      <code>$this-&gt;autoEscape ? $this-&gt;escapeAttribute($value) : $value</code>
-      <code>$this-&gt;getSeparator()</code>
+      <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($value) : $value]]></code>
+      <code><![CDATA[$this->getSeparator()]]></code>
       <code>$value</code>
     </MixedArgument>
     <MixedAssignment>
@@ -425,7 +425,7 @@
       <code>$item</code>
       <code>$item</code>
       <code>$key</code>
-      <code>$this-&gt;captureType</code>
+      <code><![CDATA[$this->captureType]]></code>
       <code>$type</code>
       <code>$useCdata</code>
       <code>$value</code>
@@ -438,16 +438,16 @@
       <code>isXhtml</code>
     </MixedMethodCall>
     <MixedOperand>
-      <code>$item-&gt;attributes['conditional']</code>
-      <code>$item-&gt;source</code>
+      <code><![CDATA[$item->attributes['conditional']]]></code>
+      <code><![CDATA[$item->source]]></code>
       <code>$type</code>
     </MixedOperand>
     <MixedPropertyFetch>
-      <code>$item-&gt;attributes</code>
-      <code>$item-&gt;attributes</code>
-      <code>$item-&gt;source</code>
-      <code>$item-&gt;source</code>
-      <code>$item-&gt;type</code>
+      <code><![CDATA[$item->attributes]]></code>
+      <code><![CDATA[$item->attributes]]></code>
+      <code><![CDATA[$item->source]]></code>
+      <code><![CDATA[$item->source]]></code>
+      <code><![CDATA[$item->type]]></code>
     </MixedPropertyFetch>
     <MixedReturnStatement>
       <code>parent::__call($method, $args)</code>
@@ -468,7 +468,7 @@
       <code>(bool) $flag</code>
     </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType>
-      <code>(null !== $spec) &amp;&amp; is_string($spec)</code>
+      <code><![CDATA[(null !== $spec) && is_string($spec)]]></code>
       <code>is_string($spec)</code>
     </RedundantConditionGivenDocblockType>
     <UndefinedInterfaceMethod>
@@ -486,20 +486,19 @@
     <MixedArgument>
       <code>$content</code>
       <code>$enc</code>
-      <code>$escaper-&gt;escapeHtmlAttr($value)</code>
+      <code><![CDATA[$escaper->escapeHtmlAttr($value)]]></code>
       <code>$indent</code>
       <code>$index</code>
       <code>$item</code>
-      <code>$item-&gt;attributes['conditional']</code>
+      <code><![CDATA[$item->attributes['conditional']]]></code>
       <code>$key</code>
-      <code>$value</code>
       <code>$value</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$attributes['media']</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
-      <code>$item-&gt;attributes['conditional']</code>
+      <code><![CDATA[$item->attributes['conditional']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$content</code>
@@ -517,8 +516,8 @@
     <MixedOperand>
       <code>$indent</code>
       <code>$indent</code>
-      <code>$item-&gt;attributes['conditional']</code>
-      <code>$item-&gt;content</code>
+      <code><![CDATA[$item->attributes['conditional']]]></code>
+      <code><![CDATA[$item->content]]></code>
     </MixedOperand>
     <ParamNameMismatch>
       <code>$index</code>
@@ -537,7 +536,7 @@
       <code>$captureType</code>
     </PropertyNotSetInConstructor>
     <RedundantConditionGivenDocblockType>
-      <code>(null !== $content) &amp;&amp; is_string($content)</code>
+      <code><![CDATA[(null !== $content) && is_string($content)]]></code>
       <code>is_string($content)</code>
     </RedundantConditionGivenDocblockType>
     <UndefinedMagicMethod>
@@ -553,7 +552,7 @@
       <code>$item</code>
     </MissingClosureParamType>
     <MissingClosureReturnType>
-      <code>static fn($item) =&gt; $item</code>
+      <code><![CDATA[static fn($item) => $item]]></code>
     </MissingClosureReturnType>
     <MixedArgument>
       <code>$item</code>
@@ -662,7 +661,7 @@
       <code>$value</code>
     </MixedAssignment>
     <PossiblyNullArgument>
-      <code>$this-&gt;view</code>
+      <code><![CDATA[$this->view]]></code>
     </PossiblyNullArgument>
     <RedundantCastGivenDocblockType>
       <code>(bool) $useNamespaces</code>
@@ -689,7 +688,7 @@
       <code>null</code>
     </NullArgument>
     <RedundantConditionGivenDocblockType>
-      <code>$this-&gt;response instanceof Response</code>
+      <code><![CDATA[$this->response instanceof Response]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/Layout.php">
@@ -729,10 +728,10 @@
   </file>
   <file src="src/Helper/Navigation/AbstractHelper.php">
     <DocblockTypeContradiction>
-      <code>! is_int($this-&gt;minDepth)</code>
+      <code><![CDATA[! is_int($this->minDepth)]]></code>
       <code>! is_string($message)</code>
       <code>$container instanceof AbstractContainer</code>
-      <code>null === $this-&gt;container</code>
+      <code><![CDATA[null === $this->container]]></code>
     </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch>
       <code>AbstractHelper</code>
@@ -763,8 +762,8 @@
       <code>$minDepth</code>
     </MissingConstructor>
     <MixedArgument>
-      <code>$page-&gt;getTextDomain()</code>
-      <code>$page-&gt;getTextDomain()</code>
+      <code><![CDATA[$page->getTextDomain()]]></code>
+      <code><![CDATA[$page->getTextDomain()]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code>$container</code>
@@ -779,7 +778,7 @@
       <code>$label</code>
     </MixedOperand>
     <MixedReturnStatement>
-      <code>$results-&gt;last()</code>
+      <code><![CDATA[$results->last()]]></code>
     </MixedReturnStatement>
     <ParamNameMismatch>
       <code>$events</code>
@@ -788,7 +787,7 @@
       <code>strrpos($prefix, '\\')</code>
     </PossiblyFalseArgument>
     <PossiblyNullArgument>
-      <code>$page-&gt;getTitle()</code>
+      <code><![CDATA[$page->getTitle()]]></code>
     </PossiblyNullArgument>
     <PossiblyNullPropertyAssignmentValue>
       <code>$maxDepth</code>
@@ -798,7 +797,6 @@
       <code>attach</code>
       <code>getParent</code>
       <code>plugin</code>
-      <code>translate</code>
     </PossiblyNullReference>
     <RedundantCastGivenDocblockType>
       <code>(bool) $renderInvisible</code>
@@ -806,10 +804,10 @@
       <code>(string) $indent</code>
     </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType>
-      <code>$this-&gt;acl === null &amp;&amp; static::$defaultAcl !== null</code>
+      <code><![CDATA[$this->acl === null && static::$defaultAcl !== null]]></code>
       <code>is_int($maxDepth)</code>
       <code>is_int($minDepth)</code>
-      <code>null !== $this-&gt;container</code>
+      <code><![CDATA[null !== $this->container]]></code>
       <code>static::$defaultAcl !== null</code>
     </RedundantConditionGivenDocblockType>
     <ReferenceConstraintViolation>
@@ -830,8 +828,8 @@
       <code>null === $partial</code>
     </DocblockTypeContradiction>
     <InvalidReturnStatement>
-      <code>$this-&gt;renderPartialModel($params, $container, $partial)</code>
-      <code>$this-&gt;renderPartialModel([], $container, $partial)</code>
+      <code><![CDATA[$this->renderPartialModel($params, $container, $partial)]]></code>
+      <code><![CDATA[$this->renderPartialModel([], $container, $partial)]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code>string</code>
@@ -842,8 +840,8 @@
     </MissingConstructor>
     <MixedArgument>
       <code>$active</code>
-      <code>$active-&gt;getLabel()</code>
-      <code>$active-&gt;getTextDomain()</code>
+      <code><![CDATA[$active->getLabel()]]></code>
+      <code><![CDATA[$active->getTextDomain()]]></code>
       <code>$model['pages']</code>
       <code>$partial[0]</code>
     </MixedArgument>
@@ -908,7 +906,7 @@
       <code>$intermediate</code>
       <code>$page</code>
       <code>$page</code>
-      <code>$page-&gt;$meth()</code>
+      <code><![CDATA[$page->$meth()]]></code>
       <code>$type</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
@@ -948,7 +946,7 @@
       <code>(int) $renderFlag</code>
     </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType>
-      <code>$this-&gt;root</code>
+      <code><![CDATA[$this->root]]></code>
     </RedundantConditionGivenDocblockType>
     <TypeDoesNotContainNull>
       <code>null === $container</code>
@@ -979,8 +977,8 @@
       <code>null === $partial</code>
     </DocblockTypeContradiction>
     <InvalidReturnStatement>
-      <code>$this-&gt;renderPartialModel($params, $container, $partial)</code>
-      <code>$this-&gt;renderPartialModel([], $container, $partial)</code>
+      <code><![CDATA[$this->renderPartialModel($params, $container, $partial)]]></code>
+      <code><![CDATA[$this->renderPartialModel([], $container, $partial)]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code>string</code>
@@ -1008,8 +1006,8 @@
       <code>$options['ulClass']</code>
       <code>$page</code>
       <code>$page</code>
-      <code>$page-&gt;getTextDomain()</code>
-      <code>$page-&gt;getTextDomain()</code>
+      <code><![CDATA[$page->getTextDomain()]]></code>
+      <code><![CDATA[$page->getTextDomain()]]></code>
       <code>$partial[0]</code>
       <code>$subPage</code>
     </MixedArgument>
@@ -1052,7 +1050,7 @@
       <code>$container</code>
     </MoreSpecificImplementedParamType>
     <PossiblyNullArgument>
-      <code>$page-&gt;getTitle()</code>
+      <code><![CDATA[$page->getTitle()]]></code>
     </PossiblyNullArgument>
     <PossiblyNullOperand>
       <code>$minDepth</code>
@@ -1115,7 +1113,7 @@
       <code>$page</code>
       <code>$priority</code>
       <code>$serverUrlHelper</code>
-      <code>$this-&gt;serverUrl</code>
+      <code><![CDATA[$this->serverUrl]]></code>
     </MixedAssignment>
     <MixedFunctionCall>
       <code>$basePathHelper()</code>
@@ -1128,8 +1126,8 @@
     </MixedInferredReturnType>
     <MixedReturnStatement>
       <code>$escaper($string)</code>
-      <code>$this-&gt;serverUrl</code>
-      <code>$this-&gt;serverUrl</code>
+      <code><![CDATA[$this->serverUrl]]></code>
+      <code><![CDATA[$this->serverUrl]]></code>
     </MixedReturnStatement>
     <MoreSpecificImplementedParamType>
       <code>$container</code>
@@ -1155,7 +1153,7 @@
       <code>(string) $href</code>
     </RedundantCastGivenDocblockType>
     <RedundantPropertyInitializationCheck>
-      <code>isset($this-&gt;serverUrl)</code>
+      <code><![CDATA[isset($this->serverUrl)]]></code>
     </RedundantPropertyInitializationCheck>
     <UndefinedInterfaceMethod>
       <code>plugin</code>
@@ -1184,7 +1182,7 @@
       <code>$partialHelper($partial[0], $pages)</code>
     </MixedReturnStatement>
     <NoInterfaceProperties>
-      <code>$this-&gt;view-&gt;paginator</code>
+      <code><![CDATA[$this->view->paginator]]></code>
     </NoInterfaceProperties>
     <PossiblyNullReference>
       <code>plugin</code>
@@ -1232,13 +1230,13 @@
     </MixedArgument>
     <MixedAssignment>
       <code>$item</code>
-      <code>$this-&gt;objectKey</code>
+      <code><![CDATA[$this->objectKey]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$values-&gt;toArray()</code>
+      <code><![CDATA[$values->toArray()]]></code>
     </MixedReturnStatement>
     <MoreSpecificImplementedParamType>
       <code>$name</code>
@@ -1256,16 +1254,16 @@
   </file>
   <file src="src/Helper/Placeholder.php">
     <InvalidStringClass>
-      <code>new $this-&gt;containerClass($value)</code>
+      <code><![CDATA[new $this->containerClass($value)]]></code>
     </InvalidStringClass>
     <LessSpecificReturnStatement>
-      <code>$this-&gt;items[$key]</code>
+      <code><![CDATA[$this->items[$key]]]></code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType>
       <code>AbstractContainer</code>
     </MoreSpecificReturnType>
     <PropertyTypeCoercion>
-      <code>$this-&gt;items</code>
+      <code><![CDATA[$this->items]]></code>
     </PropertyTypeCoercion>
     <RedundantCastGivenDocblockType>
       <code>(string) $key</code>
@@ -1318,15 +1316,15 @@
       <code>(string) $separator</code>
     </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType>
-      <code>null !== $this-&gt;captureKey</code>
+      <code><![CDATA[null !== $this->captureKey]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/Placeholder/Container/AbstractStandalone.php">
     <InvalidStringClass>
-      <code>new $this-&gt;containerClass()</code>
+      <code><![CDATA[new $this->containerClass()]]></code>
     </InvalidStringClass>
     <LessSpecificReturnStatement>
-      <code>$this-&gt;container</code>
+      <code><![CDATA[$this->container]]></code>
     </LessSpecificReturnStatement>
     <MissingTemplateParam>
       <code>ArrayAccess</code>
@@ -1345,8 +1343,8 @@
       <code>escapeHtmlAttr</code>
     </MixedMethodCall>
     <MixedReturnStatement>
-      <code>$this-&gt;getEscaper()-&gt;escapeHtml((string) $string)</code>
-      <code>$this-&gt;getEscaper()-&gt;escapeHtmlAttr((string) $string)</code>
+      <code><![CDATA[$this->getEscaper()->escapeHtml((string) $string)]]></code>
+      <code><![CDATA[$this->getEscaper()->escapeHtmlAttr((string) $string)]]></code>
     </MixedReturnStatement>
     <MoreSpecificReturnType>
       <code>AbstractContainer</code>
@@ -1358,7 +1356,7 @@
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
     <PropertyTypeCoercion>
-      <code>new $this-&gt;containerClass()</code>
+      <code><![CDATA[new $this->containerClass()]]></code>
     </PropertyTypeCoercion>
     <RedundantCastGivenDocblockType>
       <code>(bool) $autoEscape</code>
@@ -1366,7 +1364,7 @@
       <code>(string) $string</code>
     </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType>
-      <code>null !== $this-&gt;container</code>
+      <code><![CDATA[null !== $this->container]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/Placeholder/Registry.php">
@@ -1374,16 +1372,16 @@
       <code>null === static::$instance</code>
     </DocblockTypeContradiction>
     <InvalidStringClass>
-      <code>new $this-&gt;containerClass($value)</code>
+      <code><![CDATA[new $this->containerClass($value)]]></code>
     </InvalidStringClass>
     <LessSpecificReturnStatement>
-      <code>$this-&gt;items[$key]</code>
+      <code><![CDATA[$this->items[$key]]]></code>
     </LessSpecificReturnStatement>
     <MixedInferredReturnType>
       <code>AbstractContainer</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$this-&gt;items[$key]</code>
+      <code><![CDATA[$this->items[$key]]]></code>
     </MixedReturnStatement>
     <MoreSpecificReturnType>
       <code>AbstractContainer</code>
@@ -1406,7 +1404,7 @@
     </MissingConstructor>
     <MixedAssignment>
       <code>$childModel</code>
-      <code>$this-&gt;viewModelHelper</code>
+      <code><![CDATA[$this->viewModelHelper]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
       <code>ViewModel</code>
@@ -1417,13 +1415,13 @@
     </MixedMethodCall>
     <MixedReturnStatement>
       <code>$childModel</code>
-      <code>$this-&gt;viewModelHelper</code>
+      <code><![CDATA[$this->viewModelHelper]]></code>
     </MixedReturnStatement>
     <PossiblyNullArgument>
-      <code>$this-&gt;getView()</code>
+      <code><![CDATA[$this->getView()]]></code>
     </PossiblyNullArgument>
     <PossiblyNullPropertyAssignmentValue>
-      <code>$model = $this-&gt;getCurrent()</code>
+      <code><![CDATA[$model = $this->getCurrent()]]></code>
     </PossiblyNullPropertyAssignmentValue>
     <PossiblyNullReference>
       <code>getChildren</code>
@@ -1431,7 +1429,7 @@
       <code>render</code>
     </PossiblyNullReference>
     <RedundantConditionGivenDocblockType>
-      <code>$this-&gt;viewModelHelper</code>
+      <code><![CDATA[$this->viewModelHelper]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/RenderToPlaceholder.php">
@@ -1464,8 +1462,8 @@
       <code>string</code>
     </InvalidNullableReturnType>
     <NullableReturnStatement>
-      <code>$this-&gt;host</code>
-      <code>$this-&gt;scheme</code>
+      <code><![CDATA[$this->host]]></code>
+      <code><![CDATA[$this->scheme]]></code>
     </NullableReturnStatement>
     <PossiblyUndefinedArrayOffset>
       <code>$_SERVER['REQUEST_URI']</code>
@@ -1544,7 +1542,7 @@
   </file>
   <file src="src/Helper/Url.php">
     <DocblockTypeContradiction>
-      <code>3 === func_num_args() &amp;&amp; is_bool($options)</code>
+      <code><![CDATA[3 === func_num_args() && is_bool($options)]]></code>
       <code>is_array($params)</code>
       <code>is_bool($options)</code>
     </DocblockTypeContradiction>
@@ -1565,10 +1563,10 @@
       <code>! $events</code>
     </DocblockTypeContradiction>
     <MixedArgument>
-      <code>$container-&gt;get('EventManager')</code>
-      <code>$container-&gt;get('MvcTranslator')</code>
-      <code>$container-&gt;get('Translator')</code>
-      <code>$container-&gt;get(TranslatorInterface::class)</code>
+      <code><![CDATA[$container->get('EventManager')]]></code>
+      <code><![CDATA[$container->get('MvcTranslator')]]></code>
+      <code><![CDATA[$container->get('Translator')]]></code>
+      <code><![CDATA[$container->get(TranslatorInterface::class)]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code>$container</code>
@@ -1591,8 +1589,8 @@
       <code>parent::get($name, $options)</code>
     </MixedReturnStatement>
     <PropertyTypeCoercion>
-      <code>$this-&gt;initializers</code>
-      <code>$this-&gt;initializers</code>
+      <code><![CDATA[$this->initializers]]></code>
+      <code><![CDATA[$this->initializers]]></code>
     </PropertyTypeCoercion>
     <UndefinedInterfaceMethod>
       <code>getServiceLocator</code>
@@ -1623,7 +1621,7 @@
       <code>int</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$this-&gt;options['errorLevel']</code>
+      <code><![CDATA[$this->options['errorLevel']]]></code>
     </MixedReturnStatement>
     <NonInvariantDocblockPropertyType>
       <code>$captureTo</code>
@@ -1631,15 +1629,15 @@
   </file>
   <file src="src/Model/FeedModel.php">
     <MixedAssignment>
-      <code>$this-&gt;type</code>
-      <code>$this-&gt;type</code>
+      <code><![CDATA[$this->type]]></code>
+      <code><![CDATA[$this->type]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
       <code>false|string</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$this-&gt;type</code>
-      <code>$this-&gt;type</code>
+      <code><![CDATA[$this->type]]></code>
+      <code><![CDATA[$this->type]]></code>
     </MixedReturnStatement>
     <PossiblyInvalidArgument>
       <code>$variables</code>
@@ -1648,7 +1646,7 @@
       <code>$feed</code>
     </PropertyNotSetInConstructor>
     <RedundantConditionGivenDocblockType>
-      <code>$this-&gt;feed instanceof Feed</code>
+      <code><![CDATA[$this->feed instanceof Feed]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Model/JsonModel.php">
@@ -1689,7 +1687,7 @@
       <code>getChildrenByCaptureTo</code>
     </MixedMethodCall>
     <MixedOperand>
-      <code>$child-&gt;getChildrenByCaptureTo($capture)</code>
+      <code><![CDATA[$child->getChildrenByCaptureTo($capture)]]></code>
     </MixedOperand>
     <MixedReturnStatement>
       <code>$children</code>
@@ -1698,9 +1696,6 @@
     <PossiblyInvalidArrayAccess>
       <code>$variables[$name]</code>
     </PossiblyInvalidArrayAccess>
-    <PossiblyInvalidPropertyAssignmentValue>
-      <code>$variables</code>
-    </PossiblyInvalidPropertyAssignmentValue>
     <RedundantCastGivenDocblockType>
       <code>(bool) $append</code>
       <code>(bool) $terminate</code>
@@ -1729,7 +1724,7 @@
     </MixedAssignment>
     <MixedOperand>
       <code>$setting</code>
-      <code>$this-&gt;getFilterChain()-&gt;filter($values['result'])</code>
+      <code><![CDATA[$this->getFilterChain()->filter($values['result'])]]></code>
     </MixedOperand>
     <ParamNameMismatch>
       <code>$model</code>
@@ -1791,7 +1786,7 @@
     </RedundantCondition>
     <RedundantConditionGivenDocblockType>
       <code>! is_object($nameOrModel)</code>
-      <code>null !== $this-&gt;jsonpCallback</code>
+      <code><![CDATA[null !== $this->jsonpCallback]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Renderer/PhpRenderer.php">
@@ -1804,9 +1799,9 @@
     </ImplementedParamTypeMismatch>
     <MixedArgument>
       <code>$__vars</code>
-      <code>$this-&gt;__template</code>
-      <code>$this-&gt;__template</code>
-      <code>array_pop($this-&gt;__varsCache)</code>
+      <code><![CDATA[$this->__template]]></code>
+      <code><![CDATA[$this->__template]]></code>
+      <code><![CDATA[array_pop($this->__varsCache)]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code>$vars[$name]</code>
@@ -1816,14 +1811,14 @@
       <code>$vars[$name]</code>
     </MixedArrayAssignment>
     <MixedArrayOffset>
-      <code>$this-&gt;__vars[$key]</code>
-      <code>$this-&gt;__vars[$key]</code>
+      <code><![CDATA[$this->__vars[$key]]]></code>
+      <code><![CDATA[$this->__vars[$key]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
       <code>$includeReturn</code>
       <code>$setting</code>
-      <code>$this-&gt;__template</code>
-      <code>$this-&gt;__vars</code>
+      <code><![CDATA[$this->__template]]></code>
+      <code><![CDATA[$this->__vars]]></code>
       <code>$value</code>
       <code>$value</code>
       <code>$variablesAsArray[$key]</code>
@@ -1834,7 +1829,7 @@
       <code>$vars[$name]</code>
     </MixedAssignment>
     <MixedClone>
-      <code>clone $this-&gt;vars()</code>
+      <code><![CDATA[clone $this->vars()]]></code>
     </MixedClone>
     <MixedInferredReturnType>
       <code>string</code>
@@ -1848,29 +1843,29 @@
       <code>$setting</code>
     </MixedOperand>
     <MixedReturnStatement>
-      <code>$this-&gt;__filterChain-&gt;filter($this-&gt;__content)</code>
-      <code>$this-&gt;__templateResolver-&gt;resolve($name, $this)</code>
+      <code><![CDATA[$this->__filterChain->filter($this->__content)]]></code>
+      <code><![CDATA[$this->__templateResolver->resolve($name, $this)]]></code>
     </MixedReturnStatement>
     <NullableReturnStatement>
-      <code>$this-&gt;__templateResolver</code>
+      <code><![CDATA[$this->__templateResolver]]></code>
     </NullableReturnStatement>
     <PossibleRawObjectIteration>
       <code>$variables</code>
     </PossibleRawObjectIteration>
     <PossiblyInvalidArgument>
-      <code>$this-&gt;__file</code>
+      <code><![CDATA[$this->__file]]></code>
       <code>$values</code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidPropertyAssignmentValue>
-      <code>$this-&gt;resolver($this-&gt;__template)</code>
+      <code><![CDATA[$this->resolver($this->__template)]]></code>
     </PossiblyInvalidPropertyAssignmentValue>
     <PossiblyNullArrayAccess>
-      <code>$this-&gt;__vars[$key]</code>
-      <code>$this-&gt;__vars[$key]</code>
+      <code><![CDATA[$this->__vars[$key]]]></code>
+      <code><![CDATA[$this->__vars[$key]]]></code>
     </PossiblyNullArrayAccess>
     <PossiblyNullReference>
-      <code>$this-&gt;__vars</code>
-      <code>$this-&gt;__vars</code>
+      <code><![CDATA[$this->__vars]]></code>
+      <code><![CDATA[$this->__vars]]></code>
       <code>resolve</code>
     </PossiblyNullReference>
     <RedundantCastGivenDocblockType>
@@ -1881,7 +1876,7 @@
       <code>is_object($variables)</code>
     </RedundantConditionGivenDocblockType>
     <UnresolvableInclude>
-      <code>include $this-&gt;__file</code>
+      <code><![CDATA[include $this->__file]]></code>
     </UnresolvableInclude>
   </file>
   <file src="src/Resolver/AggregateResolver.php">
@@ -1891,9 +1886,9 @@
     <MixedAssignment>
       <code>$resolver</code>
       <code>$resource</code>
-      <code>$this-&gt;lastLookupFailure</code>
-      <code>$this-&gt;lastLookupFailure</code>
-      <code>$this-&gt;lastSuccessfulResolver</code>
+      <code><![CDATA[$this->lastLookupFailure]]></code>
+      <code><![CDATA[$this->lastLookupFailure]]></code>
+      <code><![CDATA[$this->lastSuccessfulResolver]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
       <code>false|string</code>
@@ -1921,8 +1916,8 @@
   </file>
   <file src="src/Resolver/TemplateMapResolver.php">
     <DocblockTypeContradiction>
-      <code>! is_array($map) &amp;&amp; ! $map instanceof Traversable</code>
-      <code>! is_array($map) &amp;&amp; ! $map instanceof Traversable</code>
+      <code><![CDATA[! is_array($map) && ! $map instanceof Traversable]]></code>
+      <code><![CDATA[! is_array($map) && ! $map instanceof Traversable]]></code>
       <code>is_string($nameOrMap)</code>
     </DocblockTypeContradiction>
     <MissingTemplateParam>
@@ -1932,7 +1927,7 @@
       <code>false|string</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$this-&gt;map[$name]</code>
+      <code><![CDATA[$this->map[$name]]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Resolver/TemplatePathStack.php">
@@ -1950,12 +1945,12 @@
       <code>$value</code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$this-&gt;lastLookupFailure</code>
-      <code>$this-&gt;lastLookupFailure</code>
+      <code><![CDATA[$this->lastLookupFailure]]></code>
+      <code><![CDATA[$this->lastLookupFailure]]></code>
       <code>$value</code>
     </MixedAssignment>
     <NullArgument>
-      <code>$this-&gt;paths</code>
+      <code><![CDATA[$this->paths]]></code>
     </NullArgument>
     <RedundantCastGivenDocblockType>
       <code>(bool) $flag</code>
@@ -2027,9 +2022,9 @@
       <code>$whence</code>
     </MissingParamType>
     <MixedAssignment>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
+      <code><![CDATA[$this->pos]]></code>
+      <code><![CDATA[$this->pos]]></code>
+      <code><![CDATA[$this->pos]]></code>
     </MixedAssignment>
     <MixedOperand>
       <code>$offset</code>
@@ -2043,9 +2038,6 @@
     </UnevaluatedCode>
   </file>
   <file src="src/Variables.php">
-    <InvalidCast>
-      <code>ArrayIterator::class</code>
-    </InvalidCast>
     <MissingTemplateParam>
       <code>Variables</code>
     </MissingTemplateParam>
@@ -2126,7 +2118,7 @@
   </file>
   <file src="test/Helper/CycleTest.php">
     <RedundantCastGivenDocblockType>
-      <code>(string) $this-&gt;helper-&gt;toString()</code>
+      <code><![CDATA[(string) $this->helper->toString()]]></code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="test/Helper/DeclareVarsTest.php">
@@ -2143,15 +2135,15 @@
       <code>$vars</code>
     </MixedPropertyAssignment>
     <MixedPropertyFetch>
-      <code>$vars-&gt;varName1</code>
-      <code>$vars-&gt;varName1</code>
-      <code>$vars-&gt;varName2</code>
-      <code>$vars-&gt;varName2</code>
-      <code>$vars-&gt;varName3</code>
-      <code>$vars-&gt;varName3</code>
-      <code>$vars-&gt;varName4</code>
-      <code>$vars-&gt;varName4</code>
-      <code>$vars-&gt;varName5</code>
+      <code><![CDATA[$vars->varName1]]></code>
+      <code><![CDATA[$vars->varName1]]></code>
+      <code><![CDATA[$vars->varName2]]></code>
+      <code><![CDATA[$vars->varName2]]></code>
+      <code><![CDATA[$vars->varName3]]></code>
+      <code><![CDATA[$vars->varName3]]></code>
+      <code><![CDATA[$vars->varName4]]></code>
+      <code><![CDATA[$vars->varName4]]></code>
+      <code><![CDATA[$vars->varName5]]></code>
     </MixedPropertyFetch>
     <PossiblyInvalidMethodCall>
       <code>addPath</code>
@@ -2204,7 +2196,7 @@
     <ArgumentTypeCoercion>
       <code>$plugin</code>
       <code>$plugin</code>
-      <code>$this-&gt;mvcPluginClass</code>
+      <code><![CDATA[$this->mvcPluginClass]]></code>
     </ArgumentTypeCoercion>
     <DeprecatedClass>
       <code>FlashMessenger</code>
@@ -2327,17 +2319,17 @@
       <code>$attributeEscaper('/foo/bar')</code>
     </MixedOperand>
     <MixedPropertyFetch>
-      <code>$item-&gt;conditionalStylesheet</code>
-      <code>$item-&gt;conditionalStylesheet</code>
-      <code>$item-&gt;conditionalStylesheet</code>
-      <code>$item-&gt;conditionalStylesheet</code>
-      <code>$item-&gt;conditionalStylesheet</code>
-      <code>$item-&gt;media</code>
-      <code>$link-&gt;href</code>
-      <code>$link-&gt;href</code>
-      <code>$value-&gt;href</code>
-      <code>$value-&gt;href</code>
-      <code>$value-&gt;href</code>
+      <code><![CDATA[$item->conditionalStylesheet]]></code>
+      <code><![CDATA[$item->conditionalStylesheet]]></code>
+      <code><![CDATA[$item->conditionalStylesheet]]></code>
+      <code><![CDATA[$item->conditionalStylesheet]]></code>
+      <code><![CDATA[$item->conditionalStylesheet]]></code>
+      <code><![CDATA[$item->media]]></code>
+      <code><![CDATA[$link->href]]></code>
+      <code><![CDATA[$link->href]]></code>
+      <code><![CDATA[$value->href]]></code>
+      <code><![CDATA[$value->href]]></code>
+      <code><![CDATA[$value->href]]></code>
     </MixedPropertyFetch>
     <UndefinedMagicMethod>
       <code>appendNext</code>
@@ -2377,9 +2369,9 @@
       <code>$item</code>
       <code>$item</code>
       <code>$item</code>
-      <code>$item-&gt;type</code>
-      <code>$item-&gt;type</code>
-      <code>$item-&gt;type</code>
+      <code><![CDATA[$item->type]]></code>
+      <code><![CDATA[$item->type]]></code>
+      <code><![CDATA[$item->type]]></code>
       <code>$modifiers</code>
       <code>$modifiers</code>
       <code>$value</code>
@@ -2418,22 +2410,22 @@
       <code>$attributeEscaper('foo bar')</code>
     </MixedOperand>
     <MixedPropertyFetch>
-      <code>$item-&gt;content</code>
-      <code>$item-&gt;content</code>
-      <code>$item-&gt;content</code>
-      <code>$item-&gt;content</code>
-      <code>$item-&gt;content</code>
-      <code>$item-&gt;name</code>
-      <code>$item-&gt;name</code>
-      <code>$item-&gt;type</code>
-      <code>$item-&gt;type</code>
-      <code>$item-&gt;type</code>
-      <code>$item-&gt;type</code>
-      <code>$item-&gt;type</code>
-      <code>$item-&gt;{$item-&gt;type}</code>
-      <code>$item-&gt;{$item-&gt;type}</code>
-      <code>$item-&gt;{$item-&gt;type}</code>
-      <code>$value-&gt;modifiers</code>
+      <code><![CDATA[$item->content]]></code>
+      <code><![CDATA[$item->content]]></code>
+      <code><![CDATA[$item->content]]></code>
+      <code><![CDATA[$item->content]]></code>
+      <code><![CDATA[$item->content]]></code>
+      <code><![CDATA[$item->name]]></code>
+      <code><![CDATA[$item->name]]></code>
+      <code><![CDATA[$item->type]]></code>
+      <code><![CDATA[$item->type]]></code>
+      <code><![CDATA[$item->type]]></code>
+      <code><![CDATA[$item->type]]></code>
+      <code><![CDATA[$item->type]]></code>
+      <code><![CDATA[$item->{$item->type}]]></code>
+      <code><![CDATA[$item->{$item->type}]]></code>
+      <code><![CDATA[$item->{$item->type}]]></code>
+      <code><![CDATA[$value->modifiers]]></code>
     </MixedPropertyFetch>
     <UndefinedMagicMethod>
       <code>getArrayCopy</code>
@@ -2463,7 +2455,7 @@
       <code>$item</code>
       <code>$item</code>
       <code>$item</code>
-      <code>$item-&gt;source</code>
+      <code><![CDATA[$item->source]]></code>
       <code>$values</code>
       <code>$values</code>
       <code>$values</code>
@@ -2473,20 +2465,20 @@
       <code>$values</code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$first-&gt;attributes['src']</code>
+      <code><![CDATA[$first->attributes['src']]]></code>
       <code>$items[$i]</code>
       <code>$values[$i]</code>
       <code>$values[$i]</code>
       <code>$values[$i]</code>
-      <code>$values[$i]-&gt;attributes['src']</code>
+      <code><![CDATA[$values[$i]->attributes['src']]]></code>
       <code>$values[0]</code>
       <code>$values[0]</code>
       <code>$values[0]</code>
-      <code>$values[0]-&gt;attributes['src']</code>
+      <code><![CDATA[$values[0]->attributes['src']]]></code>
       <code>$values[5]</code>
       <code>$values[5]</code>
       <code>$values[5]</code>
-      <code>$values[5]-&gt;attributes['src']</code>
+      <code><![CDATA[$values[5]->attributes['src']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$first</code>
@@ -2500,25 +2492,25 @@
       <code>$values</code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>Generator&lt;string, array&lt;int, string&gt;</code>
+      <code><![CDATA[Generator<string, array<int, string>]]></code>
     </MixedInferredReturnType>
     <MixedPropertyFetch>
-      <code>$first-&gt;attributes</code>
-      <code>$first-&gt;source</code>
-      <code>$first-&gt;type</code>
-      <code>$item-&gt;attributes</code>
-      <code>$item-&gt;source</code>
-      <code>$item-&gt;source</code>
-      <code>$item-&gt;source</code>
-      <code>$values[$i]-&gt;attributes</code>
-      <code>$values[$i]-&gt;source</code>
-      <code>$values[$i]-&gt;type</code>
-      <code>$values[0]-&gt;attributes</code>
-      <code>$values[0]-&gt;source</code>
-      <code>$values[0]-&gt;type</code>
-      <code>$values[5]-&gt;attributes</code>
-      <code>$values[5]-&gt;source</code>
-      <code>$values[5]-&gt;type</code>
+      <code><![CDATA[$first->attributes]]></code>
+      <code><![CDATA[$first->source]]></code>
+      <code><![CDATA[$first->type]]></code>
+      <code><![CDATA[$item->attributes]]></code>
+      <code><![CDATA[$item->source]]></code>
+      <code><![CDATA[$item->source]]></code>
+      <code><![CDATA[$item->source]]></code>
+      <code><![CDATA[$values[$i]->attributes]]></code>
+      <code><![CDATA[$values[$i]->source]]></code>
+      <code><![CDATA[$values[$i]->type]]></code>
+      <code><![CDATA[$values[0]->attributes]]></code>
+      <code><![CDATA[$values[0]->source]]></code>
+      <code><![CDATA[$values[0]->type]]></code>
+      <code><![CDATA[$values[5]->attributes]]></code>
+      <code><![CDATA[$values[5]->source]]></code>
+      <code><![CDATA[$values[5]->type]]></code>
     </MixedPropertyFetch>
     <UndefinedMagicMethod>
       <code>getArrayCopy</code>
@@ -2533,8 +2525,8 @@
   </file>
   <file src="test/Helper/HeadStyleTest.php">
     <MixedArgument>
-      <code>$item-&gt;content</code>
-      <code>$item-&gt;content</code>
+      <code><![CDATA[$item->content]]></code>
+      <code><![CDATA[$item->content]]></code>
       <code>$value</code>
       <code>$values</code>
       <code>$values</code>
@@ -2544,9 +2536,9 @@
       <code>$values</code>
       <code>$values</code>
       <code>$values</code>
-      <code>$values[0]-&gt;content</code>
-      <code>$values[1]-&gt;content</code>
-      <code>$values[2]-&gt;content</code>
+      <code><![CDATA[$values[0]->content]]></code>
+      <code><![CDATA[$values[1]->content]]></code>
+      <code><![CDATA[$values[2]->content]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code>$values[$i]</code>
@@ -2565,12 +2557,12 @@
       <code>$values</code>
     </MixedAssignment>
     <MixedPropertyFetch>
-      <code>$item-&gt;content</code>
-      <code>$item-&gt;content</code>
-      <code>$value-&gt;attributes</code>
-      <code>$values[0]-&gt;content</code>
-      <code>$values[1]-&gt;content</code>
-      <code>$values[2]-&gt;content</code>
+      <code><![CDATA[$item->content]]></code>
+      <code><![CDATA[$item->content]]></code>
+      <code><![CDATA[$value->attributes]]></code>
+      <code><![CDATA[$values[0]->content]]></code>
+      <code><![CDATA[$values[1]->content]]></code>
+      <code><![CDATA[$values[2]->content]]></code>
     </MixedPropertyFetch>
     <UndefinedMagicMethod>
       <code>bogusMethod</code>
@@ -2610,7 +2602,7 @@
     <MixedArgument>
       <code>$acl</code>
       <code>$acl</code>
-      <code>$this-&gt;serviceManager-&gt;get('Navigation')</code>
+      <code><![CDATA[$this->serviceManager->get('Navigation')]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code>$acl</code>
@@ -2622,7 +2614,7 @@
       <code>$_helper</code>
     </NonInvariantDocblockPropertyType>
     <RedundantConditionGivenDocblockType>
-      <code>$this-&gt;_helper</code>
+      <code><![CDATA[$this->_helper]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/Helper/Navigation/AbstractTest.php">
@@ -2824,9 +2816,9 @@
   </file>
   <file src="test/Helper/Navigation/NavigationTest.php">
     <InvalidArgument>
-      <code>function (int $code, string $message) {
-            $this-&gt;errorHandlerMessage = $message;
-        }</code>
+      <code><![CDATA[function (int $code, string $message) {
+            $this->errorHandlerMessage = $message;
+        }]]></code>
     </InvalidArgument>
     <MixedArgument>
       <code>$acl['acl']</code>
@@ -2847,20 +2839,17 @@
       <code>$_helper</code>
     </NonInvariantDocblockPropertyType>
     <PossiblyNullArgument>
-      <code>$this-&gt;errorHandlerMessage</code>
+      <code><![CDATA[$this->errorHandlerMessage]]></code>
     </PossiblyNullArgument>
     <TooManyArguments>
-      <code>new Page\Uri([
-                'resource'  =&gt; 'unknownresource',
-                'privilege' =&gt; 'someprivilege',
-            ], false)</code>
+      <code><![CDATA[new Page\Uri([
+                'resource'  => 'unknownresource',
+                'privilege' => 'someprivilege',
+            ], false)]]></code>
     </TooManyArguments>
     <UndefinedClass>
       <code>PsrContainerDecorator</code>
     </UndefinedClass>
-    <UnusedClosureParam>
-      <code>$code</code>
-    </UnusedClosureParam>
   </file>
   <file src="test/Helper/Navigation/SitemapTest.php">
     <MixedArgument>
@@ -2880,20 +2869,20 @@
       <code>plugin</code>
     </UndefinedInterfaceMethod>
     <UnevaluatedCode>
-      <code>$nav = clone $this-&gt;nav2;</code>
-      <code>$nav-&gt;addPage(['label' =&gt; 'Invalid', 'uri' =&gt; 'http://w.']);</code>
-      <code>static::fail('A Laminas\View\Exception\InvalidArgumentException was not thrown on invalid &lt;loc /&gt;');</code>
-      <code>try {
-            $this-&gt;_helper-&gt;render($nav);
+      <code><![CDATA[$nav = clone $this->nav2;]]></code>
+      <code><![CDATA[$nav->addPage(['label' => 'Invalid', 'uri' => 'http://w.']);]]></code>
+      <code><![CDATA[static::fail('A Laminas\View\Exception\InvalidArgumentException was not thrown on invalid <loc />');]]></code>
+      <code><![CDATA[try {
+            $this->_helper->render($nav);
         } catch (View\Exception\ExceptionInterface $e) {
             $expected = sprintf(
                 'Encountered an invalid URL for Sitemap XML: "%s"',
                 'http://w.'
             );
-            $actual   = $e-&gt;getMessage();
+            $actual   = $e->getMessage();
             static::assertEquals($expected, $actual);
             return;
-        }</code>
+        }]]></code>
     </UnevaluatedCode>
   </file>
   <file src="test/Helper/PaginationControlTest.php">
@@ -2942,10 +2931,10 @@
       <code>$value</code>
     </MixedAssignment>
     <MixedOperand>
-      <code>$item-&gt;message</code>
-      <code>$item-&gt;message</code>
-      <code>$item-&gt;objectKey</code>
-      <code>$item-&gt;objectKey</code>
+      <code><![CDATA[$item->message]]></code>
+      <code><![CDATA[$item->message]]></code>
+      <code><![CDATA[$item->objectKey]]></code>
+      <code><![CDATA[$item->objectKey]]></code>
       <code>$value</code>
       <code>$value</code>
     </MixedOperand>
@@ -3054,8 +3043,8 @@
       <code>addPath</code>
     </UndefinedInterfaceMethod>
     <UndefinedPropertyFetch>
-      <code>$item-&gt;message</code>
-      <code>$item-&gt;message</code>
+      <code><![CDATA[$item->message]]></code>
+      <code><![CDATA[$item->message]]></code>
     </UndefinedPropertyFetch>
     <UnusedVariable>
       <code>$data</code>
@@ -3082,11 +3071,11 @@
       <code>$value</code>
     </MixedAssignment>
     <MixedPropertyAssignment>
-      <code>$view-&gt;vars()</code>
+      <code><![CDATA[$view->vars()]]></code>
     </MixedPropertyAssignment>
     <PossibleRawObjectIteration>
-      <code>$model-&gt;getVariables()</code>
-      <code>$model-&gt;getVariables()</code>
+      <code><![CDATA[$model->getVariables()]]></code>
+      <code><![CDATA[$model->getVariables()]]></code>
     </PossibleRawObjectIteration>
     <PossiblyInvalidArgument>
       <code>$return</code>
@@ -3131,7 +3120,7 @@
   </file>
   <file src="test/Helper/Placeholder/RegistryTest.php">
     <UndefinedPropertyFetch>
-      <code>$container-&gt;data</code>
+      <code><![CDATA[$container->data]]></code>
     </UndefinedPropertyFetch>
   </file>
   <file src="test/Helper/ServerUrlTest.php">
@@ -3142,7 +3131,7 @@
   </file>
   <file src="test/Helper/TestAsset/ArrayTranslator.php">
     <InvalidArgument>
-      <code>$this-&gt;translations</code>
+      <code><![CDATA[$this->translations]]></code>
     </InvalidArgument>
   </file>
   <file src="test/Helper/TestAsset/Bar.php">
@@ -3165,6 +3154,9 @@
     <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
+    <UndefinedAttributeClass>
+      <code>AllowDynamicProperties</code>
+    </UndefinedAttributeClass>
   </file>
   <file src="test/Helper/TestAsset/MockContainer.php">
     <PropertyNotSetInConstructor>
@@ -3194,7 +3186,7 @@
     </MixedAssignment>
     <MixedFunctionCall>
       <code>$urlHelper('test')</code>
-      <code>$urlHelper('test', [], ['force_canonical' =&gt; true])</code>
+      <code><![CDATA[$urlHelper('test', [], ['force_canonical' => true])]]></code>
     </MixedFunctionCall>
     <MixedMethodCall>
       <code>bootstrap</code>
@@ -3228,7 +3220,7 @@
       <code>$target</code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>Generator&lt;mixed, array{0: mixed, 1: mixed}, mixed, void&gt;</code>
+      <code><![CDATA[Generator<mixed, array{0: mixed, 1: mixed}, mixed, void>]]></code>
     </MixedInferredReturnType>
   </file>
   <file src="test/HelperPluginManagerTest.php">
@@ -3252,34 +3244,6 @@
       <code>new stdClass()</code>
       <code>new stdClass()</code>
     </InvalidArgument>
-    <LessSpecificReturnStatement>
-      <code>[
-            // variables                     default   expected
-
-            // if it is set always get the value
-            [['foo' =&gt; 'bar'], 'baz', 'bar'],
-            [['foo' =&gt; 'bar'], null, 'bar'],
-            [new ArrayObject(['foo' =&gt; 'bar']), 'baz', 'bar'],
-            [new ArrayObject(['foo' =&gt; 'bar']), null, 'bar'],
-
-            // if it is null always get null value
-            [['foo' =&gt; null], null, null],
-            [['foo' =&gt; null], 'baz', null],
-            [new ArrayObject(['foo' =&gt; null]), null, null],
-            [new ArrayObject(['foo' =&gt; null]), 'baz', null],
-
-            // when it is not set always get default value
-            [[], 'baz', 'baz'],
-            [new ArrayObject(),                 'baz', 'baz'],
-        ]</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType>
-      <code>array&lt;array-key, array{
-     *     0: array&lt;string, null|string&gt;|ArrayObject&lt;string, null|string&gt;,
-     *     1: null|string,
-     *     2: null|string
-     * }&gt;</code>
-    </MoreSpecificReturnType>
     <PossiblyInvalidArrayAccess>
       <code>$variables['foo']</code>
     </PossiblyInvalidArrayAccess>
@@ -3302,7 +3266,7 @@
       <code>getArrayCopy</code>
     </MixedMethodCall>
     <MixedPropertyFetch>
-      <code>$this-&gt;renderer-&gt;vars()-&gt;foo</code>
+      <code><![CDATA[$this->renderer->vars()->foo]]></code>
     </MixedPropertyFetch>
     <PossiblyInvalidArrayAssignment>
       <code>$vars['foo']</code>
@@ -3354,12 +3318,12 @@
   </file>
   <file src="test/Strategy/JsonStrategyTest.php">
     <MixedArgument>
-      <code>$headers-&gt;get('content-type')-&gt;getFieldValue()</code>
-      <code>$headers-&gt;get('content-type')-&gt;getFieldValue()</code>
-      <code>$headers-&gt;get('content-type')-&gt;getFieldValue()</code>
-      <code>$headers-&gt;get('content-type')-&gt;getFieldValue()</code>
-      <code>$headers-&gt;get('content-type')-&gt;getFieldValue()</code>
-      <code>$headers-&gt;get('content-type')-&gt;getFieldValue()</code>
+      <code><![CDATA[$headers->get('content-type')->getFieldValue()]]></code>
+      <code><![CDATA[$headers->get('content-type')->getFieldValue()]]></code>
+      <code><![CDATA[$headers->get('content-type')->getFieldValue()]]></code>
+      <code><![CDATA[$headers->get('content-type')->getFieldValue()]]></code>
+      <code><![CDATA[$headers->get('content-type')->getFieldValue()]]></code>
+      <code><![CDATA[$headers->get('content-type')->getFieldValue()]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code>$content</code>
@@ -3433,8 +3397,8 @@
       <code>$e</code>
     </MissingClosureParamType>
     <MixedArgument>
-      <code>$result-&gt;content</code>
-      <code>$this-&gt;result-&gt;content</code>
+      <code><![CDATA[$result->content]]></code>
+      <code><![CDATA[$this->result->content]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code>$result[]</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -798,11 +798,14 @@
     </MixedAssignment>
     <MixedInferredReturnType>
       <code>bool</code>
+      <code>string</code>
     </MixedInferredReturnType>
     <MixedOperand>
       <code>$label</code>
     </MixedOperand>
     <MixedReturnStatement>
+      <code>$message</code>
+      <code>$message</code>
       <code><![CDATA[$results->last()]]></code>
     </MixedReturnStatement>
     <ParamNameMismatch>

--- a/src/Helper/Navigation/AbstractHelper.php
+++ b/src/Helper/Navigation/AbstractHelper.php
@@ -434,7 +434,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     protected function translate($message, $textDomain = null)
     {
         if (! is_string($message) || empty($message)) {
-            return '';
+            return $message;
         }
 
         if (! $this->isTranslatorEnabled() || ! $this->hasTranslator()) {

--- a/src/Helper/Navigation/AbstractHelper.php
+++ b/src/Helper/Navigation/AbstractHelper.php
@@ -9,6 +9,7 @@ use Laminas\EventManager\EventManager;
 use Laminas\EventManager\EventManagerAwareInterface;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\EventManager\SharedEventManager;
+use Laminas\I18n\Translator\TranslatorInterface;
 use Laminas\Navigation;
 use Laminas\Navigation\AbstractContainer;
 use Laminas\Navigation\Page\AbstractPage;
@@ -21,6 +22,7 @@ use Laminas\View\Helper\TranslatorAwareTrait;
 use RecursiveIteratorIterator;
 use ReflectionClass;
 
+use function assert;
 use function call_user_func_array;
 use function gettype;
 use function in_array;
@@ -432,7 +434,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     protected function translate($message, $textDomain = null)
     {
         if (! is_string($message) || empty($message)) {
-            return $message;
+            return '';
         }
 
         if (! $this->isTranslatorEnabled() || ! $this->hasTranslator()) {
@@ -440,6 +442,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
         }
 
         $translator = $this->getTranslator();
+        assert($translator instanceof TranslatorInterface);
         $textDomain = $textDomain ?: $this->getTranslatorTextDomain();
 
         return $translator->translate($message, $textDomain);

--- a/test/Helper/Navigation/NavigationTest.php
+++ b/test/Helper/Navigation/NavigationTest.php
@@ -577,9 +577,8 @@ class NavigationTest extends AbstractTest
         $plugins = $helper->getPluginManager();
         $this->assertInstanceOf(Navigation\PluginManager::class, $plugins);
 
-        $pluginsReflection = new ReflectionObject($plugins);
-        $creationContext   = $pluginsReflection->getProperty('creationContext');
-        $creationContext->setAccessible(true);
+        $pluginsReflection    = new ReflectionObject($plugins);
+        $creationContext      = $pluginsReflection->getProperty('creationContext');
         $creationContextValue = $creationContext->getValue($plugins);
 
         /** Later versions of AbstractPluginManager Decorate Psr Containers */

--- a/test/Helper/Navigation/PluginManagerCompatibilityTest.php
+++ b/test/Helper/Navigation/PluginManagerCompatibilityTest.php
@@ -17,7 +17,7 @@ class PluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
 
-    protected function getPluginManager(): PluginManager
+    protected static function getPluginManager(): PluginManager
     {
         return new PluginManager(new ServiceManager());
     }

--- a/test/Helper/UrlIntegrationTest.php
+++ b/test/Helper/UrlIntegrationTest.php
@@ -39,8 +39,7 @@ class UrlIntegrationTest extends TestCase
         $serviceListenerFactory           = new ServiceListenerFactory();
         $serviceListenerFactoryReflection = new ReflectionObject($serviceListenerFactory);
         $serviceConfigReflection          = $serviceListenerFactoryReflection->getProperty('defaultServiceConfig');
-        $serviceConfigReflection->setAccessible(true);
-        $serviceConfig = $serviceConfigReflection->getValue($serviceListenerFactory);
+        $serviceConfig                    = $serviceConfigReflection->getValue($serviceListenerFactory);
 
         $this->serviceManager = new ServiceManager();
         (new ServiceManagerConfig($serviceConfig))->configureServiceManager($this->serviceManager);

--- a/test/Helper/UrlTest.php
+++ b/test/Helper/UrlTest.php
@@ -197,9 +197,8 @@ class UrlTest extends TestCase
         $url    = new UrlHelper();
         $url->setRouter($router);
 
-        $urlReflection  = new ReflectionObject($url);
-        $routerProperty = $urlReflection->getProperty('router');
-        $routerProperty->setAccessible(true);
+        $urlReflection       = new ReflectionObject($url);
+        $routerProperty      = $urlReflection->getProperty('router');
         $routerPropertyValue = $routerProperty->getValue($url);
 
         $this->assertSame($router, $routerPropertyValue);
@@ -211,9 +210,8 @@ class UrlTest extends TestCase
         $url        = new UrlHelper();
         $url->setRouteMatch($routeMatch);
 
-        $routeMatchReflection = new ReflectionObject($url);
-        $routeMatchProperty   = $routeMatchReflection->getProperty('routeMatch');
-        $routeMatchProperty->setAccessible(true);
+        $routeMatchReflection    = new ReflectionObject($url);
+        $routeMatchProperty      = $routeMatchReflection->getProperty('routeMatch');
         $routeMatchPropertyValue = $routeMatchProperty->getValue($url);
 
         $this->assertSame($routeMatch, $routeMatchPropertyValue);

--- a/test/HelperPluginManagerCompatibilityTest.php
+++ b/test/HelperPluginManagerCompatibilityTest.php
@@ -23,7 +23,7 @@ class HelperPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
 
-    protected function getPluginManager(): HelperPluginManager
+    protected static function getPluginManager(): HelperPluginManager
     {
         $factories = [];
 
@@ -59,8 +59,7 @@ class HelperPluginManagerCompatibilityTest extends TestCase
     {
         $pluginManager = $this->getPluginManager();
         $r             = new ReflectionProperty($pluginManager, 'aliases');
-        $r->setAccessible(true);
-        $aliases = $r->getValue($pluginManager);
+        $aliases       = $r->getValue($pluginManager);
 
         foreach ($aliases as $alias => $target) {
             // Skipping conditionally since it depends on laminas-mvc

--- a/test/Model/ViewModelTest.php
+++ b/test/Model/ViewModelTest.php
@@ -364,9 +364,9 @@ class ViewModelTest extends TestCase
 
     /**
      * @psalm-return array<array-key, array{
-     *     0: array<string, null|string>|ArrayObject<string, null|string>,
+     *     0: array<string, null|string>|ArrayObject<string, null|string>|ArrayObject,
      *     1: null|string,
-     *     2: null|string
+     *     2: null|string,
      * }>
      */
     public function variableValue(): array

--- a/test/PhpRendererTest.php
+++ b/test/PhpRendererTest.php
@@ -466,8 +466,7 @@ class PhpRendererTest extends TestCase
         $this->assertStringContainsString('Empty view', $result);
         $rendererReflection = new ReflectionObject($this->renderer);
         $method             = $rendererReflection->getProperty('__filterChain');
-        $method->setAccessible(true);
-        $filterChain = $method->getValue($this->renderer);
+        $filterChain        = $method->getValue($this->renderer);
 
         $this->assertEmpty($filterChain);
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes
| QA            | yes

### Description

Includes commits from #201

Works around a BC break relating to tests introduced in `laminas-servicemanager` 3.21 where a protected method was made static.

Resolves SA issues introduced by the PHP upgrade and baselines other (currently) unfixable SA issues