### PR TITLE
Clean up HeadStyle View Helper

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.12.0@f90118cdeacd0088e7215e64c0c99ceca819e176">
+<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
   <file src="bin/templatemap_generator.php">
     <MissingParamType>
       <code>$templatePath</code>
@@ -507,64 +507,20 @@
     </MethodSignatureMustProvideReturnType>
     <MixedArgument>
       <code>$content</code>
-      <code>$enc</code>
-      <code><![CDATA[$escaper->escapeHtmlAttr($value)]]></code>
-      <code>$indent</code>
       <code>$index</code>
-      <code>$item</code>
-      <code><![CDATA[$item->attributes['conditional']]]></code>
-      <code>$key</code>
-      <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$attributes['media']]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayAccess>
-      <code><![CDATA[$item->attributes['conditional']]]></code>
-    </MixedArrayAccess>
     <MixedAssignment>
       <code>$content</code>
-      <code>$enc</code>
-      <code>$escaper</code>
-      <code>$indent</code>
       <code>$index</code>
-      <code>$item</code>
-      <code>$key</code>
-      <code>$value</code>
     </MixedAssignment>
-    <MixedMethodCall>
-      <code>escapeHtmlAttr</code>
-    </MixedMethodCall>
-    <MixedOperand>
-      <code>$indent</code>
-      <code>$indent</code>
-      <code><![CDATA[$item->attributes['conditional']]]></code>
-      <code><![CDATA[$item->content]]></code>
-    </MixedOperand>
     <ParamNameMismatch>
       <code>$index</code>
     </ParamNameMismatch>
-    <PossiblyNullOperand>
-      <code>$escapeEnd</code>
-      <code>$escapeStart</code>
-    </PossiblyNullOperand>
-    <PossiblyNullPropertyAssignmentValue>
-      <code>$attrs</code>
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor>
-      <code>$captureAttrs</code>
-      <code>$captureLock</code>
-      <code>$captureType</code>
-    </PropertyNotSetInConstructor>
     <RedundantConditionGivenDocblockType>
       <code><![CDATA[(null !== $content) && is_string($content)]]></code>
       <code>is_string($content)</code>
     </RedundantConditionGivenDocblockType>
     <UndefinedMagicMethod>
-      <code>getIndent</code>
-      <code>getSeparator</code>
-      <code>getWhitespace</code>
       <code>setSeparator</code>
     </UndefinedMagicMethod>
   </file>
@@ -1368,24 +1324,9 @@
       <code>$container[$key]</code>
       <code>$return</code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code>string</code>
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall>
-      <code>escapeHtml</code>
-      <code>escapeHtmlAttr</code>
-    </MixedMethodCall>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->getEscaper()->escapeHtml((string) $string)]]></code>
-      <code><![CDATA[$this->getEscaper()->escapeHtmlAttr((string) $string)]]></code>
-    </MixedReturnStatement>
     <MoreSpecificReturnType>
       <code>AbstractContainer</code>
     </MoreSpecificReturnType>
-    <PossiblyNullArgument>
-      <code>$enc</code>
-    </PossiblyNullArgument>
     <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
@@ -2474,49 +2415,6 @@
       <code>setIndent</code>
     </UndefinedMagicMethod>
   </file>
-  <file src="test/Helper/HeadStyleTest.php">
-    <MixedArgument>
-      <code><![CDATA[$item->content]]></code>
-      <code><![CDATA[$item->content]]></code>
-      <code>$value</code>
-      <code>$values</code>
-      <code>$values</code>
-      <code>$values</code>
-      <code>$values</code>
-      <code>$values</code>
-      <code>$values</code>
-      <code>$values</code>
-      <code>$values</code>
-    </MixedArgument>
-    <MixedArrayAccess>
-      <code>$values[$i]</code>
-    </MixedArrayAccess>
-    <MixedAssignment>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$value</code>
-      <code>$values</code>
-      <code>$values</code>
-      <code>$values</code>
-      <code>$values</code>
-    </MixedAssignment>
-    <MixedPropertyFetch>
-      <code><![CDATA[$item->content]]></code>
-      <code><![CDATA[$item->content]]></code>
-    </MixedPropertyFetch>
-    <UndefinedMagicMethod>
-      <code>bogusMethod</code>
-      <code>getArrayCopy</code>
-      <code>getArrayCopy</code>
-      <code>getArrayCopy</code>
-      <code>getArrayCopy</code>
-      <code>getArrayCopy</code>
-      <code>getValue</code>
-      <code>setIndent</code>
-      <code>setIndent</code>
-      <code>setIndent</code>
-    </UndefinedMagicMethod>
-  </file>
   <file src="test/Helper/HeadTitleTest.php">
     <MixedAssignment>
       <code>$placeholder</code>
@@ -3062,9 +2960,6 @@
     <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <UndefinedAttributeClass>
-      <code>AllowDynamicProperties</code>
-    </UndefinedAttributeClass>
   </file>
   <file src="test/Helper/TestAsset/MockContainer.php">
     <PropertyNotSetInConstructor>

--- a/src/Helper/Placeholder/Container/AbstractStandalone.php
+++ b/src/Helper/Placeholder/Container/AbstractStandalone.php
@@ -49,7 +49,7 @@ abstract class AbstractStandalone extends AbstractHelper implements
      */
     protected $containerClass = Container::class;
 
-    /** @var Escaper[] */
+    /** @var array<string, Escaper> */
     protected $escapers = [];
 
     /**
@@ -282,7 +282,7 @@ abstract class AbstractStandalone extends AbstractHelper implements
     /**
      * Set Escaper instance
      *
-     * @return AbstractStandalone
+     * @return $this
      */
     public function setEscaper(Escaper $escaper)
     {
@@ -297,8 +297,8 @@ abstract class AbstractStandalone extends AbstractHelper implements
      *
      * Lazy-loads one if none available
      *
-     * @param  string|null $enc Encoding to use
-     * @return mixed
+     * @param  string $enc Encoding to use
+     * @return Escaper
      */
     public function getEscaper($enc = 'UTF-8')
     {

--- a/test/Helper/HeadStyleTest.php
+++ b/test/Helper/HeadStyleTest.php
@@ -6,64 +6,54 @@ namespace LaminasTest\View\Helper;
 
 use DOMDocument;
 use Laminas\View;
-use Laminas\View\Helper;
+use Laminas\View\Exception\InvalidArgumentException;
+use Laminas\View\Helper\HeadStyle;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function array_shift;
-use function count;
 use function substr_count;
 
 use const PHP_EOL;
 
 class HeadStyleTest extends TestCase
 {
-    /** @var Helper\HeadStyle */
-    public $helper;
+    private HeadStyle $helper;
 
-    /** @var string */
-    public $basePath;
-
-    /**
-     * Sets up the fixture, for example, open a network connection.
-     * This method is called before a test is executed.
-     */
     protected function setUp(): void
     {
-        $this->basePath = __DIR__ . '/_files/modules';
-        $this->helper   = new Helper\HeadStyle();
+        $this->helper = new HeadStyle();
     }
 
-    public function testHeadStyleReturnsObjectInstance(): void
+    public function testInvokeWithoutArgumentsReturnsSelf(): void
     {
-        $placeholder = $this->helper->__invoke();
-        $this->assertInstanceOf(Helper\HeadStyle::class, $placeholder);
+        self::assertSame($this->helper, $this->helper->__invoke());
     }
 
     public function testAppendThrowsExceptionGivenNonStyleArgument(): void
     {
-        $this->expectException(View\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid value passed to append');
         $this->helper->append('foo');
     }
 
     public function testPrependThrowsExceptionGivenNonStyleArgument(): void
     {
-        $this->expectException(View\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid value passed to prepend');
         $this->helper->prepend('foo');
     }
 
     public function testSetThrowsExceptionGivenNonStyleArgument(): void
     {
-        $this->expectException(View\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid value passed to set');
         $this->helper->set('foo');
     }
 
     public function testOffsetSetThrowsExceptionGivenNonStyleArgument(): void
     {
-        $this->expectException(View\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid value passed to offsetSet');
         $this->helper->offsetSet(1, 'foo');
     }
@@ -74,14 +64,14 @@ class HeadStyleTest extends TestCase
         for ($i = 0; $i < 3; ++$i) {
             $string .= PHP_EOL . 'a {}';
             $this->helper->appendStyle($string);
-            $values = $this->helper->getArrayCopy();
-            $this->assertEquals($i + 1, count($values));
+            $values = $this->helper->getContainer()->getArrayCopy();
+            self::assertCount($i + 1, $values);
             $item = $values[$i];
 
-            $this->assertInstanceOf(stdClass::class, $item);
-            $this->assertObjectHasProperty('content', $item);
-            $this->assertObjectHasProperty('attributes', $item);
-            $this->assertEquals($string, $item->content);
+            self::assertInstanceOf(stdClass::class, $item);
+            self::assertObjectHasProperty('content', $item);
+            self::assertObjectHasProperty('attributes', $item);
+            self::assertEquals($string, $item->content);
         }
     }
 
@@ -91,33 +81,34 @@ class HeadStyleTest extends TestCase
         for ($i = 0; $i < 3; ++$i) {
             $string .= PHP_EOL . 'a {}';
             $this->helper->prependStyle($string);
-            $values = $this->helper->getArrayCopy();
-            $this->assertEquals($i + 1, count($values));
+            $values = $this->helper->getContainer()->getArrayCopy();
+            self::assertCount($i + 1, $values);
             $item = array_shift($values);
 
-            $this->assertInstanceOf(stdClass::class, $item);
-            $this->assertObjectHasProperty('content', $item);
-            $this->assertObjectHasProperty('attributes', $item);
-            $this->assertEquals($string, $item->content);
+            self::assertInstanceOf(stdClass::class, $item);
+            self::assertObjectHasProperty('content', $item);
+            self::assertObjectHasProperty('attributes', $item);
+            self::assertEquals($string, $item->content);
         }
     }
 
-    public function testOverloadSetOversitesStack(): void
+    public function testOverloadSetOverwritesStack(): void
     {
         $string = 'a {}';
         for ($i = 0; $i < 3; ++$i) {
             $this->helper->appendStyle($string);
             $string .= PHP_EOL . 'a {}';
         }
+
         $this->helper->setStyle($string);
-        $values = $this->helper->getArrayCopy();
-        $this->assertEquals(1, count($values));
+        $values = $this->helper->getContainer()->getArrayCopy();
+        self::assertCount(1, $values);
         $item = array_shift($values);
 
-        $this->assertInstanceOf(stdClass::class, $item);
-        $this->assertObjectHasProperty('content', $item);
-        $this->assertObjectHasProperty('attributes', $item);
-        $this->assertEquals($string, $item->content);
+        self::assertInstanceOf(stdClass::class, $item);
+        self::assertObjectHasProperty('content', $item);
+        self::assertObjectHasProperty('attributes', $item);
+        self::assertEquals($string, $item->content);
     }
 
     public function testCanBuildStyleTagsWithAttributes(): void
@@ -126,52 +117,66 @@ class HeadStyleTest extends TestCase
             'lang'  => 'us_en',
             'title' => 'foo',
             'media' => 'projection',
-            'dir'   => 'rtol',
+            'dir'   => 'rtl',
             'bogus' => 'unused',
         ]);
-        $value = $this->helper->getValue();
-
-        $this->assertObjectHasProperty('attributes', $value);
+        $value = $this->helper->getContainer()->getValue();
+        self::assertIsObject($value);
+        self::assertObjectHasProperty('attributes', $value);
         $attributes = $value->attributes;
 
-        $this->assertTrue(isset($attributes['lang']));
-        $this->assertTrue(isset($attributes['title']));
-        $this->assertTrue(isset($attributes['media']));
-        $this->assertTrue(isset($attributes['dir']));
-        $this->assertTrue(isset($attributes['bogus']));
-        $this->assertEquals('us_en', $attributes['lang']);
-        $this->assertEquals('foo', $attributes['title']);
-        $this->assertEquals('projection', $attributes['media']);
-        $this->assertEquals('rtol', $attributes['dir']);
-        $this->assertEquals('unused', $attributes['bogus']);
+        self::assertTrue(isset($attributes['lang']));
+        self::assertTrue(isset($attributes['title']));
+        self::assertTrue(isset($attributes['media']));
+        self::assertTrue(isset($attributes['dir']));
+        self::assertTrue(isset($attributes['bogus']));
+        self::assertEquals('us_en', $attributes['lang']);
+        self::assertEquals('foo', $attributes['title']);
+        self::assertEquals('projection', $attributes['media']);
+        self::assertEquals('rtl', $attributes['dir']);
+        self::assertEquals('unused', $attributes['bogus']);
     }
 
-    public function testRenderedStyleTagsContainHtmlEscaping(): void
+    public function testRenderedStyleMarkupHasExpectedOutput(): void
     {
         $this->helper->setStyle('a {}', [
-            'lang'  => 'us_en',
+            'lang'  => 'en_us',
             'title' => 'foo',
             'media' => 'screen',
-            'dir'   => 'rtol',
+            'dir'   => 'rtl',
             'bogus' => 'unused',
         ]);
-        $value = $this->helper->toString();
-        $this->assertStringContainsString('<!--' . PHP_EOL, $value);
-        $this->assertStringContainsString(PHP_EOL . '-->', $value);
+
+        $expect = <<<HTML
+            <style type="text/css" lang="en_us" title="foo" media="screen" dir="rtl">
+            a {}
+            </style>
+            HTML;
+        self::assertSame($expect, $this->helper->toString());
     }
 
     public function testRenderedStyleTagsContainsDefaultMedia(): void
     {
         $this->helper->setStyle('a {}', []);
         $value = $this->helper->toString();
-        $this->assertMatchesRegularExpression('#<style [^>]*?media="screen"#', $value, $value);
+        self::assertMatchesRegularExpression('#<style [^>]*?media="screen"#', $value, $value);
     }
 
     public function testMediaAttributeCanHaveSpaceInCommaSeparatedString(): void
     {
         $this->helper->appendStyle('a { }', ['media' => 'screen, projection']);
         $string = $this->helper->toString();
-        $this->assertStringContainsString('media="screen,projection"', $string);
+        self::assertStringContainsString('media="screen,&#x20;projection"', $string);
+    }
+
+    public function testMediaAttributeCanContainARegularMediaQuery(): void
+    {
+        $this->helper->appendStyle('a { }', ['media' => 'screen and (max-width: 100px)']);
+        $string = $this->helper->toString();
+        self::assertStringContainsString(
+            'media="screen&#x20;and&#x20;&#x28;max-width&#x3A;&#x20;100px&#x29;"',
+            $string,
+        );
     }
 
     public function testHeadStyleProxiesProperly(): void
@@ -209,15 +214,15 @@ class HeadStyleTest extends TestCase
         self::assertNotEmpty($html);
         $doc = new DOMDocument();
         $dom = $doc->loadHtml($html);
-        $this->assertTrue($dom);
+        self::assertTrue($dom);
 
         $styles = substr_count($html, '<style type="text/css"');
-        $this->assertEquals(3, $styles);
+        self::assertEquals(3, $styles);
         $styles = substr_count($html, '</style>');
-        $this->assertEquals(3, $styles);
-        $this->assertStringContainsString($style3, $html);
-        $this->assertStringContainsString($style2, $html);
-        $this->assertStringContainsString($style1, $html);
+        self::assertEquals(3, $styles);
+        self::assertStringContainsString($style3, $html);
+        self::assertStringContainsString($style2, $html);
+        self::assertStringContainsString($style1, $html);
     }
 
     public function testCapturingCapturesToObject(): void
@@ -225,26 +230,33 @@ class HeadStyleTest extends TestCase
         $this->helper->captureStart();
         echo 'foobar';
         $this->helper->captureEnd();
-        $values = $this->helper->getArrayCopy();
-        $this->assertEquals(1, count($values));
+        $values = $this->helper->getContainer()->getArrayCopy();
+        self::assertCount(1, $values);
         $item = array_shift($values);
-        $this->assertStringContainsString('foobar', $item->content);
+        self::assertIsObject($item);
+        self::assertObjectHasProperty('content', $item);
+        self::assertIsString($item->content);
+        self::assertStringContainsString('foobar', $item->content);
     }
 
     public function testOverloadingOffsetSetWritesToSpecifiedIndex(): void
     {
         $this->helper->offsetSetStyle(100, 'foobar');
-        $values = $this->helper->getArrayCopy();
-        $this->assertEquals(1, count($values));
-        $this->assertTrue(isset($values[100]));
+        $values = $this->helper->getContainer()->getArrayCopy();
+        self::assertCount(1, $values);
+        self::assertTrue(isset($values[100]));
         $item = $values[100];
-        $this->assertStringContainsString('foobar', $item->content);
+        self::assertIsObject($item);
+        self::assertObjectHasProperty('content', $item);
+        self::assertIsString($item->content);
+        self::assertStringContainsString('foobar', $item->content);
     }
 
     public function testInvalidMethodRaisesException(): void
     {
         $this->expectException(View\Exception\BadMethodCallException::class);
         $this->expectExceptionMessage('Method "bogusMethod" does not exist');
+        /** @psalm-suppress UndefinedMagicMethod */
         $this->helper->bogusMethod();
     }
 
@@ -256,27 +268,41 @@ class HeadStyleTest extends TestCase
         $this->helper->appendStyle();
     }
 
+    public function testThatEmptyStylesWillYieldAnEmptyValue(): void
+    {
+        $this->helper->appendStyle('', ['media' => 'screen']);
+        self::assertSame('', $this->helper->toString());
+    }
+
     public function testIndentationIsHonored(): void
     {
-        $this->helper->setIndent(4);
-        $this->helper->appendStyle('
-a {
-    display: none;
-}');
-        $this->helper->appendStyle('
-h1 {
-    font-weight: bold
-}');
-        $string = $this->helper->toString();
+        $returnValue = $this->helper->setIndent(4);
+        self::assertSame($this->helper, $returnValue);
+        $this->helper->appendStyle(<<<CSS
+            a {
+                display: none;
+            }
+            CSS);
+        $this->helper->appendStyle(<<<CSS
+            h1 {
+                font-weight: bold
+            }
+            CSS);
 
-        $scripts = substr_count($string, '    <style');
-        $this->assertEquals(2, $scripts);
-        $this->assertStringContainsString('    <!--', $string);
-        $this->assertStringContainsString('    a {', $string);
-        $this->assertStringContainsString('    h1 {', $string);
-        $this->assertStringContainsString('        display', $string);
-        $this->assertStringContainsString('        font-weight', $string);
-        $this->assertStringContainsString('    }', $string);
+        $expect = <<<HTML
+                <style type="text/css" media="screen">
+                a {
+                    display: none;
+                }
+                </style>
+                <style type="text/css" media="screen">
+                h1 {
+                    font-weight: bold
+                }
+                </style>
+            HTML;
+
+        self::assertSame($expect, $this->helper->toString());
     }
 
     public function testSerialCapturingWorks(): void
@@ -303,40 +329,59 @@ h1 {
             $this->fail('Nested capturing should fail');
         } catch (View\Exception\ExceptionInterface $e) {
             $this->helper->__invoke()->captureEnd();
-            $this->assertStringContainsString('Cannot nest', $e->getMessage());
+            self::assertStringContainsString('Cannot nest', $e->getMessage());
         }
     }
 
     public function testMediaAttributeAsArray(): void
     {
         $this->helper->setIndent(4);
-        $this->helper->appendStyle('
-a {
-    display: none;
-}', ['media' => ['screen', 'projection']]);
+        $this->helper->appendStyle(
+            <<<CSS
+            a {
+                display: none;
+            }
+            CSS,
+            ['media' => ['screen', 'projection']],
+        );
         $string = $this->helper->toString();
 
         $scripts = substr_count($string, '    <style');
-        $this->assertEquals(1, $scripts);
-        $this->assertStringContainsString('    <!--', $string);
-        $this->assertStringContainsString('    a {', $string);
-        $this->assertStringContainsString(' media="screen,projection"', $string);
+        self::assertEquals(1, $scripts);
+        self::assertStringContainsString('    a {', $string);
+        self::assertStringContainsString(' media="screen,&#x20;projection"', $string);
+    }
+
+    public function testThatAnExceptionIsThrownIfMediaAttributeArrayContainsNonStringValues(): void
+    {
+        $this->helper->appendStyle(
+            'a {display: none;}',
+            ['media' => [0.2, []]],
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('When the media attribute is an array, the array can only contain string values');
+
+        $this->helper->toString();
     }
 
     public function testMediaAttributeAsCommaSeparatedString(): void
     {
         $this->helper->setIndent(4);
-        $this->helper->appendStyle('
-a {
-    display: none;
-}', ['media' => 'screen,projection']);
+        $this->helper->appendStyle(
+            <<<CSS
+            a {
+                display: none;
+            }
+            CSS,
+            ['media' => 'screen,projection'],
+        );
         $string = $this->helper->toString();
 
         $scripts = substr_count($string, '    <style');
-        $this->assertEquals(1, $scripts);
-        $this->assertStringContainsString('    <!--', $string);
-        $this->assertStringContainsString('    a {', $string);
-        $this->assertStringContainsString(' media="screen,projection"', $string);
+        self::assertEquals(1, $scripts);
+        self::assertStringContainsString('    a {', $string);
+        self::assertStringContainsString(' media="screen,projection"', $string);
     }
 
     public function testConditionalScript(): void
@@ -346,7 +391,7 @@ a {
     display: none;
 }', ['media' => 'screen,projection', 'conditional' => 'lt IE 7']);
         $test = $this->helper->toString();
-        $this->assertStringContainsString('<!--[if lt IE 7]>', $test);
+        self::assertStringContainsString('<!--[if lt IE 7]>', $test);
     }
 
     public function testConditionalScriptNoIE(): void
@@ -356,8 +401,8 @@ a {
     display: none;
 }', ['media' => 'screen,projection', 'conditional' => '!IE']);
         $test = $this->helper->toString();
-        $this->assertStringContainsString('<!--[if !IE]><!--><', $test);
-        $this->assertStringContainsString('<!--<![endif]-->', $test);
+        self::assertStringContainsString('<!--[if !IE]><!--><', $test);
+        self::assertStringContainsString('<!--<![endif]-->', $test);
     }
 
     public function testConditionalScriptNoIEWidthSpace(): void
@@ -367,8 +412,8 @@ a {
     display: none;
 }', ['media' => 'screen,projection', 'conditional' => '! IE']);
         $test = $this->helper->toString();
-        $this->assertStringContainsString('<!--[if ! IE]><!--><', $test);
-        $this->assertStringContainsString('<!--<![endif]-->', $test);
+        self::assertStringContainsString('<!--[if ! IE]><!--><', $test);
+        self::assertStringContainsString('<!--<![endif]-->', $test);
     }
 
     public function testContainerMaintainsCorrectOrderOfItems(): void
@@ -380,18 +425,19 @@ a {
         $this->helper->offsetSetStyle(5, $style2);
 
         $test     = $this->helper->toString();
-        $expected = '<style type="text/css" media="screen">' . PHP_EOL
-                  . '<!--' . PHP_EOL
-                  . $style2 . PHP_EOL
-                  . '-->' . PHP_EOL
-                  . '</style>' . PHP_EOL
-                  . '<style type="text/css" media="screen">' . PHP_EOL
-                  . '<!--' . PHP_EOL
-                  . $style1 . PHP_EOL
-                  . '-->' . PHP_EOL
-                  . '</style>';
+        $expected = '<style type="text/css" media="screen">'
+            . PHP_EOL
+            . $style2
+            . PHP_EOL
+            . '</style>'
+            . PHP_EOL
+            . '<style type="text/css" media="screen">'
+            . PHP_EOL
+            . $style1
+            . PHP_EOL
+            . '</style>';
 
-        $this->assertEquals($expected, $test);
+        self::assertEquals($expected, $test);
     }
 
     public function testRenderConditionalCommentsShouldNotContainHtmlEscaping(): void
@@ -402,7 +448,7 @@ a {
         ]);
         $value = $this->helper->toString();
 
-        $this->assertStringNotContainsString('<!--' . PHP_EOL, $value);
-        $this->assertStringNotContainsString(PHP_EOL . '-->', $value);
+        self::assertStringNotContainsString('<!--' . PHP_EOL, $value);
+        self::assertStringNotContainsString(PHP_EOL . '-->', $value);
     }
 }


### PR DESCRIPTION
Closes #6

It is not necessary to comment CSS within style tags so output has changed from:

`<style><!-- a {} --></style>` to `<style> a {} </style>`

The `<style media="">` attribute was restricted to list of pre-defined values such as `[screen, print, braille]`, when in reality the media attribute can contain any sort of media query such as `screen and (min-width: 10rem)`. These restrictions have been removed the property listing those restrictions deprecated.

Additionally, if the `media` attribute is an array containing non-string values, an exception will be thrown. Previously, there would have been a type error.

Style tag attributes not present in a list of 'allowed' attributes are silently ignored. This list has been updated to include the `nonce` attribute.

Adds `@method setIndent` which magically proxies to the container.

Adds probably desirable behaviour where if the user provides an empty string, i.e. `$this->headStyle()->appendStyle('');`, then no markup will be output for that item.

Lots of type inference improvements and some test improvements.
