### PR TITLE
Fix layout() return type

### DIFF
--- a/src/Helper/Layout.php
+++ b/src/Helper/Layout.php
@@ -35,7 +35,7 @@ class Layout extends AbstractHelper
      * Otherwise, attempts to set the template for that view model.
      *
      * @param null|string $template
-     * @return Model|null|self
+     * @return Model|self
      */
     public function __invoke($template = null)
     {

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -45,7 +45,7 @@ use function sprintf;
  * mark them as part of the internal implementation, and thus prevent conflict
  * with variables injected into the renderer.
  *
- * Convenience methods for build in helpers (@see __call):
+ * Convenience methods for built-in helpers (@see __call):
  *
  * @method string asset($asset)
  * @method string|null basePath($file = null)
@@ -73,7 +73,7 @@ use function sprintf;
  * @method mixed|null identity()
  * @method \Laminas\View\Helper\InlineScript inlineScript($mode = \Laminas\View\Helper\HeadScript::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
  * @method string|void json($data, array $jsonOptions = array())
- * @method \Laminas\View\Helper\Layout layout($template = null)
+ * @method Model|\Laminas\View\Helper\Layout layout($template = null)
  * @method \Laminas\View\Helper\Navigation navigation($container = null)
  * @method string paginationControl(\Laminas\Paginator\Paginator $paginator = null, $scrollingStyle = null, $partial = null, $params = null)
  * @method string|\Laminas\View\Helper\Partial partial($name = null, $values = null)


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Bring `PhpRenderer` `@method` for `layout()` in sync with `Layout::__invoke` and remove `null` from that method's return type union (`@return`). Result reflects reality and thus helps static analysis tools to reduce detection of false negatives.

See #247.