### PR TITLE
added missing allowed types to constructor (#239)

### DIFF
--- a/src/Model/ViewModel.php
+++ b/src/Model/ViewModel.php
@@ -76,7 +76,7 @@ class ViewModel implements ModelInterface, ClearableModelInterface, RetrievableC
     /**
      * Constructor
      *
-     * @param  null|array<string, mixed>|Traversable<string, mixed>|ArrayAccess<string, mixed> $variables
+     * @param  null|array<string, mixed>|Traversable<string, mixed>|ArrayAccess<string, mixed>|array<int, mixed>|Traversable<int, mixed>|ArrayAccess<int, mixed> $variables
      * @param  null|array<string, mixed>|Traversable<string, mixed> $options
      */
     public function __construct($variables = null, $options = null)

--- a/src/Model/ViewModel.php
+++ b/src/Model/ViewModel.php
@@ -76,8 +76,9 @@ class ViewModel implements ModelInterface, ClearableModelInterface, RetrievableC
     /**
      * Constructor
      *
-     * @param  null|array<string, mixed>|Traversable<string, mixed>|ArrayAccess<string, mixed>|array<int, mixed>|Traversable<int, mixed>|ArrayAccess<int, mixed> $variables
-     * @param  null|array<string, mixed>|Traversable<string, mixed> $options
+     * @param null $variables null|array<string, mixed>|Traversable<string, mixed>|ArrayAccess<string, mixed>|
+     *                        array<int, mixed>|Traversable<int, mixed>|ArrayAccess<int, mixed> $variables
+     * @param null $options null|array<string, mixed>|Traversable<string, mixed> $options
      */
     public function __construct($variables = null, $options = null)
     {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This bugfix addresses the issue #239 by allowing lists in the constructor of `ViewModel`.
