### PR TITLE
`HeadTitle` and translation related deprecations

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -136,6 +136,9 @@
     </MixedAssignment>
   </file>
   <file src="src/Helper/FlashMessenger.php">
+    <DeprecatedTrait>
+      <code><![CDATA[TranslatorAwareTrait]]></code>
+    </DeprecatedTrait>
     <DocblockTypeContradiction>
       <code><![CDATA[null === $this->pluginFlashMessenger]]></code>
     </DocblockTypeContradiction>
@@ -416,6 +419,18 @@
       <code><![CDATA[$indent]]></code>
     </UnusedParam>
   </file>
+  <file src="src/Helper/HeadTitle.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getDefaultAttachOrder]]></code>
+    </DeprecatedMethod>
+    <DeprecatedProperty>
+      <code><![CDATA[$this->defaultAttachOrder]]></code>
+      <code><![CDATA[$this->defaultAttachOrder]]></code>
+    </DeprecatedProperty>
+    <DeprecatedTrait>
+      <code><![CDATA[TranslatorAwareTrait]]></code>
+    </DeprecatedTrait>
+  </file>
   <file src="src/Helper/HelperInterface.php">
     <PossiblyUnusedReturnValue>
       <code><![CDATA[HelperInterface]]></code>
@@ -586,6 +601,9 @@
     <DeprecatedInterface>
       <code><![CDATA[AbstractHelper]]></code>
     </DeprecatedInterface>
+    <DeprecatedTrait>
+      <code><![CDATA[TranslatorAwareTrait]]></code>
+    </DeprecatedTrait>
     <DocblockTypeContradiction>
       <code><![CDATA[! is_int($this->minDepth)]]></code>
       <code><![CDATA[! is_string($message)]]></code>

--- a/src/Helper/HeadTitle.php
+++ b/src/Helper/HeadTitle.php
@@ -30,6 +30,8 @@ class HeadTitle extends AbstractStandalone
     /**
      * Default title rendering order (i.e. order in which each title attached)
      *
+     * @deprecated Since 2.38.0 This property will be removed in 3.0 without replacement
+     *
      * @var string|null
      */
     protected $defaultAttachOrder;
@@ -116,6 +118,9 @@ class HeadTitle extends AbstractStandalone
     /**
      * Set a default order to add titles
      *
+     * @deprecated Since 2.38.0 This method will be removed in 3.0. You should instead use the `append` or `prepend`
+     *             methods
+     *
      * @param  string $setType
      * @throws Exception\DomainException
      * @return $this
@@ -140,6 +145,8 @@ class HeadTitle extends AbstractStandalone
 
     /**
      * Get the default attach order, if any.
+     *
+     * @deprecated Since 2.38.0 This method will be removed in 3.0 without replacement
      *
      * @return string|null
      */

--- a/src/Helper/TranslatorAwareTrait.php
+++ b/src/Helper/TranslatorAwareTrait.php
@@ -11,6 +11,10 @@ use Laminas\I18n\Translator\TranslatorInterface as Translator;
  *
  * This can be used by helpers that need to implement the interface,
  * whether via explicit implementation or duck typing.
+ *
+ * @deprecated Since 2.38.0 This trait will be removed in Version 3.0. Instead of using initializers and setter
+ *             injection, you should inject the translator into the constructor of your view helper so it cannot be
+ *             constructed in an invalid state.
  */
 trait TranslatorAwareTrait
 {

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -404,6 +404,9 @@ class HelperPluginManager extends AbstractPluginManager
     /**
      * Inject a helper instance with the registered translator
      *
+     * @deprecated Since 2.38.0 This method will be removed in 3.0 without replacement. If your view helper requires a
+     *             translator, you should instead create a factory and inject the translator into the helper constructor
+     *
      * @param ContainerInterface|HelperInterface $first helper instance
      *     under laminas-servicemanager v2, ContainerInterface under v3.
      * @param ContainerInterface|HelperInterface $second


### PR DESCRIPTION
Covers deprecations for `HeadTitle`, the translator aware trait and removal of the translator initialiser in the plugin manager

See #268 