### PR TITLE
Improve type inference for stateful container implementations

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -289,7 +289,6 @@
       <code>$args[1]</code>
       <code>$args[2]</code>
       <code>$index</code>
-      <code>$item</code>
       <code><![CDATA[$item->$type]]></code>
       <code><![CDATA[$item->content]]></code>
       <code><![CDATA[$item->type]]></code>
@@ -303,9 +302,7 @@
     </MixedArgument>
     <MixedAssignment>
       <code>$doctype</code>
-      <code>$indent</code>
       <code>$index</code>
-      <code>$item</code>
       <code>$key</code>
       <code>$type</code>
       <code>$value</code>
@@ -321,10 +318,6 @@
       <code>isRdfa</code>
       <code>isXhtml</code>
     </MixedMethodCall>
-    <MixedOperand>
-      <code>$indent</code>
-      <code>$indent</code>
-    </MixedOperand>
     <MixedReturnStatement>
       <code>parent::__call($method, $args)</code>
       <code>parent::__call($method, $args)</code>
@@ -346,9 +339,6 @@
       <code>plugin</code>
       <code>plugin</code>
     </UndefinedInterfaceMethod>
-    <UndefinedMagicMethod>
-      <code>getWhitespace</code>
-    </UndefinedMagicMethod>
   </file>
   <file src="src/Helper/HeadScript.php">
     <MethodSignatureMustProvideReturnType>
@@ -374,7 +364,6 @@
       <code><![CDATA[$attrs['src']]]></code>
       <code>$content</code>
       <code>$index</code>
-      <code>$item</code>
       <code>$key</code>
       <code>$type</code>
       <code>$value</code>
@@ -414,17 +403,10 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/HeadStyle.php">
-    <ArgumentTypeCoercion>
-      <code>$item</code>
-    </ArgumentTypeCoercion>
     <DocblockTypeContradiction>
       <code><![CDATA[! is_string($item->content)]]></code>
       <code><![CDATA[! isset($item->content)]]></code>
       <code><![CDATA[! isset($item->content) || ! is_string($item->content)]]></code>
-      <code><![CDATA[$this->isValid($value)]]></code>
-      <code><![CDATA[$this->isValid($value)]]></code>
-      <code><![CDATA[$this->isValid($value)]]></code>
-      <code><![CDATA[$this->isValid($value)]]></code>
     </DocblockTypeContradiction>
     <MethodSignatureMustProvideReturnType>
       <code>offsetSet</code>
@@ -447,14 +429,6 @@
       <code><![CDATA[(null !== $content) && is_string($content)]]></code>
       <code>is_string($content)</code>
     </RedundantConditionGivenDocblockType>
-  </file>
-  <file src="src/Helper/HeadTitle.php">
-    <MixedArgument>
-      <code>$item</code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code>$item</code>
-    </MixedAssignment>
   </file>
   <file src="src/Helper/HtmlFlash.php">
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2150,59 +2150,14 @@
       <code><![CDATA['foo']]></code>
       <code><![CDATA['foo']]></code>
       <code><![CDATA['foo']]></code>
-      <code><![CDATA[[$this, 'handleErrors']]]></code>
     </InvalidArgument>
-    <MixedArgument>
-      <code><![CDATA[$attributeEscaper('HeadMeta with Microdata')]]></code>
-      <code><![CDATA[$attributeEscaper('og:title')]]></code>
-      <code><![CDATA[$attributeEscaper('some content')]]></code>
-      <code><![CDATA[$attributeEscaper('some content')]]></code>
-      <code>$modifiers</code>
-      <code>$value</code>
-      <code>$values</code>
-      <code>$values</code>
-      <code>$values</code>
-      <code>$values</code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$modifiers</code>
-      <code>$value</code>
-      <code>$values</code>
-      <code>$values</code>
-    </MixedAssignment>
-    <MixedOperand>
-      <code><![CDATA[$attributeEscaper('boo bah')]]></code>
-      <code><![CDATA[$attributeEscaper('foo bar')]]></code>
-    </MixedOperand>
-    <MixedPropertyFetch>
-      <code><![CDATA[$item->content]]></code>
-      <code><![CDATA[$item->content]]></code>
-      <code><![CDATA[$item->name]]></code>
-      <code><![CDATA[$item->name]]></code>
-      <code><![CDATA[$item->type]]></code>
-      <code><![CDATA[$item->type]]></code>
-    </MixedPropertyFetch>
     <UndefinedMagicMethod>
-      <code>getArrayCopy</code>
-      <code>getArrayCopy</code>
-      <code>getValue</code>
       <code>offsetSetHttpEquiv</code>
       <code>offsetSetHttpEquiv</code>
       <code>offsetSetName</code>
       <code>offsetSetName</code>
       <code>offsetSetName</code>
     </UndefinedMagicMethod>
-  </file>
-  <file src="test/Helper/HeadScriptTest.php">
-    <MixedArgument>
-      <code><![CDATA[$attributeEscaper('test1.js')]]></code>
-      <code><![CDATA[$attributeEscaper('test2.js')]]></code>
-      <code><![CDATA[$attributeEscaper('test3.js')]]></code>
-      <code><![CDATA[$attributeEscaper('test4.js')]]></code>
-      <code><![CDATA[$attributeEscaper('text/javascript')]]></code>
-    </MixedArgument>
   </file>
   <file src="test/Helper/HtmlFlashTest.php">
     <DeprecatedClass>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -225,6 +225,9 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/HeadLink.php">
+    <ArgumentTypeCoercion>
+      <code>$item</code>
+    </ArgumentTypeCoercion>
     <MethodSignatureMustProvideReturnType>
       <code>offsetSet</code>
     </MethodSignatureMustProvideReturnType>
@@ -236,7 +239,6 @@
       <code>$attributes[$itemKey]</code>
       <code>$href</code>
       <code>$index</code>
-      <code>$item</code>
       <code>$item</code>
       <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($attributes[$itemKey]) : $attributes[$itemKey]]]></code>
       <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($value) : $value]]></code>
@@ -258,7 +260,6 @@
       <code>$href</code>
       <code>$index</code>
       <code>$item</code>
-      <code>$item</code>
       <code>$media</code>
       <code>$title</code>
       <code>$type</code>
@@ -277,6 +278,7 @@
   </file>
   <file src="src/Helper/HeadMeta.php">
     <ArgumentTypeCoercion>
+      <code>$item</code>
       <code>$value</code>
       <code>$value</code>
     </ArgumentTypeCoercion>
@@ -349,10 +351,6 @@
       <code>$content</code>
       <code>$index</code>
       <code>$index</code>
-      <code><![CDATA[$item->attributes['conditional']]]></code>
-      <code><![CDATA[$item->type]]></code>
-      <code><![CDATA[$item->type]]></code>
-      <code>$key</code>
       <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($value) : $value]]></code>
       <code>$value</code>
     </MixedArgument>
@@ -364,8 +362,6 @@
       <code><![CDATA[$attrs['src']]]></code>
       <code>$content</code>
       <code>$index</code>
-      <code>$key</code>
-      <code>$type</code>
       <code>$value</code>
     </MixedAssignment>
     <MixedInferredReturnType>
@@ -374,16 +370,6 @@
     <MixedMethodCall>
       <code>isHtml5</code>
     </MixedMethodCall>
-    <MixedOperand>
-      <code><![CDATA[$item->attributes['conditional']]]></code>
-      <code><![CDATA[$item->source]]></code>
-      <code>$type</code>
-    </MixedOperand>
-    <MixedPropertyFetch>
-      <code><![CDATA[$item->attributes]]></code>
-      <code><![CDATA[$item->source]]></code>
-      <code><![CDATA[$item->type]]></code>
-    </MixedPropertyFetch>
     <MixedReturnStatement>
       <code>parent::__call($method, $args)</code>
       <code>parent::__call($method, $args)</code>
@@ -411,6 +397,9 @@
     <MethodSignatureMustProvideReturnType>
       <code>offsetSet</code>
     </MethodSignatureMustProvideReturnType>
+    <MismatchingDocblockParamType>
+      <code>ObjectShape</code>
+    </MismatchingDocblockParamType>
     <MixedArgument>
       <code>$content</code>
       <code>$index</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -225,18 +225,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/HeadLink.php">
-    <InvalidArgument>
-      <code>$item</code>
-    </InvalidArgument>
-    <InvalidReturnStatement>
-      <code><![CDATA[$this->getContainer()->set($value)]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code>HeadLink</code>
-    </InvalidReturnType>
-    <LessSpecificReturnStatement>
-      <code>(object) $attributes</code>
-    </LessSpecificReturnStatement>
     <MethodSignatureMustProvideReturnType>
       <code>offsetSet</code>
     </MethodSignatureMustProvideReturnType>
@@ -252,7 +240,6 @@
       <code>$item</code>
       <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($attributes[$itemKey]) : $attributes[$itemKey]]]></code>
       <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($value) : $value]]></code>
-      <code><![CDATA[$this->getSeparator()]]></code>
       <code>$value</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
@@ -269,9 +256,7 @@
       <code>$extras</code>
       <code>$href</code>
       <code>$href</code>
-      <code>$indent</code>
       <code>$index</code>
-      <code>$item</code>
       <code>$item</code>
       <code>$item</code>
       <code>$media</code>
@@ -279,32 +264,9 @@
       <code>$type</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code>HeadLink</code>
-    </MixedInferredReturnType>
-    <MixedOperand>
-      <code>$indent</code>
-      <code>$indent</code>
-    </MixedOperand>
-    <MixedPropertyFetch>
-      <code><![CDATA[$item->href]]></code>
-      <code><![CDATA[$item->rel]]></code>
-    </MixedPropertyFetch>
-    <MixedReturnStatement>
-      <code><![CDATA[call_user_func_array([$this, '__invoke'], func_get_args())]]></code>
-    </MixedReturnStatement>
-    <MoreSpecificImplementedParamType>
-      <code>$value</code>
-    </MoreSpecificImplementedParamType>
-    <MoreSpecificReturnType>
-      <code>stdClass</code>
-    </MoreSpecificReturnType>
     <ParamNameMismatch>
       <code>$index</code>
     </ParamNameMismatch>
-    <PossiblyInvalidArgument>
-      <code>$item</code>
-    </PossiblyInvalidArgument>
     <PossiblyNullArgument>
       <code>$index</code>
       <code><![CDATA[$this->view]]></code>
@@ -312,24 +274,12 @@
     <RedundantCast>
       <code>(string) $conditionalStylesheet</code>
     </RedundantCast>
-    <UndefinedMagicMethod>
-      <code>getIndent</code>
-      <code>getSeparator</code>
-      <code>getWhitespace</code>
-      <code>setSeparator</code>
-    </UndefinedMagicMethod>
   </file>
   <file src="src/Helper/HeadMeta.php">
-    <DocblockTypeContradiction>
-      <code>! $item instanceof stdClass</code>
-    </DocblockTypeContradiction>
-    <InvalidArgument>
-      <code>$item</code>
+    <ArgumentTypeCoercion>
       <code>$value</code>
-    </InvalidArgument>
-    <InvalidCast>
-      <code>$item</code>
-    </InvalidCast>
+      <code>$value</code>
+    </ArgumentTypeCoercion>
     <MethodSignatureMustProvideReturnType>
       <code>offsetSet</code>
       <code>offsetUnset</code>
@@ -347,8 +297,8 @@
       <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($item->$type) : $item->$type]]></code>
       <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($item->content) : $item->content]]></code>
       <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($value) : $value]]></code>
-      <code><![CDATA[$this->getSeparator()]]></code>
       <code>$type</code>
+      <code>$value</code>
       <code>$value</code>
     </MixedArgument>
     <MixedAssignment>
@@ -356,13 +306,12 @@
       <code>$indent</code>
       <code>$index</code>
       <code>$item</code>
-      <code>$item</code>
       <code>$key</code>
       <code>$type</code>
       <code>$value</code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>HeadMeta</code>
+      <code>$this</code>
     </MixedInferredReturnType>
     <MixedMethodCall>
       <code>isHtml5</code>
@@ -376,20 +325,10 @@
       <code>$indent</code>
       <code>$indent</code>
     </MixedOperand>
-    <MixedPropertyFetch>
-      <code><![CDATA[$item->type]]></code>
-      <code><![CDATA[$item->{$item->type}]]></code>
-    </MixedPropertyFetch>
     <MixedReturnStatement>
       <code>parent::__call($method, $args)</code>
       <code>parent::__call($method, $args)</code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType>
-      <code>$value</code>
-    </MoreSpecificImplementedParamType>
-    <NullableReturnStatement>
-      <code><![CDATA[$this->offsetSet($index, $item)]]></code>
-    </NullableReturnStatement>
     <ParamNameMismatch>
       <code>$index</code>
       <code>$index</code>
@@ -408,53 +347,43 @@
       <code>plugin</code>
     </UndefinedInterfaceMethod>
     <UndefinedMagicMethod>
-      <code>getIndent</code>
-      <code>getSeparator</code>
       <code>getWhitespace</code>
-      <code>setSeparator</code>
     </UndefinedMagicMethod>
   </file>
   <file src="src/Helper/HeadScript.php">
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[['type']]]></code>
-    </InvalidPropertyAssignmentValue>
     <MethodSignatureMustProvideReturnType>
       <code>offsetSet</code>
     </MethodSignatureMustProvideReturnType>
     <MixedArgument>
       <code>$content</code>
       <code>$content</code>
-      <code>$indent</code>
       <code>$index</code>
       <code>$index</code>
-      <code><![CDATA[$item->attributes]]></code>
       <code><![CDATA[$item->attributes['conditional']]]></code>
       <code><![CDATA[$item->type]]></code>
       <code><![CDATA[$item->type]]></code>
       <code>$key</code>
       <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($value) : $value]]></code>
-      <code><![CDATA[$this->getSeparator()]]></code>
       <code>$value</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code>$attrs</code>
+      <code>$attrs</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment>
       <code><![CDATA[$attrs['src']]]></code>
       <code>$content</code>
-      <code>$indent</code>
       <code>$index</code>
       <code>$item</code>
-      <code>$item</code>
       <code>$key</code>
-      <code><![CDATA[$this->captureType]]></code>
       <code>$type</code>
-      <code>$useCdata</code>
       <code>$value</code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>HeadScript</code>
+      <code>$this</code>
     </MixedInferredReturnType>
     <MixedMethodCall>
       <code>isHtml5</code>
-      <code>isXhtml</code>
     </MixedMethodCall>
     <MixedOperand>
       <code><![CDATA[$item->attributes['conditional']]]></code>
@@ -463,8 +392,6 @@
     </MixedOperand>
     <MixedPropertyFetch>
       <code><![CDATA[$item->attributes]]></code>
-      <code><![CDATA[$item->attributes]]></code>
-      <code><![CDATA[$item->source]]></code>
       <code><![CDATA[$item->source]]></code>
       <code><![CDATA[$item->type]]></code>
     </MixedPropertyFetch>
@@ -475,14 +402,6 @@
     <ParamNameMismatch>
       <code>$index</code>
     </ParamNameMismatch>
-    <PossiblyNullPropertyAssignmentValue>
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor>
-      <code>$captureLock</code>
-      <code>$captureScriptType</code>
-      <code>$captureType</code>
-    </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType>
       <code>(bool) $flag</code>
     </RedundantCastGivenDocblockType>
@@ -492,16 +411,21 @@
     </RedundantConditionGivenDocblockType>
     <UndefinedInterfaceMethod>
       <code>plugin</code>
-      <code>plugin</code>
     </UndefinedInterfaceMethod>
-    <UndefinedMagicMethod>
-      <code>getIndent</code>
-      <code>getSeparator</code>
-      <code>getWhitespace</code>
-      <code>setSeparator</code>
-    </UndefinedMagicMethod>
   </file>
   <file src="src/Helper/HeadStyle.php">
+    <ArgumentTypeCoercion>
+      <code>$item</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_string($item->content)]]></code>
+      <code><![CDATA[! isset($item->content)]]></code>
+      <code><![CDATA[! isset($item->content) || ! is_string($item->content)]]></code>
+      <code><![CDATA[$this->isValid($value)]]></code>
+      <code><![CDATA[$this->isValid($value)]]></code>
+      <code><![CDATA[$this->isValid($value)]]></code>
+      <code><![CDATA[$this->isValid($value)]]></code>
+    </DocblockTypeContradiction>
     <MethodSignatureMustProvideReturnType>
       <code>offsetSet</code>
     </MethodSignatureMustProvideReturnType>
@@ -509,6 +433,9 @@
       <code>$content</code>
       <code>$index</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code>$attrs</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment>
       <code>$content</code>
       <code>$index</code>
@@ -520,41 +447,14 @@
       <code><![CDATA[(null !== $content) && is_string($content)]]></code>
       <code>is_string($content)</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedMagicMethod>
-      <code>setSeparator</code>
-    </UndefinedMagicMethod>
   </file>
   <file src="src/Helper/HeadTitle.php">
-    <MissingClosureParamType>
-      <code>$item</code>
-      <code>$item</code>
-    </MissingClosureParamType>
-    <MissingClosureReturnType>
-      <code><![CDATA[static fn($item) => $item]]></code>
-    </MissingClosureReturnType>
     <MixedArgument>
       <code>$item</code>
-      <code>$separator</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code>$items</code>
-    </MixedArgumentTypeCoercion>
     <MixedAssignment>
-      <code>$indent</code>
       <code>$item</code>
-      <code>$items[]</code>
-      <code>$postfix</code>
-      <code>$prefix</code>
-      <code>$separator</code>
     </MixedAssignment>
-    <MixedOperand>
-      <code>$indent</code>
-      <code>$postfix</code>
-      <code>$prefix</code>
-    </MixedOperand>
-    <PossiblyNullReference>
-      <code>translate</code>
-    </PossiblyNullReference>
   </file>
   <file src="src/Helper/HtmlFlash.php">
     <MixedAssignment>
@@ -644,19 +544,6 @@
     <RedundantCastGivenDocblockType>
       <code>(bool) $useNamespaces</code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="src/Helper/InlineScript.php">
-    <LessSpecificReturnStatement>
-      <code>parent::__invoke($mode, $spec, $placement, $attrs, $type)</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType>
-      <code>InlineScript</code>
-    </MoreSpecificReturnType>
-    <PropertyNotSetInConstructor>
-      <code>InlineScript</code>
-      <code>InlineScript</code>
-      <code>InlineScript</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="src/Helper/Json.php">
     <MissingConstructor>
@@ -1237,18 +1124,6 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Helper/Placeholder.php">
-    <InvalidStringClass>
-      <code><![CDATA[new $this->containerClass($value)]]></code>
-    </InvalidStringClass>
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$this->items[$key]]]></code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType>
-      <code>AbstractContainer</code>
-    </MoreSpecificReturnType>
-    <PropertyTypeCoercion>
-      <code><![CDATA[$this->items]]></code>
-    </PropertyTypeCoercion>
     <RedundantCastGivenDocblockType>
       <code>(string) $key</code>
       <code>(string) $key</code>
@@ -1256,91 +1131,62 @@
       <code>(string) $key</code>
       <code>(string) $name</code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="src/Helper/Placeholder/Container.php">
-    <PropertyNotSetInConstructor>
-      <code>Container</code>
-      <code>Container</code>
-    </PropertyNotSetInConstructor>
+    <UnsafeInstantiation>
+      <code><![CDATA[new $this->containerClass($value)]]></code>
+    </UnsafeInstantiation>
   </file>
   <file src="src/Helper/Placeholder/Container/AbstractContainer.php">
     <ImplementedReturnTypeMismatch>
-      <code>self</code>
+      <code>$this</code>
     </ImplementedReturnTypeMismatch>
+    <InvalidArgument>
+      <code>$data</code>
+      <code>$data</code>
+      <code>$data</code>
+      <code>$data</code>
+      <code><![CDATA[$this->nextIndex()]]></code>
+      <code><![CDATA[$this->nextIndex()]]></code>
+      <code>$this[$key] .= $data</code>
+    </InvalidArgument>
+    <InvalidReturnStatement>
+      <code>max($keys) + 1</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code>int</code>
+    </InvalidReturnType>
     <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
-    <MissingTemplateParam>
-      <code>AbstractContainer</code>
-    </MissingTemplateParam>
     <MixedArgumentTypeCoercion>
       <code>$items</code>
+      <code><![CDATA[$this->getArrayCopy()]]></code>
+      <code>$values</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayOffset>
-      <code>$this[$key]</code>
-    </MixedArrayOffset>
-    <MixedAssignment>
-      <code>$key</code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code>int</code>
-    </MixedInferredReturnType>
     <MixedOperand>
       <code>$this[$key]</code>
       <code>max($keys)</code>
     </MixedOperand>
-    <MixedReturnStatement>
-      <code>max($keys) + 1</code>
-    </MixedReturnStatement>
-    <PropertyNotSetInConstructor>
-      <code>$captureKey</code>
-      <code>$captureType</code>
-    </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType>
-      <code>(string) $indent</code>
       <code>(string) $postfix</code>
       <code>(string) $prefix</code>
       <code>(string) $separator</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[null !== $this->captureKey]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/Placeholder/Container/AbstractStandalone.php">
-    <InvalidStringClass>
-      <code><![CDATA[new $this->containerClass()]]></code>
-    </InvalidStringClass>
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$this->container]]></code>
-    </LessSpecificReturnStatement>
     <MethodSignatureMustProvideReturnType>
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
-    <MissingTemplateParam>
-      <code>ArrayAccess</code>
-      <code>IteratorAggregate</code>
-    </MissingTemplateParam>
     <MixedAssignment>
-      <code>$container[$key]</code>
       <code>$return</code>
     </MixedAssignment>
-    <MoreSpecificReturnType>
-      <code>AbstractContainer</code>
-    </MoreSpecificReturnType>
-    <PossiblyNullPropertyAssignmentValue>
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
-    <PropertyTypeCoercion>
-      <code><![CDATA[new $this->containerClass()]]></code>
-    </PropertyTypeCoercion>
     <RedundantCastGivenDocblockType>
       <code>(bool) $autoEscape</code>
       <code>(string) $string</code>
       <code>(string) $string</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[null !== $this->container]]></code>
-    </RedundantConditionGivenDocblockType>
+    <UnsafeInstantiation>
+      <code><![CDATA[new $this->containerClass()]]></code>
+    </UnsafeInstantiation>
   </file>
   <file src="src/Helper/Placeholder/Registry.php">
     <DocblockTypeContradiction>
@@ -2253,10 +2099,6 @@
     </UndefinedMethod>
   </file>
   <file src="test/Helper/HeadLinkTest.php">
-    <InvalidArgument>
-      <code><![CDATA['foo']]></code>
-      <code><![CDATA['foo']]></code>
-    </InvalidArgument>
     <MixedArgument>
       <code><![CDATA[$attributeEscaper('/styles.css')]]></code>
       <code><![CDATA[$attributeEscaper('/styles.css')]]></code>
@@ -2327,7 +2169,6 @@
       <code>getValue</code>
       <code>getValue</code>
       <code>getValue</code>
-      <code>setIndent</code>
     </UndefinedMagicMethod>
   </file>
   <file src="test/Helper/HeadMetaTest.php">
@@ -2372,14 +2213,12 @@
     <UndefinedMagicMethod>
       <code>getArrayCopy</code>
       <code>getArrayCopy</code>
-      <code>getArrayCopy</code>
       <code>getValue</code>
       <code>offsetSetHttpEquiv</code>
       <code>offsetSetHttpEquiv</code>
       <code>offsetSetName</code>
       <code>offsetSetName</code>
       <code>offsetSetName</code>
-      <code>setIndent</code>
     </UndefinedMagicMethod>
   </file>
   <file src="test/Helper/HeadScriptTest.php">
@@ -2389,39 +2228,7 @@
       <code><![CDATA[$attributeEscaper('test3.js')]]></code>
       <code><![CDATA[$attributeEscaper('test4.js')]]></code>
       <code><![CDATA[$attributeEscaper('text/javascript')]]></code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code><![CDATA[$item->source]]></code>
-      <code>$values</code>
-      <code>$values</code>
     </MixedArgument>
-    <MixedArrayAccess>
-      <code>$items[$i]</code>
-    </MixedArrayAccess>
-    <MixedAssignment>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$items</code>
-      <code>$values</code>
-    </MixedAssignment>
-    <MixedPropertyFetch>
-      <code><![CDATA[$item->source]]></code>
-    </MixedPropertyFetch>
-    <UndefinedMagicMethod>
-      <code>getArrayCopy</code>
-      <code>getArrayCopy</code>
-      <code>setIndent</code>
-      <code>setIndent</code>
-    </UndefinedMagicMethod>
-  </file>
-  <file src="test/Helper/HeadTitleTest.php">
-    <MixedAssignment>
-      <code>$placeholder</code>
-    </MixedAssignment>
-    <MixedMethodCall>
-      <code>renderTitle</code>
-    </MixedMethodCall>
   </file>
   <file src="test/Helper/HtmlFlashTest.php">
     <DeprecatedClass>
@@ -2950,22 +2757,10 @@
       <code><![CDATA[$this->translations]]></code>
     </InvalidArgument>
   </file>
-  <file src="test/Helper/TestAsset/Bar.php">
-    <PropertyNotSetInConstructor>
-      <code>Bar</code>
-      <code>Bar</code>
-    </PropertyNotSetInConstructor>
-  </file>
   <file src="test/Helper/TestAsset/IteratorWithToArrayTestContainer.php">
     <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-  </file>
-  <file src="test/Helper/TestAsset/MockContainer.php">
-    <PropertyNotSetInConstructor>
-      <code>MockContainer</code>
-      <code>MockContainer</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="test/Helper/UrlIntegrationTest.php">
     <DeprecatedClass>

--- a/src/Helper/HeadLink.php
+++ b/src/Helper/HeadLink.php
@@ -358,17 +358,18 @@ class HeadLink extends AbstractStandalone
      */
     public function toString($indent = null)
     {
-        $indent = null !== $indent
-                ? $this->getContainer()->getWhitespace($indent)
-                : $this->getContainer()->getIndent();
+        $container = $this->getContainer();
+        $indent    = null !== $indent
+                ? $container->getWhitespace($indent)
+                : $container->getIndent();
 
         $items = [];
-        $this->getContainer()->ksort();
-        foreach ($this as $item) {
+        $container->ksort();
+        foreach ($container as $item) {
             $items[] = $this->itemToString($item);
         }
 
-        return $indent . implode($this->escape($this->getContainer()->getSeparator()) . $indent, $items);
+        return $indent . implode($this->escape($container->getSeparator()) . $indent, $items);
     }
 
     /**

--- a/src/Helper/HeadLink.php
+++ b/src/Helper/HeadLink.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Laminas\View\Helper;
 
 use Laminas\View\Exception;
-use stdClass;
+use Laminas\View\Helper\Placeholder\Container\AbstractContainer;
+use Laminas\View\Helper\Placeholder\Container\AbstractStandalone;
 
 use function array_intersect;
 use function array_keys;
 use function array_shift;
-use function call_user_func_array;
 use function count;
-use function func_get_args;
 use function get_object_vars;
 use function implode;
 use function is_array;
+use function is_object;
 use function is_string;
 use function method_exists;
 use function preg_match;
@@ -24,11 +24,8 @@ use function str_replace;
 
 use const PHP_EOL;
 
-// @codingStandardsIgnoreStart
 /**
- * Laminas_Layout_View_Helper_HeadLink
- *
- * @see http://www.w3.org/TR/xhtml1/dtds.html
+ * @extends AbstractStandalone<int, object>
  *
  * Creates the following virtual methods:
  * @method HeadLink appendStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = [])
@@ -40,8 +37,7 @@ use const PHP_EOL;
  * @method HeadLink prependAlternate($href, $type, $title, $extras = [])
  * @method HeadLink setAlternate($href, $type, $title, $extras = [])
  */
-class HeadLink extends Placeholder\Container\AbstractStandalone
-// @codingStandardsIgnoreEnd
+class HeadLink extends AbstractStandalone
 {
     /**
      * Allowed attributes
@@ -84,13 +80,13 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      * Allows calling $helper->headLink(), but, more importantly, chaining calls
      * like ->appendStylesheet()->headLink().
      *
-     * @param  array|null $attributes
+     * @param  array<string, mixed>|null $attributes
      * @param  string     $placement
      * @return HeadLink
      */
-    public function headLink(?array $attributes = null, $placement = Placeholder\Container\AbstractContainer::APPEND)
+    public function headLink(?array $attributes = null, $placement = AbstractContainer::APPEND)
     {
-        return call_user_func_array([$this, '__invoke'], func_get_args());
+        return $this->__invoke($attributes, $placement);
     }
 
     /**
@@ -99,22 +95,22 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      * Returns current object instance. Optionally, allows passing array of
      * values to build link.
      *
-     * @param  array|null $attributes
-     * @param  string     $placement
-     * @return HeadLink
+     * @param array<string, mixed>|null $attributes
+     * @param string $placement
+     * @return $this
      */
-    public function __invoke(?array $attributes = null, $placement = Placeholder\Container\AbstractContainer::APPEND)
+    public function __invoke(?array $attributes = null, $placement = AbstractContainer::APPEND)
     {
         if (null !== $attributes) {
             $item = $this->createData($attributes);
             switch ($placement) {
-                case Placeholder\Container\AbstractContainer::SET:
+                case AbstractContainer::SET:
                     $this->set($item);
                     break;
-                case Placeholder\Container\AbstractContainer::PREPEND:
+                case AbstractContainer::PREPEND:
                     $this->prepend($item);
                     break;
-                case Placeholder\Container\AbstractContainer::APPEND:
+                case AbstractContainer::APPEND:
                 default:
                     $this->append($item);
                     break;
@@ -201,12 +197,14 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
     /**
      * Check if value is valid
      *
-     * @param  mixed $value
+     * @internal This method will become private in version 3.0
+     *
+     * @param mixed $value
      * @return bool
      */
     protected function isValid($value)
     {
-        if (! $value instanceof stdClass) {
+        if (! is_object($value)) {
             return false;
         }
 
@@ -223,9 +221,9 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
     /**
      * append()
      *
-     * @param mixed $value
+     * @param object $value
      * @throws Exception\InvalidArgumentException
-     * @return Placeholder\Container\AbstractContainer
+     * @return AbstractContainer
      */
     public function append($value)
     {
@@ -241,8 +239,8 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
     /**
      * offsetSet()
      *
-     * @param  string|int $index
-     * @param  array      $value
+     * @param int $index
+     * @param object $value
      * @throws Exception\InvalidArgumentException
      * @return void
      */
@@ -260,9 +258,9 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
     /**
      * prepend()
      *
-     * @param mixed $value
+     * @param object $value
      * @throws Exception\InvalidArgumentException
-     * @return Placeholder\Container\AbstractContainer
+     * @return AbstractContainer
      */
     public function prepend($value)
     {
@@ -278,9 +276,9 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
     /**
      * set()
      *
-     * @param  array $value
+     * @param object $value
      * @throws Exception\InvalidArgumentException
-     * @return HeadLink
+     * @return $this
      */
     public function set($value)
     {
@@ -290,15 +288,19 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
             );
         }
 
-        return $this->getContainer()->set($value);
+        $this->getContainer()->set($value);
+
+        return $this;
     }
 
     /**
      * Create HTML link element from data item
      *
+     * @internal This method will become private in version 3.0
+     *
      * @return string
      */
-    public function itemToString(stdClass $item)
+    public function itemToString(object $item)
     {
         $attributes = (array) $item;
         $link       = '<link';
@@ -357,8 +359,8 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
     public function toString($indent = null)
     {
         $indent = null !== $indent
-                ? $this->getWhitespace($indent)
-                : $this->getIndent();
+                ? $this->getContainer()->getWhitespace($indent)
+                : $this->getContainer()->getIndent();
 
         $items = [];
         $this->getContainer()->ksort();
@@ -366,14 +368,16 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
             $items[] = $this->itemToString($item);
         }
 
-        return $indent . implode($this->escape($this->getSeparator()) . $indent, $items);
+        return $indent . implode($this->escape($this->getContainer()->getSeparator()) . $indent, $items);
     }
 
     /**
      * Create data item for stack
      *
-     * @param  array $attributes
-     * @return stdClass
+     * @internal This method will become private in version 3.0
+     *
+     * @param array<string, mixed> $attributes
+     * @return object
      */
     public function createData(array $attributes)
     {
@@ -383,8 +387,10 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
     /**
      * Create item for stylesheet link item
      *
+     * @deprecated This method is unused and will be removed in version 3.0 of this component
+     *
      * @param  array $args
-     * @return stdClass|false Returns false if stylesheet is a duplicate
+     * @return object|false Returns false if stylesheet is a duplicate
      */
     public function createDataStylesheet(array $args)
     {
@@ -435,6 +441,8 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
     /**
      * Is the linked stylesheet a duplicate?
      *
+     * @internal This method will become private in version 3.0
+     *
      * @param  string $uri
      * @return bool
      */
@@ -452,9 +460,11 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
     /**
      * Create item for alternate link item
      *
+     * @deprecated This method is unused and will be removed in version 3.0 of this component
+     *
      * @param  array $args
      * @throws Exception\InvalidArgumentException
-     * @return stdClass
+     * @return object
      */
     public function createDataAlternate(array $args)
     {
@@ -493,8 +503,10 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
     /**
      * Create item for a prev relationship (mainly used for pagination)
      *
+     * @deprecated This method is unused and will be removed in version 3.0 of this component
+     *
      * @param  array $args
-     * @return stdClass
+     * @return object
      */
     public function createDataPrev(array $args)
     {
@@ -507,8 +519,10 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
     /**
      * Create item for a prev relationship (mainly used for pagination)
      *
+     * @deprecated This method is unused and will be removed in version 3.0 of this component
+     *
      * @param  array $args
-     * @return stdClass
+     * @return object
      */
     public function createDataNext(array $args)
     {

--- a/src/Helper/HeadLink.php
+++ b/src/Helper/HeadLink.php
@@ -7,6 +7,7 @@ namespace Laminas\View\Helper;
 use Laminas\View\Exception;
 use Laminas\View\Helper\Placeholder\Container\AbstractContainer;
 use Laminas\View\Helper\Placeholder\Container\AbstractStandalone;
+use stdClass;
 
 use function array_intersect;
 use function array_keys;
@@ -36,6 +37,7 @@ use const PHP_EOL;
  * @method HeadLink offsetSetAlternate($index, $href, $type, $title, $extras = [])
  * @method HeadLink prependAlternate($href, $type, $title, $extras = [])
  * @method HeadLink setAlternate($href, $type, $title, $extras = [])
+ * @final
  */
 class HeadLink extends AbstractStandalone
 {
@@ -300,7 +302,7 @@ class HeadLink extends AbstractStandalone
      *
      * @return string
      */
-    public function itemToString(object $item)
+    public function itemToString(stdClass $item)
     {
         $attributes = (array) $item;
         $link       = '<link';

--- a/src/Helper/HeadMeta.php
+++ b/src/Helper/HeadMeta.php
@@ -8,6 +8,7 @@ use Laminas\View;
 use Laminas\View\Exception;
 use Laminas\View\Helper\Placeholder\Container\AbstractContainer;
 use Laminas\View\Helper\Placeholder\Container\AbstractStandalone;
+use stdClass;
 
 use function array_shift;
 use function array_unshift;
@@ -63,6 +64,7 @@ use const PHP_EOL;
  *     itemprop?: string,
  * }
  * @extends AbstractStandalone<int, ObjectShape>
+ * @final
  */
 class HeadMeta extends AbstractStandalone
 {
@@ -254,7 +256,7 @@ class HeadMeta extends AbstractStandalone
      * @throws Exception\InvalidArgumentException
      * @return string
      */
-    public function itemToString(object $item)
+    public function itemToString(stdClass $item)
     {
         if (! in_array($item->type, $this->typeKeys)) {
             throw new Exception\InvalidArgumentException(sprintf(

--- a/src/Helper/HeadScript.php
+++ b/src/Helper/HeadScript.php
@@ -272,9 +272,10 @@ class HeadScript extends AbstractStandalone
      */
     public function toString($indent = null)
     {
-        $indent = null !== $indent
-            ? $this->getContainer()->getWhitespace($indent)
-            : $this->getContainer()->getIndent();
+        $container = $this->getContainer();
+        $indent    = null !== $indent
+            ? $container->getWhitespace($indent)
+            : $container->getIndent();
 
         if ($this->view instanceof PhpRenderer) {
             $doctype = $this->view->plugin('doctype');
@@ -289,8 +290,8 @@ class HeadScript extends AbstractStandalone
         $escapeEnd   = $useCdata ? '//]]>' : '//-->';
 
         $items = [];
-        $this->getContainer()->ksort();
-        foreach ($this as $item) {
+        $container->ksort();
+        foreach ($container as $item) {
             if (! $this->isValid($item)) {
                 continue;
             }
@@ -298,7 +299,7 @@ class HeadScript extends AbstractStandalone
             $items[] = $this->itemToString($item, $indent, $escapeStart, $escapeEnd);
         }
 
-        return implode($this->getSeparator(), $items);
+        return implode($container->getSeparator(), $items);
     }
 
     /**
@@ -399,7 +400,7 @@ class HeadScript extends AbstractStandalone
      *
      * @internal This method will become private in version 3.0
      *
-     * @param  mixed  $value  Is the given script valid?
+     * @param mixed $value Is the given script valid?
      * @return bool
      */
     protected function isValid($value)

--- a/src/Helper/HeadScript.php
+++ b/src/Helper/HeadScript.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace Laminas\View\Helper;
 
 use Laminas\View\Exception;
-use stdClass;
+use Laminas\View\Helper\Placeholder\Container\AbstractContainer;
+use Laminas\View\Helper\Placeholder\Container\AbstractStandalone;
+use Laminas\View\Renderer\PhpRenderer;
 
 use function array_key_exists;
 use function array_shift;
+use function assert;
 use function count;
 use function filter_var;
 use function implode;
 use function in_array;
+use function is_object;
 use function is_string;
 use function ob_get_clean;
 use function ob_start;
@@ -38,8 +42,14 @@ use const PHP_EOL;
  * @method HeadScript offsetSetScript($index, $src, $type = 'text/javascript', $attrs = [])
  * @method HeadScript prependScript($script, $type = 'text/javascript', $attrs = [])
  * @method HeadScript setScript($script, $type = 'text/javascript', $attrs = [])
+ * @psalm-type ObjectShape = object{
+ *     type: string,
+ *     attributes: array<string, mixed>,
+ *     source: string|null,
+ * }
+ * @extends AbstractStandalone<int, ObjectShape>
  */
-class HeadScript extends Placeholder\Container\AbstractStandalone
+class HeadScript extends AbstractStandalone
 {
     /**
      * Script type constants
@@ -66,33 +76,33 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      *
      * @var bool
      */
-    protected $captureLock;
+    protected $captureLock = false;
 
     /**
      * Capture type
      *
-     * @var string
+     * @var string|null
      */
     protected $captureScriptType;
 
     /**
      * Capture attributes
      *
-     * @var null|array
+     * @var null|array<string, mixed>
      */
     protected $captureScriptAttrs;
 
     /**
      * Capture type (append, prepend, set)
      *
-     * @var string
+     * @var string|null
      */
     protected $captureType;
 
     /**
      * Optional allowed attributes for script tag
      *
-     * @var array
+     * @var list<string>
      */
     protected $optionalAttributes = [
         'charset',
@@ -111,7 +121,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
     /**
      * Script attributes that behave as booleans
      *
-     * @var string[]
+     * @var list<string>
      */
     private array $booleanAttributes = [
         'nomodule',
@@ -122,7 +132,9 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
     /**
      * Required attributes for script tag
      *
-     * @var string
+     * @deprecated This property is unused and will be removed in version 3.0 of this component
+     *
+     * @var list<string>
      */
     protected $requiredAttributes = ['type'];
 
@@ -134,16 +146,11 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      */
     public $useCdata = false;
 
-    /**
-     * Constructor
-     *
-     * Set separator to PHP_EOL.
-     */
     public function __construct()
     {
         parent::__construct();
 
-        $this->setSeparator(PHP_EOL);
+        $this->getContainer()->setSeparator(PHP_EOL);
     }
 
     /**
@@ -155,9 +162,9 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * @param  string $mode      Script or file
      * @param  string $spec      Script/url
      * @param  string $placement Append, prepend, or set
-     * @param  array  $attrs     Array of script attributes
+     * @param  array<string, mixed> $attrs Array of script attributes
      * @param  string $type      Script type and/or array of script attributes
-     * @return HeadScript
+     * @return $this
      */
     public function __invoke(
         $mode = self::FILE,
@@ -191,7 +198,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * @param  string $method Method to call
      * @param  array  $args   Arguments of method
      * @throws Exception\BadMethodCallException If too few arguments or invalid method.
-     * @return HeadScript
+     * @return $this
      */
     public function __call($method, $args)
     {
@@ -266,11 +273,14 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
     public function toString($indent = null)
     {
         $indent = null !== $indent
-            ? $this->getWhitespace($indent)
-            : $this->getIndent();
+            ? $this->getContainer()->getWhitespace($indent)
+            : $this->getContainer()->getIndent();
 
-        if ($this->view) {
-            $useCdata = $this->view->plugin('doctype')->isXhtml();
+        if ($this->view instanceof PhpRenderer) {
+            $doctype = $this->view->plugin('doctype');
+            assert($doctype instanceof Doctype);
+
+            $useCdata = $doctype->isXhtml();
         } else {
             $useCdata = $this->useCdata;
         }
@@ -294,14 +304,14 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
     /**
      * Start capture action
      *
-     * @param  mixed  $captureType Type of capture
-     * @param  string $type        Type of script
-     * @param  array  $attrs       Attributes of capture
+     * @param string $captureType Type of capture
+     * @param string $type        Type of script
+     * @param array<string, mixed> $attrs Attributes of capture
      * @throws Exception\RuntimeException
      * @return void
      */
     public function captureStart(
-        $captureType = Placeholder\Container\AbstractContainer::APPEND,
+        $captureType = AbstractContainer::APPEND,
         $type = self::DEFAULT_SCRIPT_TYPE,
         $attrs = []
     ) {
@@ -331,9 +341,9 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
         $this->captureLock        = false;
 
         switch ($this->captureType) {
-            case Placeholder\Container\AbstractContainer::SET:
-            case Placeholder\Container\AbstractContainer::PREPEND:
-            case Placeholder\Container\AbstractContainer::APPEND:
+            case AbstractContainer::SET:
+            case AbstractContainer::PREPEND:
+            case AbstractContainer::APPEND:
                 $action = strtolower($this->captureType) . 'Script';
                 break;
             default:
@@ -347,19 +357,20 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
     /**
      * Create data item containing all necessary components of script
      *
+     * @internal This method will become private in version 3.0
+     *
      * @param  string $type       Type of data
-     * @param  array  $attributes Attributes of data
+     * @param  array<string, mixed> $attributes Attributes of data
      * @param  string $content    Content of data
-     * @return stdClass
+     * @return ObjectShape
      */
     public function createData($type, array $attributes, $content = null)
     {
-        $data             = new stdClass();
-        $data->type       = $type;
-        $data->attributes = $attributes;
-        $data->source     = $content;
-
-        return $data;
+        return (object) [
+            'type'       => $type,
+            'attributes' => $attributes,
+            'source'     => $content,
+        ];
     }
 
     /**
@@ -386,13 +397,15 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
     /**
      * Is the script provided valid?
      *
+     * @internal This method will become private in version 3.0
+     *
      * @param  mixed  $value  Is the given script valid?
      * @return bool
      */
     protected function isValid($value)
     {
         if (
-            ! $value instanceof stdClass
+            ! is_object($value)
             || ! isset($value->type)
             || (! isset($value->source)
                 && ! isset($value->attributes))
@@ -405,6 +418,8 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
 
     /**
      * Create script HTML
+     *
+     * @internal This method will become private in version 3.0
      *
      * @param  mixed  $item        Item to convert
      * @param  string $indent      String to add before the item
@@ -484,9 +499,9 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
     /**
      * Override append
      *
-     * @param string $value Append script or file
+     * @param ObjectShape $value Append script or file
      * @throws Exception\InvalidArgumentException
-     * @return Placeholder\Container\AbstractContainer
+     * @return AbstractContainer
      */
     public function append($value)
     {
@@ -503,9 +518,9 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
     /**
      * Override prepend
      *
-     * @param string $value Prepend script or file
+     * @param ObjectShape $value Prepend script or file
      * @throws Exception\InvalidArgumentException
-     * @return Placeholder\Container\AbstractContainer
+     * @return AbstractContainer
      */
     public function prepend($value)
     {
@@ -522,7 +537,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
     /**
      * Override set
      *
-     * @param  string $value Set script or file
+     * @param ObjectShape $value Set script or file
      * @throws Exception\InvalidArgumentException
      * @return void
      */
@@ -540,8 +555,8 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
     /**
      * Override offsetSet
      *
-     * @param  string|int $index Set script of file offset
-     * @param  mixed      $value
+     * @param int $index Set script of file offset
+     * @param ObjectShape $value
      * @throws Exception\InvalidArgumentException
      * @return void
      */
@@ -561,7 +576,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * Set flag indicating if arbitrary attributes are allowed
      *
      * @param  bool $flag Set flag
-     * @return HeadScript
+     * @return $this
      */
     public function setAllowArbitraryAttributes($flag)
     {

--- a/src/Helper/HeadScript.php
+++ b/src/Helper/HeadScript.php
@@ -422,10 +422,10 @@ class HeadScript extends AbstractStandalone
      *
      * @internal This method will become private in version 3.0
      *
-     * @param  mixed  $item        Item to convert
-     * @param  string $indent      String to add before the item
-     * @param  string $escapeStart Starting sequence
-     * @param  string $escapeEnd   Ending sequence
+     * @param ObjectShape $item Item to convert
+     * @param string $indent String to add before the item
+     * @param string $escapeStart Starting sequence
+     * @param string $escapeEnd Ending sequence
      * @return string
      */
     public function itemToString($item, $indent, $escapeStart, $escapeEnd)

--- a/src/Helper/HeadStyle.php
+++ b/src/Helper/HeadStyle.php
@@ -191,20 +191,21 @@ class HeadStyle extends AbstractStandalone
      */
     public function toString($indent = null)
     {
-        $indent = null !== $indent
-            ? $this->getContainer()->getWhitespace($indent)
-            : $this->getContainer()->getIndent();
+        $container = $this->getContainer();
+        $indent    = null !== $indent
+            ? $container->getWhitespace($indent)
+            : $container->getIndent();
 
         $items = [];
-        $this->getContainer()->ksort();
-        foreach ($this as $item) {
+        $container->ksort();
+        foreach ($container as $item) {
             if (! $this->isValid($item)) {
                 continue;
             }
             $items[] = $this->itemToString($item, $indent);
         }
 
-        $return = implode($this->getContainer()->getSeparator(), $items);
+        $return = implode($container->getSeparator(), $items);
 
         return $indent . preg_replace("/(\r\n?|\n)/", '$1' . $indent, $return);
     }
@@ -282,7 +283,6 @@ class HeadStyle extends AbstractStandalone
      * @internal This method is internal and will be made private in version 3.0
      *
      * @return bool
-     * @psalm-assert-if-true ObjectShape $value
      */
     protected function isValid(mixed $value)
     {

--- a/src/Helper/HeadStyle.php
+++ b/src/Helper/HeadStyle.php
@@ -44,6 +44,7 @@ use const PHP_EOL;
  * @method HeadStyle prependStyle(string $content, array $attributes = [])
  * @method HeadStyle setStyle(string $content, array $attributes = [])
  * @method HeadStyle setIndent(int|string $indent)
+ * @final
  */
 class HeadStyle extends AbstractStandalone
 {
@@ -369,7 +370,7 @@ class HeadStyle extends AbstractStandalone
      * @param string $indent Indentation to use
      * @return string
      */
-    public function itemToString(object $item, $indent)
+    public function itemToString(stdClass $item, $indent)
     {
         if (! isset($item->content) || ! is_string($item->content) || $item->content === '') {
             return '';

--- a/src/Helper/HeadTitle.php
+++ b/src/Helper/HeadTitle.php
@@ -21,6 +21,7 @@ use function in_array;
  * @method HeadTitle set(string $string)
  * @method HeadTitle prepend(string $string)
  * @method HeadTitle append(string $string)
+ * @final
  */
 class HeadTitle extends AbstractStandalone
 {

--- a/src/Helper/HeadTitle.php
+++ b/src/Helper/HeadTitle.php
@@ -69,9 +69,10 @@ class HeadTitle extends AbstractStandalone
      */
     public function toString($indent = null)
     {
-        $indent = null !== $indent
-                ? $this->getContainer()->getWhitespace($indent)
-                : $this->getContainer()->getIndent();
+        $container = $this->getContainer();
+        $indent    = null !== $indent
+                ? $container->getWhitespace($indent)
+                : $container->getIndent();
 
         $output = $this->renderTitle();
 
@@ -88,21 +89,22 @@ class HeadTitle extends AbstractStandalone
         $items = [];
 
         $itemCallback = $this->getTitleItemCallback();
-        foreach ($this as $item) {
+        $container    = $this->getContainer();
+        foreach ($container as $item) {
             $items[] = $itemCallback($item);
         }
 
-        $separator = $this->getContainer()->getSeparator();
+        $separator = $container->getSeparator();
         $output    = '';
 
-        $prefix = $this->getContainer()->getPrefix();
+        $prefix = $container->getPrefix();
         if ($prefix) {
             $output .= $prefix;
         }
 
         $output .= implode($separator, $items);
 
-        $postfix = $this->getContainer()->getPostfix();
+        $postfix = $container->getPostfix();
         if ($postfix) {
             $output .= $postfix;
         }

--- a/src/Helper/InlineScript.php
+++ b/src/Helper/InlineScript.php
@@ -7,6 +7,8 @@ namespace Laminas\View\Helper;
 /**
  * Helper for setting and retrieving script elements for inclusion in HTML body
  * section
+ *
+ * @final
  */
 class InlineScript extends HeadScript
 {

--- a/src/Helper/InlineScript.php
+++ b/src/Helper/InlineScript.php
@@ -16,12 +16,12 @@ class InlineScript extends HeadScript
      * Returns InlineScript helper object; optionally, allows specifying a
      * script or script file to include.
      *
-     * @param  string $mode      Script or file
-     * @param  string $spec      Script/url
-     * @param  string $placement Append, prepend, or set
-     * @param  array  $attrs     Array of script attributes
-     * @param  string $type      Script type and/or array of script attributes
-     * @return InlineScript
+     * @param string $mode      Script or file
+     * @param string $spec      Script/url
+     * @param string $placement Append, prepend, or set
+     * @param array<string, mixed> $attrs Array of script attributes
+     * @param string $type      Script type and/or array of script attributes
+     * @return $this
      */
     public function __invoke(
         $mode = self::FILE,

--- a/src/Helper/Placeholder.php
+++ b/src/Helper/Placeholder.php
@@ -21,14 +21,14 @@ class Placeholder extends AbstractHelper
     /**
      * Placeholder items
      *
-     * @var AbstractContainer[]
+     * @var array<string, AbstractContainer>
      */
     protected $items = [];
 
     /**
      * Default container class
      *
-     * @var string
+     * @var class-string<AbstractContainer>
      */
     protected $containerClass = Container::class;
 
@@ -47,8 +47,7 @@ class Placeholder extends AbstractHelper
             );
         }
 
-        $name = (string) $name;
-        return $this->getContainer($name);
+        return $this->getContainer((string) $name);
     }
 
     /**

--- a/src/Helper/Placeholder/Container.php
+++ b/src/Helper/Placeholder/Container.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper\Placeholder;
 
+use Laminas\View\Helper\Placeholder\Container\AbstractContainer;
+
 /**
  * Container for placeholder values
+ *
+ * @template TKey
+ * @template TValue
+ * @extends AbstractContainer<TKey, TValue>
  */
-class Container extends Container\AbstractContainer
+class Container extends AbstractContainer
 {
 }

--- a/src/Helper/Placeholder/Container/AbstractContainer.php
+++ b/src/Helper/Placeholder/Container/AbstractContainer.php
@@ -6,7 +6,7 @@ namespace Laminas\View\Helper\Placeholder\Container;
 
 use ArrayObject;
 use Laminas\View\Exception;
-use ReturnTypeWillChange; // phpcs:ignore
+use ReturnTypeWillChange;
 
 use function array_keys;
 use function array_shift;
@@ -23,25 +23,29 @@ use function str_repeat;
 
 /**
  * Abstract class representing container for placeholder values
+ *
+ * @template TKey
+ * @template TValue
+ * @extends ArrayObject<TKey, TValue>
  */
 abstract class AbstractContainer extends ArrayObject
 {
     /**
-     * Whether or not to override all contents of placeholder
+     * Whether to override all contents of placeholder
      *
      * @const string
      */
     public const SET = 'SET';
 
     /**
-     * Whether or not to append contents to placeholder
+     * Whether to append contents to placeholder
      *
      * @const string
      */
     public const APPEND = 'APPEND';
 
     /**
-     * Whether or not to prepend contents to placeholder
+     * Whether to prepend contents to placeholder
      *
      * @const string
      */
@@ -50,7 +54,7 @@ abstract class AbstractContainer extends ArrayObject
     /**
      * Key to which to capture content
      *
-     * @var string
+     * @var TKey|null
      */
     protected $captureKey;
 
@@ -64,7 +68,7 @@ abstract class AbstractContainer extends ArrayObject
     /**
      * What type of capture (overwrite (set), append, prepend) to use
      *
-     * @var string
+     * @var string|null
      */
     protected $captureType;
 
@@ -98,6 +102,8 @@ abstract class AbstractContainer extends ArrayObject
 
     /**
      * Constructor - This is needed so that we can attach a class member as the ArrayObject container
+     *
+     * @final
      */
     public function __construct()
     {
@@ -145,7 +151,7 @@ abstract class AbstractContainer extends ArrayObject
      * Start capturing content to push into placeholder
      *
      * @param  string $type How to capture content into placeholder; append, prepend, or set
-     * @param  mixed  $key  Key to which to capture content
+     * @param  TKey $key  Key to which to capture content
      * @throws Exception\RuntimeException If nested captures detected.
      * @return void
      */
@@ -159,8 +165,8 @@ abstract class AbstractContainer extends ArrayObject
 
         $this->captureLock = true;
         $this->captureType = $type;
-        if ((null !== $key) && is_scalar($key)) {
-            $this->captureKey = (string) $key;
+        if (is_scalar($key)) {
+            $this->captureKey = $key;
         }
         ob_start();
     }
@@ -173,11 +179,9 @@ abstract class AbstractContainer extends ArrayObject
     public function captureEnd()
     {
         $data              = ob_get_clean();
-        $key               = null;
+        $key               = $this->captureKey;
         $this->captureLock = false;
-        if (null !== $this->captureKey) {
-            $key = $this->captureKey;
-        }
+
         switch ($this->captureType) {
             case self::SET:
                 if (null !== $key) {
@@ -214,13 +218,11 @@ abstract class AbstractContainer extends ArrayObject
     /**
      * Get keys
      *
-     * @return array
+     * @return list<TKey>
      */
     public function getKeys()
     {
-        $array = $this->getArrayCopy();
-
-        return array_keys($array);
+        return array_keys($this->getArrayCopy());
     }
 
     /**
@@ -229,7 +231,7 @@ abstract class AbstractContainer extends ArrayObject
      * If single element registered, returns that element; otherwise,
      * serializes to array.
      *
-     * @return mixed
+     * @return TValue|array<TKey, TValue>
      */
     public function getValue()
     {
@@ -254,14 +256,14 @@ abstract class AbstractContainer extends ArrayObject
             $indent = str_repeat(' ', $indent);
         }
 
-        return (string) $indent;
+        return $indent;
     }
 
     /**
      * Set a single value
      *
-     * @param mixed $value
-     * @return static
+     * @param TValue $value
+     * @return $this
      */
     public function set($value)
     {
@@ -273,8 +275,8 @@ abstract class AbstractContainer extends ArrayObject
     /**
      * Prepend a value to the top of the container
      *
-     * @param  mixed $value
-     * @return self
+     * @param TValue $value
+     * @return $this
      */
     public function prepend($value)
     {
@@ -288,8 +290,8 @@ abstract class AbstractContainer extends ArrayObject
     /**
      * Append a value to the end of the container
      *
-     * @param  mixed $value
-     * @return self
+     * @param TValue $value
+     * @return $this
      */
     #[ReturnTypeWillChange]
     public function append($value)
@@ -318,7 +320,7 @@ abstract class AbstractContainer extends ArrayObject
      * optionally, if a number is passed, it will be the number of spaces
      *
      * @param  string|int $indent
-     * @return self
+     * @return $this
      */
     public function setIndent($indent)
     {
@@ -340,7 +342,7 @@ abstract class AbstractContainer extends ArrayObject
      * Set postfix for __toString() serialization
      *
      * @param  string $postfix
-     * @return self
+     * @return $this
      */
     public function setPostfix($postfix)
     {
@@ -362,7 +364,7 @@ abstract class AbstractContainer extends ArrayObject
      * Set prefix for __toString() serialization
      *
      * @param  string $prefix
-     * @return self
+     * @return $this
      */
     public function setPrefix($prefix)
     {
@@ -386,7 +388,7 @@ abstract class AbstractContainer extends ArrayObject
      * Used to implode elements in container
      *
      * @param  string $separator
-     * @return self
+     * @return $this
      */
     public function setSeparator($separator)
     {

--- a/src/Helper/Placeholder/Container/AbstractStandalone.php
+++ b/src/Helper/Placeholder/Container/AbstractStandalone.php
@@ -12,7 +12,7 @@ use Laminas\Escaper\Escaper;
 use Laminas\View\Exception;
 use Laminas\View\Helper\AbstractHelper;
 use Laminas\View\Helper\Placeholder\Container;
-use ReturnTypeWillChange; // phpcs:ignore
+use ReturnTypeWillChange;
 
 use function call_user_func_array;
 use function class_exists;
@@ -25,6 +25,19 @@ use function strtolower;
 
 /**
  * Base class for targeted placeholder helpers
+ *
+ * @template TKey
+ * @template TValue
+ * @implements IteratorAggregate<TKey, TValue>
+ * @implements ArrayAccess<TKey, TValue>
+ * @method static setSeparator(string $separator)
+ * @method string getSeparator()
+ * @method static setIndent(int|string $indent)
+ * @method string getIndent()
+ * @method static setPrefix(string $prefix)
+ * @method string getPrefix()
+ * @method static setPostfix(string $postfix)
+ * @method string getPostfix()
  */
 abstract class AbstractStandalone extends AbstractHelper implements
     IteratorAggregate,
@@ -39,22 +52,19 @@ abstract class AbstractStandalone extends AbstractHelper implements
      */
     protected $autoEscape = true;
 
-    /** @var AbstractContainer */
+    /** @var AbstractContainer<TKey, TValue>|null */
     protected $container;
 
     /**
      * Default container class
      *
-     * @var string
+     * @var class-string<AbstractContainer>
      */
     protected $containerClass = Container::class;
 
     /** @var array<string, Escaper> */
     protected $escapers = [];
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
         $this->setContainer($this->getContainer());
@@ -88,8 +98,8 @@ abstract class AbstractStandalone extends AbstractHelper implements
     /**
      * Overloading: set property value
      *
-     * @param  string $key
-     * @param  mixed $value
+     * @param TKey $key
+     * @param TValue $value
      * @return void
      */
     public function __set($key, $value)
@@ -101,8 +111,8 @@ abstract class AbstractStandalone extends AbstractHelper implements
     /**
      * Overloading: retrieve property
      *
-     * @param  string $key
-     * @return mixed
+     * @param TKey $key
+     * @return TValue|null
      */
     public function __get($key)
     {
@@ -115,7 +125,7 @@ abstract class AbstractStandalone extends AbstractHelper implements
     /**
      * Overloading: check if property is set
      *
-     * @param  string $key
+     * @param TKey $key
      * @return bool
      */
     public function __isset($key)
@@ -127,7 +137,7 @@ abstract class AbstractStandalone extends AbstractHelper implements
     /**
      * Overloading: unset property
      *
-     * @param  string $key
+     * @param TKey $key
      * @return void
      */
     public function __unset($key)
@@ -184,7 +194,7 @@ abstract class AbstractStandalone extends AbstractHelper implements
      * Set whether or not auto escaping should be used
      *
      * @param  bool $autoEscape whether or not to auto escape output
-     * @return AbstractStandalone
+     * @return $this
      */
     public function setAutoEscape($autoEscape = true)
     {
@@ -205,7 +215,7 @@ abstract class AbstractStandalone extends AbstractHelper implements
     /**
      * Set container on which to operate
      *
-     * @return AbstractStandalone
+     * @return $this
      */
     public function setContainer(AbstractContainer $container)
     {
@@ -216,7 +226,7 @@ abstract class AbstractStandalone extends AbstractHelper implements
     /**
      * Retrieve placeholder container
      *
-     * @return AbstractContainer
+     * @return AbstractContainer<TKey, TValue>
      */
     public function getContainer()
     {
@@ -244,10 +254,10 @@ abstract class AbstractStandalone extends AbstractHelper implements
     /**
      * Set the container class to use
      *
-     * @param  string $name
+     * @param class-string<AbstractContainer> $name
      * @throws Exception\InvalidArgumentException
      * @throws Exception\DomainException
-     * @return AbstractStandalone
+     * @return $this
      */
     public function setContainerClass($name)
     {
@@ -272,7 +282,7 @@ abstract class AbstractStandalone extends AbstractHelper implements
     /**
      * Retrieve the container class
      *
-     * @return string
+     * @return class-string<AbstractContainer>
      */
     public function getContainerClass()
     {
@@ -325,7 +335,7 @@ abstract class AbstractStandalone extends AbstractHelper implements
     /**
      * ArrayAccess: offsetExists
      *
-     * @param  string|int $offset
+     * @param TKey $offset
      * @return bool
      */
     #[ReturnTypeWillChange]
@@ -337,8 +347,8 @@ abstract class AbstractStandalone extends AbstractHelper implements
     /**
      * ArrayAccess: offsetGet
      *
-     * @param  string|int $offset
-     * @return mixed
+     * @param TKey $offset
+     * @return TValue
      */
     #[ReturnTypeWillChange]
     public function offsetGet($offset)
@@ -349,8 +359,8 @@ abstract class AbstractStandalone extends AbstractHelper implements
     /**
      * ArrayAccess: offsetSet
      *
-     * @param  string|int $offset
-     * @param  mixed $value
+     * @param TKey $offset
+     * @param TValue $value
      * @return void
      */
     #[ReturnTypeWillChange]
@@ -362,7 +372,7 @@ abstract class AbstractStandalone extends AbstractHelper implements
     /**
      * ArrayAccess: offsetUnset
      *
-     * @param  string|int $offset
+     * @param TKey $offset
      * @return void
      */
     #[ReturnTypeWillChange]

--- a/test/Helper/HeadLinkTest.php
+++ b/test/Helper/HeadLinkTest.php
@@ -25,7 +25,6 @@ class HeadLinkTest extends TestCase
 {
     private HeadLink $helper;
     private EscapeHtmlAttr $attributeEscaper;
-    private string $basePath;
     private View $view;
 
     /**
@@ -35,9 +34,8 @@ class HeadLinkTest extends TestCase
     protected function setUp(): void
     {
         Helper\Doctype::unsetDoctypeRegistry();
-        $this->basePath = __DIR__ . '/_files/modules';
-        $this->view     = new View();
-        $this->helper   = new HeadLink();
+        $this->view   = new View();
+        $this->helper = new HeadLink();
         $this->helper->setView($this->view);
         $this->attributeEscaper = new EscapeHtmlAttr();
     }
@@ -51,24 +49,28 @@ class HeadLinkTest extends TestCase
     public function testPrependThrowsExceptionWithoutArrayArgument(): void
     {
         $this->expectException(Exception\ExceptionInterface::class);
+        /** @psalm-suppress InvalidArgument */
         $this->helper->prepend('foo');
     }
 
     public function testAppendThrowsExceptionWithoutArrayArgument(): void
     {
         $this->expectException(Exception\ExceptionInterface::class);
+        /** @psalm-suppress InvalidArgument */
         $this->helper->append('foo');
     }
 
     public function testSetThrowsExceptionWithoutArrayArgument(): void
     {
         $this->expectException(Exception\ExceptionInterface::class);
+        /** @psalm-suppress InvalidArgument */
         $this->helper->set('foo');
     }
 
     public function testOffsetSetThrowsExceptionWithoutArrayArgument(): void
     {
         $this->expectException(Exception\ExceptionInterface::class);
+        /** @psalm-suppress InvalidArgument */
         $this->helper->offsetSet(1, 'foo');
     }
 

--- a/test/Helper/HeadMetaTest.php
+++ b/test/Helper/HeadMetaTest.php
@@ -103,11 +103,9 @@ class HeadMetaTest extends TestCase
             $this->assertCount($i + 1, $values);
 
             $item = $values[$i];
-            self::assertIsObject($item);
             $this->assertObjectHasProperty('type', $item);
             $this->assertObjectHasProperty('modifiers', $item);
             $this->assertObjectHasProperty('content', $item);
-            self::assertIsString($item->type);
             $this->assertObjectHasProperty($item->type, $item);
             $this->assertEquals('keywords', $item->{$item->type});
             $this->assertEquals($string, $item->content);
@@ -128,7 +126,6 @@ class HeadMetaTest extends TestCase
             $this->assertObjectHasProperty('type', $item);
             $this->assertObjectHasProperty('modifiers', $item);
             $this->assertObjectHasProperty('content', $item);
-            self::assertIsString($item->type);
             $this->assertObjectHasProperty($item->type, $item);
             $this->assertEquals('keywords', $item->{$item->type});
             $this->assertEquals($string, $item->content);
@@ -146,8 +143,7 @@ class HeadMetaTest extends TestCase
         }
         $this->helper->$setAction('keywords', $string);
 
-        $values = $this->helper->getArrayCopy();
-        self::assertIsArray($values);
+        $values = $this->helper->getContainer()->getArrayCopy();
         $this->assertCount(1, $values);
         $item = array_shift($values);
         self::assertIsObject($item);
@@ -155,7 +151,6 @@ class HeadMetaTest extends TestCase
         $this->assertObjectHasProperty('type', $item);
         $this->assertObjectHasProperty('modifiers', $item);
         $this->assertObjectHasProperty('content', $item);
-        self::assertIsString($item->type);
         $this->assertObjectHasProperty($item->type, $item);
         $this->assertEquals('keywords', $item->{$item->type});
         $this->assertEquals($string, $item->content);

--- a/test/Helper/HeadMetaTest.php
+++ b/test/Helper/HeadMetaTest.php
@@ -4,30 +4,30 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Helper;
 
+use Laminas\Escaper\Escaper;
 use Laminas\View\Exception;
 use Laminas\View\Exception\ExceptionInterface as ViewException;
 use Laminas\View\Helper;
 use Laminas\View\Helper\Doctype;
-use Laminas\View\Helper\EscapeHtmlAttr;
 use Laminas\View\Helper\HeadMeta;
 use Laminas\View\Renderer\PhpRenderer as View;
 use PHPUnit\Framework\TestCase;
 
 use function array_shift;
-use function count;
+use function restore_error_handler;
 use function set_error_handler;
 use function sprintf;
 use function str_replace;
 use function substr_count;
 use function ucwords;
 
+use const E_USER_WARNING;
 use const PHP_EOL;
 
 class HeadMetaTest extends TestCase
 {
     private HeadMeta $helper;
-    private EscapeHtmlAttr $attributeEscaper;
-    private ?string $error = null;
+    private Escaper $escaper;
     private View $view;
 
     /**
@@ -42,12 +42,7 @@ class HeadMetaTest extends TestCase
         $doctype->__invoke('XHTML1_STRICT');
         $this->helper = new HeadMeta();
         $this->helper->setView($this->view);
-        $this->attributeEscaper = new EscapeHtmlAttr();
-    }
-
-    public function handleErrors(int $errno, string $errstr): void
-    {
-        $this->error = $errstr;
+        $this->escaper = new Escaper();
     }
 
     public function testHeadMetaReturnsObjectInstance(): void
@@ -203,8 +198,8 @@ class HeadMetaTest extends TestCase
     public function testCanBuildMetaTagsWithAttributes(): void
     {
         $this->helper->setName('keywords', 'foo bar', ['lang' => 'us_en', 'scheme' => 'foo', 'bogus' => 'unused']);
-        $value = $this->helper->getValue();
-
+        $value = $this->helper->getContainer()->getValue();
+        self::assertIsObject($value);
         $this->assertObjectHasProperty('modifiers', $value);
         $modifiers = $value->modifiers;
         $this->assertArrayHasKey('lang', $modifiers);
@@ -229,31 +224,45 @@ class HeadMetaTest extends TestCase
         $metas = substr_count($string, 'http-equiv="');
         $this->assertEquals(1, $metas);
 
-        $attributeEscaper = $this->attributeEscaper;
-
         $this->assertStringContainsString('http-equiv="screen" content="projection"', $string);
-        $this->assertStringContainsString('name="keywords" content="' . $attributeEscaper('foo bar') . '"', $string);
+        $this->assertStringContainsString(
+            'name="keywords" content="' . $this->escaper->escapeHtmlAttr('foo bar') . '"',
+            $string,
+        );
         $this->assertStringContainsString('lang="us_en"', $string);
         $this->assertStringContainsString('scheme="foo"', $string);
         $this->assertStringNotContainsString('bogus', $string);
         $this->assertStringNotContainsString('unused', $string);
-        $this->assertStringContainsString('name="title" content="' . $attributeEscaper('boo bah') . '"', $string);
+        $this->assertStringContainsString(
+            'name="title" content="' . $this->escaper->escapeHtmlAttr('boo bah') . '"',
+            $string,
+        );
     }
 
     public function testToStringWhenInvalidKeyProvidedShouldConvertThrownException(): void
     {
         $this->helper->__invoke('some-content', 'tag value', 'not allowed key');
-        set_error_handler([$this, 'handleErrors']);
-        $string = @$this->helper->toString();
-        $this->assertEquals('', $string);
-        $this->assertIsString($this->error);
+        $error = null;
+        set_error_handler(function (int $code, string $message) use (&$error): bool {
+            self::assertSame(E_USER_WARNING, $code);
+            $error = $message;
+
+            return true;
+        }, E_USER_WARNING);
+        $string = $this->helper->toString();
+        self::assertEquals('', $string);
+        self::assertEquals(
+            'Invalid type "not allowed key" provided for meta',
+            $error,
+        );
+        restore_error_handler();
     }
 
     public function testHeadMetaHelperCreatesItemEntry(): void
     {
         $this->helper->__invoke('foo', 'keywords');
-        $values = $this->helper->getArrayCopy();
-        $this->assertEquals(1, count($values));
+        $values = $this->helper->getContainer()->getArrayCopy();
+        $this->assertCount(1, $values);
         $item = array_shift($values);
         $this->assertEquals('foo', $item->content);
         $this->assertEquals('name', $item->type);
@@ -263,8 +272,8 @@ class HeadMetaTest extends TestCase
     public function testOverloadingOffsetInsertsAtOffset(): void
     {
         $this->helper->offsetSetName(100, 'keywords', 'foo');
-        $values = $this->helper->getArrayCopy();
-        $this->assertEquals(1, count($values));
+        $values = $this->helper->getContainer()->getArrayCopy();
+        $this->assertCount(1, $values);
         $this->assertArrayHasKey(100, $values);
         $item = $values[100];
         $this->assertEquals('foo', $item->content);
@@ -290,36 +299,32 @@ class HeadMetaTest extends TestCase
 
         $test = $this->helper->toString();
 
-        $attributeEscaper = $this->attributeEscaper;
-
         $this->assertStringNotContainsString('/>', $test);
-        $this->assertStringContainsString($attributeEscaper('some content'), $test);
+        $this->assertStringContainsString($this->escaper->escapeHtmlAttr('some content'), $test);
         $this->assertStringContainsString('foo', $test);
     }
 
     public function testSetNameDoesntClobber(): void
     {
-        $view = new View();
-        $view->plugin(HeadMeta::class)->setName('keywords', 'foo');
-        $view->plugin(HeadMeta::class)->appendHttpEquiv('pragma', 'bar');
-        $view->plugin(HeadMeta::class)->appendHttpEquiv('Cache-control', 'baz');
-        $view->plugin(HeadMeta::class)->setName('keywords', 'bat');
+        $this->helper->setName('keywords', 'foo');
+        $this->helper->appendHttpEquiv('pragma', 'bar');
+        $this->helper->appendHttpEquiv('Cache-control', 'baz');
+        $this->helper->setName('keywords', 'bat');
 
         $this->assertEquals(
             '<meta http-equiv="pragma" content="bar" />' . PHP_EOL . '<meta http-equiv="Cache-control" content="baz" />'
             . PHP_EOL . '<meta name="keywords" content="bat" />',
-            $view->plugin(HeadMeta::class)->toString()
+            $this->helper->toString()
         );
     }
 
     public function testSetNameDoesntClobberPart2(): void
     {
-        $view = new View();
-        $view->plugin(HeadMeta::class)->setName('keywords', 'foo');
-        $view->plugin(HeadMeta::class)->setName('description', 'foo');
-        $view->plugin(HeadMeta::class)->appendHttpEquiv('pragma', 'baz');
-        $view->plugin(HeadMeta::class)->appendHttpEquiv('Cache-control', 'baz');
-        $view->plugin(HeadMeta::class)->setName('keywords', 'bar');
+        $this->helper->setName('keywords', 'foo');
+        $this->helper->setName('description', 'foo');
+        $this->helper->appendHttpEquiv('pragma', 'baz');
+        $this->helper->appendHttpEquiv('Cache-control', 'baz');
+        $this->helper->setName('keywords', 'bar');
 
         $expected = sprintf(
             '<meta name="description" content="foo" />%1$s'
@@ -329,14 +334,13 @@ class HeadMetaTest extends TestCase
             PHP_EOL
         );
 
-        $this->assertEquals($expected, $view->plugin(HeadMeta::class)->toString());
+        $this->assertEquals($expected, $this->helper->toString());
     }
 
     public function testPlacesMetaTagsInProperOrder(): void
     {
-        $view = new View();
-        $view->plugin(HeadMeta::class)->setName('keywords', 'foo');
-        $view->plugin(HeadMeta::class)->__invoke(
+        $this->helper->setName('keywords', 'foo');
+        $this->helper->__invoke(
             'some content',
             'bar',
             'name',
@@ -344,15 +348,13 @@ class HeadMetaTest extends TestCase
             Helper\Placeholder\Container\AbstractContainer::PREPEND
         );
 
-        $attributeEscaper = $this->attributeEscaper;
-
         $expected = sprintf(
             '<meta name="bar" content="%s" />%s'
             . '<meta name="keywords" content="foo" />',
-            $attributeEscaper('some content'),
+            $this->escaper->escapeHtmlAttr('some content'),
             PHP_EOL
         );
-        $this->assertEquals($expected, $view->plugin(HeadMeta::class)->toString());
+        $this->assertEquals($expected, $this->helper->toString());
     }
 
     public function testContainerMaintainsCorrectOrderOfItems(): void
@@ -381,7 +383,7 @@ class HeadMetaTest extends TestCase
         $view->plugin(Doctype::class)->__invoke('HTML4_STRICT');
 
         $this->expectException(Exception\ExceptionInterface::class);
-        $view->plugin(HeadMeta::class)->setCharset('utf-8');
+        $this->helper->setCharset('utf-8');
     }
 
     public function testCharset(): void
@@ -389,17 +391,17 @@ class HeadMetaTest extends TestCase
         $view = new View();
         $view->plugin(Doctype::class)->__invoke('HTML5');
 
-        $view->plugin(HeadMeta::class)->setCharset('utf-8');
+        $this->helper->setCharset('utf-8');
         $this->assertEquals(
             '<meta charset="utf-8">',
-            $view->plugin(HeadMeta::class)->toString()
+            $this->helper->toString()
         );
 
         $view->plugin(Doctype::class)->__invoke('XHTML5');
 
         $this->assertEquals(
             '<meta charset="utf-8"/>',
-            $view->plugin(HeadMeta::class)->toString()
+            $this->helper->toString()
         );
     }
 
@@ -408,18 +410,18 @@ class HeadMetaTest extends TestCase
         $view = new View();
         $view->plugin(Doctype::class)->__invoke('HTML5');
 
-        $view->plugin(HeadMeta::class)
+        $this->helper
             ->setProperty('description', 'foobar')
             ->setCharset('utf-8');
 
         $this->assertEquals(
             '<meta charset="utf-8">' . PHP_EOL
             . '<meta property="description" content="foobar">',
-            $view->plugin(HeadMeta::class)->toString()
+            $this->helper->toString()
         );
     }
 
-    public function testCarsetWithXhtmlDoctypeGotException(): void
+    public function testCharsetWithXhtmlDoctypeGotException(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('XHTML* doctype has no attribute charset; please use appendHttpEquiv()');
@@ -427,7 +429,7 @@ class HeadMetaTest extends TestCase
         $view = new View();
         $view->plugin(Doctype::class)->__invoke('XHTML1_RDFA');
 
-        $view->plugin(HeadMeta::class)
+        $this->helper
              ->setCharset('utf-8');
     }
 
@@ -436,9 +438,7 @@ class HeadMetaTest extends TestCase
         $this->view->doctype('XHTML1_RDFA');
         $this->helper->__invoke('foo', 'og:title', 'property');
 
-        $attributeEscaper = $this->attributeEscaper;
-
-        $expected = sprintf('<meta property="%s" content="foo" />', $attributeEscaper('og:title'));
+        $expected = sprintf('<meta property="%s" content="foo" />', $this->escaper->escapeHtmlAttr('og:title'));
         $this->assertEquals($expected, $this->helper->toString());
     }
 
@@ -484,9 +484,10 @@ class HeadMetaTest extends TestCase
         $this->view->doctype('HTML5');
         $this->helper->__invoke('HeadMeta with Microdata', 'description', 'itemprop');
 
-        $attributeEscaper = $this->attributeEscaper;
-
-        $expected = sprintf('<meta itemprop="description" content="%s">', $attributeEscaper('HeadMeta with Microdata'));
+        $expected = sprintf(
+            '<meta itemprop="description" content="%s">',
+            $this->escaper->escapeHtmlAttr('HeadMeta with Microdata'),
+        );
         $this->assertEquals($expected, $this->helper->toString());
     }
 

--- a/test/Helper/HeadScriptTest.php
+++ b/test/Helper/HeadScriptTest.php
@@ -6,9 +6,9 @@ namespace LaminasTest\View\Helper;
 
 use DOMDocument;
 use Generator;
+use Laminas\Escaper\Escaper;
 use Laminas\View;
 use Laminas\View\Helper\Doctype;
-use Laminas\View\Helper\EscapeHtmlAttr;
 use Laminas\View\Helper\HeadScript;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -25,20 +25,13 @@ use const PHP_EOL;
 
 class HeadScriptTest extends TestCase
 {
-    /** @var HeadScript */
-    public $helper;
+    private HeadScript $helper;
+    private Escaper $escaper;
 
-    /** @var EscapeHtmlAttr */
-    public $attributeEscaper;
-
-    /**
-     * Sets up the fixture, for example, open a network connection.
-     * This method is called before a test is executed.
-     */
     protected function setUp(): void
     {
-        $this->helper           = new HeadScript();
-        $this->attributeEscaper = new EscapeHtmlAttr();
+        $this->helper  = new HeadScript();
+        $this->escaper = new Escaper();
     }
 
     public function testHeadScriptReturnsObjectInstance(): void
@@ -417,19 +410,17 @@ document.write(bar.strlen());');
 
         $test = $this->helper->toString();
 
-        $attributeEscaper = $this->attributeEscaper;
-
         $expected = sprintf(
             '<script type="%2$s" src="%3$s"></script>%1$s'
             . '<script type="%2$s" src="%4$s"></script>%1$s'
             . '<script type="%2$s" src="%5$s"></script>%1$s'
             . '<script type="%2$s" src="%6$s"></script>',
             PHP_EOL,
-            $attributeEscaper('text/javascript'),
-            $attributeEscaper('test1.js'),
-            $attributeEscaper('test4.js'),
-            $attributeEscaper('test3.js'),
-            $attributeEscaper('test2.js')
+            $this->escaper->escapeHtmlAttr('text/javascript'),
+            $this->escaper->escapeHtmlAttr('test1.js'),
+            $this->escaper->escapeHtmlAttr('test4.js'),
+            $this->escaper->escapeHtmlAttr('test3.js'),
+            $this->escaper->escapeHtmlAttr('test2.js')
         );
 
         $this->assertEquals($expected, $test);

--- a/test/Helper/HeadStyleTest.php
+++ b/test/Helper/HeadStyleTest.php
@@ -34,6 +34,7 @@ class HeadStyleTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid value passed to append');
+        /** @psalm-suppress InvalidArgument */
         $this->helper->append('foo');
     }
 
@@ -41,6 +42,7 @@ class HeadStyleTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid value passed to prepend');
+        /** @psalm-suppress InvalidArgument */
         $this->helper->prepend('foo');
     }
 
@@ -48,6 +50,7 @@ class HeadStyleTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid value passed to set');
+        /** @psalm-suppress InvalidArgument */
         $this->helper->set('foo');
     }
 
@@ -55,6 +58,7 @@ class HeadStyleTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid value passed to offsetSet');
+        /** @psalm-suppress InvalidArgument */
         $this->helper->offsetSet(1, 'foo');
     }
 
@@ -190,12 +194,6 @@ class HeadStyleTest extends TestCase
                      ->__invoke($style3, 'APPEND');
         self::assertCount(3, $this->helper);
         $values = $this->helper->getContainer()->getArrayCopy();
-        self::assertIsObject($values[0]);
-        self::assertIsObject($values[1]);
-        self::assertIsObject($values[2]);
-        self::assertIsString($values[0]->content);
-        self::assertIsString($values[1]->content);
-        self::assertIsString($values[2]->content);
         self::assertStringContainsString($values[0]->content, $style2);
         self::assertStringContainsString($values[1]->content, $style1);
         self::assertStringContainsString($values[2]->content, $style3);
@@ -235,7 +233,6 @@ class HeadStyleTest extends TestCase
         $item = array_shift($values);
         self::assertIsObject($item);
         self::assertObjectHasProperty('content', $item);
-        self::assertIsString($item->content);
         self::assertStringContainsString('foobar', $item->content);
     }
 
@@ -246,9 +243,7 @@ class HeadStyleTest extends TestCase
         self::assertCount(1, $values);
         self::assertTrue(isset($values[100]));
         $item = $values[100];
-        self::assertIsObject($item);
         self::assertObjectHasProperty('content', $item);
-        self::assertIsString($item->content);
         self::assertStringContainsString('foobar', $item->content);
     }
 

--- a/test/Helper/HeadTitleTest.php
+++ b/test/Helper/HeadTitleTest.php
@@ -5,64 +5,55 @@ declare(strict_types=1);
 namespace LaminasTest\View\Helper;
 
 use Laminas\I18n\Translator\Translator;
-use Laminas\View\Helper;
+use Laminas\View\Helper\HeadTitle;
 use PHPUnit\Framework\TestCase;
 
 class HeadTitleTest extends TestCase
 {
-    /** @var Helper\HeadTitle */
+    /** @var HeadTitle */
     public $helper;
 
-    /** @var string */
-    public $basePath;
-
-    /**
-     * Sets up the fixture, for example, open a network connection.
-     * This method is called before a test is executed.
-     */
     protected function setUp(): void
     {
-        $this->basePath = __DIR__ . '/_files/modules';
-        $this->helper   = new Helper\HeadTitle();
+        $this->helper = new HeadTitle();
     }
 
-    public function testHeadTitleReturnsObjectInstance(): void
+    public function testInvokeWithNoArgumentsReturnsSelf(): void
     {
-        $placeholder = $this->helper->__invoke();
-        $this->assertInstanceOf(Helper\HeadTitle::class, $placeholder);
+        self::assertSame($this->helper, $this->helper->__invoke());
     }
 
     public function testCanSetTitleViaHeadTitle(): void
     {
         $placeholder = $this->helper->__invoke('Foo Bar', 'SET');
-        $this->assertEquals('Foo Bar', $placeholder->renderTitle());
+        self::assertEquals('Foo Bar', $placeholder->renderTitle());
     }
 
     public function testToStringWrapsToTitleTag(): void
     {
         $placeholder = $this->helper->__invoke('Foo Bar', 'SET');
-        $this->assertEquals('<title>Foo Bar</title>', $placeholder->toString());
+        self::assertEquals('<title>Foo Bar</title>', $placeholder->toString());
     }
 
     public function testCanAppendTitleViaHeadTitle(): void
     {
         $this->helper->__invoke('Foo');
-        $placeholder = $this->helper->__invoke('Bar');
-        $this->assertEquals('FooBar', $placeholder->renderTitle());
+        $this->helper->__invoke('Bar');
+        self::assertEquals('FooBar', $this->helper->renderTitle());
     }
 
     public function testCanPrependTitleViaHeadTitle(): void
     {
         $this->helper->__invoke('Foo');
         $placeholder = $this->helper->__invoke('Bar', 'PREPEND');
-        $this->assertEquals('BarFoo', $placeholder->renderTitle());
+        self::assertEquals('BarFoo', $placeholder->renderTitle());
     }
 
     public function testReturnedPlaceholderRenderTitleContainsFullTitleElement(): void
     {
         $this->helper->__invoke('Foo');
-        $placeholder = $this->helper->__invoke('Bar', 'APPEND')->setSeparator(' :: ');
-        $this->assertEquals('Foo :: Bar', $placeholder->renderTitle());
+        $this->helper->__invoke('Bar', 'APPEND')->setSeparator(' :: ');
+        self::assertEquals('Foo :: Bar', $this->helper->renderTitle());
     }
 
     public function testRenderTitleEscapesEntries(): void
@@ -82,7 +73,7 @@ class HeadTitleTest extends TestCase
         $this->assertStringNotContainsString('<br />', $string);
         $this->assertStringContainsString('Foo', $string);
         $this->assertStringContainsString('Bar', $string);
-        $this->assertStringContainsString('br /', $string);
+        $this->assertStringContainsString('&lt;br /&gt;', $string);
     }
 
     public function testIndentationIsHonored(): void
@@ -106,7 +97,7 @@ class HeadTitleTest extends TestCase
         $this->assertEquals('Some Title &copyright;', $this->helper->renderTitle());
     }
 
-    public function testLaminas918(): void
+    public function testThatAPrefixAndPostfixCanBeApplied(): void
     {
         $this->helper->__invoke('Some Title');
         $this->helper->setPrefix('Prefix: ');
@@ -115,7 +106,7 @@ class HeadTitleTest extends TestCase
         $this->assertEquals('Prefix: Some Title :Postfix', $this->helper->renderTitle());
     }
 
-    public function testLaminas577(): void
+    public function testThatPrefixAndPostfixAreEscapedProperly(): void
     {
         $this->helper->setAutoEscape(true);
         $this->helper->__invoke('Some Title');
@@ -171,7 +162,17 @@ class HeadTitleTest extends TestCase
 
     public function testReturnTypeDefaultAttachOrder(): void
     {
-        $this->assertInstanceOf(Helper\HeadTitle::class, $this->helper->setDefaultAttachOrder('PREPEND'));
+        $this->assertInstanceOf(HeadTitle::class, $this->helper->setDefaultAttachOrder('PREPEND'));
         $this->assertEquals('PREPEND', $this->helper->getDefaultAttachOrder());
+    }
+
+    public function testCommonMagicMethods(): void
+    {
+        $this->helper->set('a little');
+        $this->helper->prepend('Mary had');
+        $this->helper->append('lamb');
+        $this->helper->setSeparator(' ');
+
+        self::assertSame('<title>Mary had a little lamb</title>', (string) $this->helper);
     }
 }

--- a/test/Helper/Placeholder/StandaloneContainerTest.php
+++ b/test/Helper/Placeholder/StandaloneContainerTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\View\Helper\Placeholder;
 use Laminas\View\Exception\DomainException;
 use Laminas\View\Exception\InvalidArgumentException;
 use Laminas\View\Helper\Placeholder\Container;
+use Laminas\View\Helper\Placeholder\Container\AbstractContainer;
 use Laminas\View\Renderer\PhpRenderer as View;
 use LaminasTest\View\Helper\TestAsset\Bar;
 use LaminasTest\View\Helper\TestAsset\Foo;
@@ -14,8 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class StandaloneContainerTest extends TestCase
 {
-    /** @var Foo */
-    protected $helper;
+    private Foo $helper;
 
     /**
      * Sets up the fixture, for example, open a network connection.
@@ -37,14 +37,14 @@ class StandaloneContainerTest extends TestCase
     public function testGetContainer(): void
     {
         $container = $this->helper->getContainer();
-        $this->assertInstanceOf(Container::class, $container);
+        $this->assertInstanceOf(AbstractContainer::class, $container);
     }
 
     public function testGetContainerCreatesNewContainer(): void
     {
         $this->helper->deleteContainer();
         $container = $this->helper->getContainer();
-        $this->assertInstanceOf(Container::class, $container);
+        $this->assertInstanceOf(AbstractContainer::class, $container);
     }
 
     public function testDeleteContainer(): void
@@ -57,12 +57,14 @@ class StandaloneContainerTest extends TestCase
     public function testSetContainerClassThrowsDomainException(): void
     {
         $this->expectException(DomainException::class);
-        $this->helper->setContainerClass('bat');
+        /** @psalm-suppress UndefinedClass, ArgumentTypeCoercion */
+        $this->helper->setContainerClass('not-a-known-class');
     }
 
     public function testSetContainerClassThrowsInvalidArgumentException(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        /** @psalm-suppress InvalidArgument */
         $this->helper->setContainerClass(static::class);
     }
 
@@ -82,11 +84,11 @@ class StandaloneContainerTest extends TestCase
     public function testContainerDoesNotPersistBetweenInstances(): void
     {
         $foo1 = new Foo();
-        $foo1->append('Foo');
+        $foo1->getContainer()->append('Foo');
         $foo1->setSeparator(' - ');
 
         $foo2 = new Foo();
-        $foo2->append('Bar');
+        $foo2->getContainer()->append('Bar');
 
         $test = $foo2->toString();
         $this->assertStringNotContainsString('Foo', $test);

--- a/test/Helper/TestAsset/Bar.php
+++ b/test/Helper/TestAsset/Bar.php
@@ -6,6 +6,7 @@ namespace LaminasTest\View\Helper\TestAsset;
 
 use Laminas\View\Helper\Placeholder\Container\AbstractContainer;
 
+/** @extends AbstractContainer<array-key, mixed> */
 class Bar extends AbstractContainer
 {
 }

--- a/test/Helper/TestAsset/Foo.php
+++ b/test/Helper/TestAsset/Foo.php
@@ -6,6 +6,7 @@ namespace LaminasTest\View\Helper\TestAsset;
 
 use Laminas\View\Helper\Placeholder\Container\AbstractStandalone;
 
+/** @extends AbstractStandalone<array-key, mixed> */
 class Foo extends AbstractStandalone
 {
 }

--- a/test/Helper/TestAsset/MockContainer.php
+++ b/test/Helper/TestAsset/MockContainer.php
@@ -5,7 +5,15 @@ declare(strict_types=1);
 namespace LaminasTest\View\Helper\TestAsset;
 
 use Laminas\View\Helper\Placeholder\Container\AbstractContainer;
+use LaminasTest\View\Helper\Placeholder\RegistryTest;
 
+/**
+ * @deprecated Should be removed in 3.0 when RegistryTest is removed
+ *
+ * @see RegistryTest
+ *
+ * @psalm-suppress MissingTemplateParam
+ */
 class MockContainer extends AbstractContainer
 {
     /** @var array */

--- a/test/Helper/TestAsset/NonStringableObject.php
+++ b/test/Helper/TestAsset/NonStringableObject.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\View\Helper\TestAsset;
+
+final class NonStringableObject
+{
+}


### PR DESCRIPTION
Adds templates to the container and abstract placeholder view helper classes and documents the types used by each implementing view helper.

A lot of incorrect docblocks have been fixed, additional magic methods documented and a decent reduction in the baseline.

<strike>Several implementations store values as plain objects and were in places (parameter) type hinting on `stdClass`. All references to `stdClass` have been replaced with `object` and `instanceof` conditions replaced with `is_object`. There's no BC break because `object` is more general than `stdClass`. The main purpose here is that it's not possible to express object shapes with `stdClass` which is central to the significant improvements in type inference.</strike>

Methods that expect `stdClass` have been annotated to accept `object{foo:string}` which results in a lot fewer psalm issues and better inference than the handful of `ArgumentTypeCoercion` and `MismatchingDocblockParamType` added to the baseline.

Various public and protected methods have been marked `@internal` so that they can be made private in the next major, and there are a handful of deprecations for unused, un-documented and un-tested public methods.
