### PR TITLE
Deprecate the URL Helper

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2747,7 +2747,13 @@
   </file>
   <file src="test/Helper/UrlTest.php">
     <DeprecatedClass>
+      <code><![CDATA[UrlHelper]]></code>
       <code><![CDATA[Wildcard::class]]></code>
+      <code><![CDATA[new UrlHelper()]]></code>
+      <code><![CDATA[new UrlHelper()]]></code>
+      <code><![CDATA[new UrlHelper()]]></code>
+      <code><![CDATA[new UrlHelper()]]></code>
+      <code><![CDATA[new UrlHelper()]]></code>
     </DeprecatedClass>
     <InvalidArgument>
       <code><![CDATA[$it]]></code>
@@ -2770,6 +2776,8 @@
   </file>
   <file src="test/HelperPluginManagerTest.php">
     <DeprecatedClass>
+      <code><![CDATA[Url::class]]></code>
+      <code><![CDATA[Url::class]]></code>
       <code><![CDATA[new Config(
             [
                 'factories' => [

--- a/src/Helper/Url.php
+++ b/src/Helper/Url.php
@@ -20,6 +20,9 @@ use function sprintf;
 
 /**
  * Helper for making easy links and getting urls that depend on the routes and router.
+ *
+ * @deprecated The URL helper will be removed in 3.0 and relocated to the `laminas-mvc-view` package because it is an
+ *             MVC specific implementation.
  */
 class Url extends AbstractHelper
 {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

The URL helper is MVC specific and as such it will be provided in future by the `laminas-mvc-view` package.

The URL view helper necessitates the dependencies:

- laminas-mvc
- laminas-router
- laminas-http
- maybe others…

Extracting it will allow removal of these dependencies which all prevent independent evolution of this lib…
