### PR TITLE
Add return type hint to ViewModel::getIterator()

### DIFF
--- a/src/Model/ViewModel.php
+++ b/src/Model/ViewModel.php
@@ -32,6 +32,7 @@ class ViewModel implements ModelInterface, ClearableModelInterface, RetrievableC
      * Child models
      *
      * @var array
+     * @psalm-type list<ModelInterface>
      */
     protected $children = [];
 
@@ -508,7 +509,7 @@ class ViewModel implements ModelInterface, ClearableModelInterface, RetrievableC
     /**
      * Get iterator of children
      *
-     * @return ArrayIterator
+     * @return Traversable<int, ModelInterface>
      */
     #[ReturnTypeWillChange]
     public function getIterator()


### PR DESCRIPTION
This is to satisfy static code analytic tools like PHPStan and Psalm.

Resolves #73 and also helps with #56