### PR TITLE
Refactor Template Resolvers

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -65,6 +65,37 @@
       <code><![CDATA[getName]]></code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="src/Helper/DeclareVars.php">
+    <MissingConstructor>
+      <code><![CDATA[$view]]></code>
+    </MissingConstructor>
+    <MixedArgument>
+      <code><![CDATA[$key]]></code>
+      <code><![CDATA[$value]]></code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$name]]></code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment>
+      <code><![CDATA[$key]]></code>
+      <code><![CDATA[$value]]></code>
+      <code><![CDATA[$vars]]></code>
+    </MixedAssignment>
+    <MixedPropertyFetch>
+      <code><![CDATA[$vars->$key]]></code>
+    </MixedPropertyFetch>
+    <NonInvariantDocblockPropertyType>
+      <code><![CDATA[$view]]></code>
+    </NonInvariantDocblockPropertyType>
+    <PossiblyNullReference>
+      <code><![CDATA[vars]]></code>
+      <code><![CDATA[vars]]></code>
+    </PossiblyNullReference>
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[vars]]></code>
+      <code><![CDATA[vars]]></code>
+    </UndefinedInterfaceMethod>
+  </file>
   <file src="src/Helper/Doctype.php">
     <DocblockTypeContradiction>
       <code><![CDATA[null === static::$registeredDoctypes]]></code>
@@ -852,16 +883,11 @@
     </DocblockTypeContradiction>
     <FalsableReturnStatement>
       <code><![CDATA[$this->__content]]></code>
-      <code><![CDATA[$this->__templateResolver->resolve($name, $this)]]></code>
     </FalsableReturnStatement>
     <ImplementedParamTypeMismatch>
       <code><![CDATA[$values]]></code>
     </ImplementedParamTypeMismatch>
-    <InvalidNullableReturnType>
-      <code><![CDATA[string|Resolver]]></code>
-    </InvalidNullableReturnType>
     <MixedArgument>
-      <code><![CDATA[$this->__template]]></code>
       <code><![CDATA[$this->__template]]></code>
       <code><![CDATA[array_pop($this->__varsCache)]]></code>
     </MixedArgument>
@@ -881,9 +907,6 @@
       <code><![CDATA[$this->__vars[$key]]]></code>
       <code><![CDATA[$this->getHelperPluginManager()->get($name, $options)]]></code>
     </MixedReturnStatement>
-    <NullableReturnStatement>
-      <code><![CDATA[$this->__templateResolver]]></code>
-    </NullableReturnStatement>
     <PossibleRawObjectIteration>
       <code><![CDATA[$variables]]></code>
     </PossibleRawObjectIteration>
@@ -901,7 +924,6 @@
     </PossiblyNullArrayAccess>
     <PossiblyNullReference>
       <code><![CDATA[$this->__vars]]></code>
-      <code><![CDATA[resolve]]></code>
     </PossiblyNullReference>
     <PossiblyUnusedMethod>
       <code><![CDATA[__get]]></code>
@@ -918,69 +940,6 @@
     <UnusedParam>
       <code><![CDATA[$config]]></code>
     </UnusedParam>
-  </file>
-  <file src="src/Resolver/AggregateResolver.php">
-    <DeprecatedProperty>
-      <code><![CDATA[$this->lastLookupFailure]]></code>
-      <code><![CDATA[$this->lastLookupFailure]]></code>
-      <code><![CDATA[$this->lastLookupFailure]]></code>
-      <code><![CDATA[$this->lastLookupFailure]]></code>
-      <code><![CDATA[$this->lastSuccessfulResolver]]></code>
-      <code><![CDATA[$this->lastSuccessfulResolver]]></code>
-      <code><![CDATA[$this->lastSuccessfulResolver]]></code>
-    </DeprecatedProperty>
-  </file>
-  <file src="src/Resolver/PrefixPathStackResolver.php">
-    <InvalidNullableReturnType>
-      <code><![CDATA[resolve]]></code>
-    </InvalidNullableReturnType>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(string) $prefix]]></code>
-    </RedundantCastGivenDocblockType>
-  </file>
-  <file src="src/Resolver/TemplateMapResolver.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_iterable($map)]]></code>
-      <code><![CDATA[is_iterable($map)]]></code>
-    </DocblockTypeContradiction>
-    <MixedPropertyTypeCoercion>
-      <code><![CDATA[array_replace_recursive($this->map, $map)]]></code>
-    </MixedPropertyTypeCoercion>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[is_string($nameOrMap) && is_string($path)]]></code>
-      <code><![CDATA[is_string($path)]]></code>
-    </RedundantConditionGivenDocblockType>
-  </file>
-  <file src="src/Resolver/TemplatePathStack.php">
-    <DeprecatedConstant>
-      <code><![CDATA[static::FAILURE_NOT_FOUND]]></code>
-      <code><![CDATA[static::FAILURE_NO_PATHS]]></code>
-    </DeprecatedConstant>
-    <DeprecatedProperty>
-      <code><![CDATA[$this->lastLookupFailure]]></code>
-      <code><![CDATA[$this->lastLookupFailure]]></code>
-      <code><![CDATA[$this->lastLookupFailure]]></code>
-      <code><![CDATA[$this->lastLookupFailure]]></code>
-    </DeprecatedProperty>
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_string($path)]]></code>
-    </DocblockTypeContradiction>
-    <FalsableReturnStatement>
-      <code><![CDATA[false]]></code>
-      <code><![CDATA[false]]></code>
-    </FalsableReturnStatement>
-    <MixedArgument>
-      <code><![CDATA[$options['default_suffix']]]></code>
-      <code><![CDATA[$options['lfi_protection']]]></code>
-      <code><![CDATA[$options['script_paths']]]></code>
-    </MixedArgument>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[TemplatePathStack]]></code>
-    </PossiblyUnusedReturnValue>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $flag]]></code>
-      <code><![CDATA[(string) $defaultSuffix]]></code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Strategy/FeedStrategy.php">
     <MixedAssignment>
@@ -1112,6 +1071,21 @@
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(string) $this->helper->toString()]]></code>
     </RedundantCastGivenDocblockType>
+  </file>
+  <file src="test/Helper/DeclareVarsTest.php">
+    <RedundantCondition>
+      <code><![CDATA[assertTrue]]></code>
+      <code><![CDATA[assertTrue]]></code>
+      <code><![CDATA[assertTrue]]></code>
+    </RedundantCondition>
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[addPath]]></code>
+    </UndefinedInterfaceMethod>
+    <UndefinedPropertyAssignment>
+      <code><![CDATA[$vars->varName2]]></code>
+      <code><![CDATA[$vars->varName3]]></code>
+      <code><![CDATA[$vars->varName5]]></code>
+    </UndefinedPropertyAssignment>
   </file>
   <file src="test/Helper/HeadLinkTest.php">
     <MixedArgument>
@@ -1309,36 +1283,6 @@
       <code><![CDATA[$result]]></code>
       <code><![CDATA[$result]]></code>
     </PossiblyInvalidCast>
-    <PossiblyInvalidMethodCall>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-    </PossiblyInvalidMethodCall>
     <UndefinedInterfaceMethod>
       <code><![CDATA[addPath]]></code>
       <code><![CDATA[addPath]]></code>
@@ -1420,15 +1364,6 @@
       <code><![CDATA[$return]]></code>
       <code><![CDATA[$return]]></code>
     </PossiblyInvalidCast>
-    <PossiblyInvalidMethodCall>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-      <code><![CDATA[addPath]]></code>
-    </PossiblyInvalidMethodCall>
     <UndefinedInterfaceMethod>
       <code><![CDATA[addPath]]></code>
       <code><![CDATA[addPath]]></code>
@@ -1590,47 +1525,6 @@
       <code><![CDATA[json_encode($model->value)]]></code>
       <code><![CDATA[json_encode(['foo' => 'bar'])]]></code>
     </PossiblyFalseOperand>
-  </file>
-  <file src="test/Resolver/AggregateResolverTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getLastLookupFailure]]></code>
-      <code><![CDATA[getLastLookupFailure]]></code>
-      <code><![CDATA[getLastSuccessfulResolver]]></code>
-      <code><![CDATA[getLastSuccessfulResolver]]></code>
-      <code><![CDATA[getLastSuccessfulResolver]]></code>
-      <code><![CDATA[getLastSuccessfulResolver]]></code>
-    </DeprecatedMethod>
-    <DocblockTypeContradiction>
-      <code><![CDATA[assertNull]]></code>
-    </DocblockTypeContradiction>
-  </file>
-  <file src="test/Resolver/PrefixPathStackResolverTest.php">
-    <PossiblyFalsePropertyAssignmentValue>
-      <code><![CDATA[realpath(__DIR__ . '/../_templates/prefix-path-stack-resolver')]]></code>
-    </PossiblyFalsePropertyAssignmentValue>
-  </file>
-  <file src="test/Resolver/TemplatePathStackTest.php">
-    <DeprecatedConstant>
-      <code><![CDATA[TemplatePathStack::FAILURE_NOT_FOUND]]></code>
-      <code><![CDATA[TemplatePathStack::FAILURE_NO_PATHS]]></code>
-    </DeprecatedConstant>
-    <DeprecatedMethod>
-      <code><![CDATA[getLastLookupFailure]]></code>
-      <code><![CDATA[getLastLookupFailure]]></code>
-    </DeprecatedMethod>
-    <PossiblyFalseArgument>
-      <code><![CDATA[$this->baseDir]]></code>
-    </PossiblyFalseArgument>
-    <PossiblyFalseOperand>
-      <code><![CDATA[$this->baseDir]]></code>
-    </PossiblyFalseOperand>
-    <PossiblyFalsePropertyAssignmentValue>
-      <code><![CDATA[realpath(__DIR__ . '/..')]]></code>
-    </PossiblyFalsePropertyAssignmentValue>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[testAllowsPassingOptionsToConstructor]]></code>
-      <code><![CDATA[testAllowsSettingOptions]]></code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="test/Strategy/FeedStrategyTest.php">
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -65,37 +65,6 @@
       <code><![CDATA[getName]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="src/Helper/DeclareVars.php">
-    <MissingConstructor>
-      <code><![CDATA[$view]]></code>
-    </MissingConstructor>
-    <MixedArgument>
-      <code><![CDATA[$key]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$name]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedAssignment>
-      <code><![CDATA[$key]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$vars]]></code>
-    </MixedAssignment>
-    <MixedPropertyFetch>
-      <code><![CDATA[$vars->$key]]></code>
-    </MixedPropertyFetch>
-    <NonInvariantDocblockPropertyType>
-      <code><![CDATA[$view]]></code>
-    </NonInvariantDocblockPropertyType>
-    <PossiblyNullReference>
-      <code><![CDATA[vars]]></code>
-      <code><![CDATA[vars]]></code>
-    </PossiblyNullReference>
-    <UndefinedInterfaceMethod>
-      <code><![CDATA[vars]]></code>
-      <code><![CDATA[vars]]></code>
-    </UndefinedInterfaceMethod>
-  </file>
   <file src="src/Helper/Doctype.php">
     <DocblockTypeContradiction>
       <code><![CDATA[null === static::$registeredDoctypes]]></code>
@@ -1071,21 +1040,6 @@
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(string) $this->helper->toString()]]></code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="test/Helper/DeclareVarsTest.php">
-    <RedundantCondition>
-      <code><![CDATA[assertTrue]]></code>
-      <code><![CDATA[assertTrue]]></code>
-      <code><![CDATA[assertTrue]]></code>
-    </RedundantCondition>
-    <UndefinedInterfaceMethod>
-      <code><![CDATA[addPath]]></code>
-    </UndefinedInterfaceMethod>
-    <UndefinedPropertyAssignment>
-      <code><![CDATA[$vars->varName2]]></code>
-      <code><![CDATA[$vars->varName3]]></code>
-      <code><![CDATA[$vars->varName5]]></code>
-    </UndefinedPropertyAssignment>
   </file>
   <file src="test/Helper/HeadLinkTest.php">
     <MixedArgument>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -21,7 +21,15 @@ use Laminas\View\Helper\Service\EscaperFactory;
  *     view_manager?: array{
  *         base_path?: non-empty-string|null,
  *         encoding?: non-empty-string,
- *     }
+ *         template_map?: array<string, string>,
+ *         template_path_stack?: list<string>,
+ *         prefix_template_path_stack?: array<string, string>,
+ *         default_template_suffix?: non-empty-string,
+ *     },
+ *     templates?: array{
+ *         extension?: non-empty-string,
+ *         map?: array<string, string>,
+ *     },
  * }
  */
 final class ConfigProvider
@@ -54,6 +62,45 @@ final class ConfigProvider
                  */
                 'base_path' => null,
             ],
+            'view_manager'       => [
+                /**
+                 * Templates configured here will be provided to the TemplateMapResolver.
+                 * This is conventional for an MVC app
+                 */
+                'template_map' => [
+                    // 'template-name' => 'path/to/template.phtml',
+                ],
+                /**
+                 * Templates configured here will be provided to the TemplatePathStack resolver.
+                 * This is conventional for an MVC app
+                 */
+                'template_path_stack' => [
+                    // 'path/to/a/directory/of/templates',
+                ],
+                /**
+                 * Templates configured here will be provided to the PrefixPathStackResolver
+                 */
+                'prefix_template_path_stack' => [
+                    // 'prefix' => 'path/to/a/directory/of/templates',
+                ],
+                /**
+                 * The default template suffix is configured here in MVC applications
+                 */
+                //'default_template_suffix' => 'phtml',
+            ],
+            'templates'          => [
+                /**
+                 * Templates configured here will be provided to the TemplateMapResolver
+                 * This is conventional for a Mezzio app
+                 */
+                'map' => [
+                    // 'template-name' => 'path/to/template.phtml',
+                ],
+                /**
+                 * The default template filename extension is configured here. The default is 'phtml'
+                 */
+                //'extension' => 'phtml',
+            ],
         ];
     }
 
@@ -62,12 +109,17 @@ final class ConfigProvider
     {
         return [
             'factories' => [
-                HelperPluginManager::class  => HelperPluginManagerFactory::class,
-                Escaper::class              => EscaperFactory::class,
-                Renderer\PhpRenderer::class => Renderer\PhpRendererFactory::class,
+                HelperPluginManager::class              => HelperPluginManagerFactory::class,
+                Escaper::class                          => EscaperFactory::class,
+                Renderer\PhpRenderer::class             => Renderer\PhpRendererFactory::class,
+                Resolver\AggregateResolver::class       => Resolver\Factory\AggregateResolverFactory::class,
+                Resolver\PrefixPathStackResolver::class => Resolver\Factory\PrefixPathStackResolverFactory::class,
+                Resolver\TemplateMapResolver::class     => Resolver\Factory\TemplateMapResolverFactory::class,
+                Resolver\TemplatePathStack::class       => Resolver\Factory\TemplatePathStackResolverFactory::class,
             ],
             'aliases'   => [
                 Renderer\RendererInterface::class => Renderer\PhpRenderer::class,
+                Resolver\ResolverInterface::class => Resolver\AggregateResolver::class,
             ],
         ];
     }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -68,20 +68,20 @@ final class ConfigProvider
                  * This is conventional for an MVC app
                  */
                 'template_map' => [
-                    // 'template-name' => 'path/to/template.phtml',
+                    // 'template-name' => __DIR__ . '/path/to/template.phtml',
                 ],
                 /**
                  * Templates configured here will be provided to the TemplatePathStack resolver.
                  * This is conventional for an MVC app
                  */
                 'template_path_stack' => [
-                    // 'path/to/a/directory/of/templates',
+                    // __DIR__ . '/path/to/a/directory/of/templates',
                 ],
                 /**
                  * Templates configured here will be provided to the PrefixPathStackResolver
                  */
                 'prefix_template_path_stack' => [
-                    // 'prefix' => 'path/to/a/directory/of/templates',
+                    // 'prefix' => __DIR__ . '/path/to/a/directory/of/templates',
                 ],
                 /**
                  * The default template suffix is configured here in MVC applications
@@ -94,7 +94,7 @@ final class ConfigProvider
                  * This is conventional for a Mezzio app
                  */
                 'map' => [
-                    // 'template-name' => 'path/to/template.phtml',
+                    // 'template-name' => __DIR__ . '/path/to/template.phtml',
                 ],
                 /**
                  * The default template filename extension is configured here. The default is 'phtml'

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -22,8 +22,8 @@ use Laminas\View\Helper\Service\EscaperFactory;
  *         base_path?: non-empty-string|null,
  *         encoding?: non-empty-string,
  *         template_map?: array<string, string>,
- *         template_path_stack?: list<string>,
- *         prefix_template_path_stack?: array<string, string>,
+ *         template_path_stack?: list<non-empty-string>,
+ *         prefix_template_path_stack?: array<non-empty-string, non-empty-string>,
  *         default_template_suffix?: non-empty-string,
  *     },
  *     templates?: array{

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -6,7 +6,6 @@ namespace Laminas\View\Exception;
 
 use RuntimeException as RuntimeError;
 
-/** @final */
 class RuntimeException extends RuntimeError implements ExceptionInterface
 {
 }

--- a/src/Helper/Service/Configuration.php
+++ b/src/Helper/Service/Configuration.php
@@ -8,6 +8,7 @@ use Laminas\View\ConfigProvider;
 use Psr\Container\ContainerInterface;
 
 use function is_array;
+use function is_string;
 
 /**
  * Provides consistent retrieval of configuration and individual values based on historic conventions
@@ -18,7 +19,8 @@ use function is_array;
  */
 final class Configuration
 {
-    private const DEFAULT_ENCODING = 'utf-8';
+    private const DEFAULT_ENCODING        = 'utf-8';
+    private const DEFAULT_TEMPLATE_SUFFIX = 'phtml';
 
     /** @return array<array-key, mixed> */
     public static function get(ContainerInterface $container): array
@@ -50,5 +52,23 @@ final class Configuration
         $encoding = $config['view_helper_config']['encoding'] ?? $encoding;
 
         return $encoding !== '' ? $encoding : $defaultEncoding;
+    }
+
+    /**
+     * Retrieve the default template suffix from conventional locations
+     *
+     * @param non-empty-string $fallbackDefault
+     * @return non-empty-string
+     */
+    public static function defaultTemplateSuffix(
+        ContainerInterface $container,
+        string $fallbackDefault = self::DEFAULT_TEMPLATE_SUFFIX,
+    ): string {
+        /** @var ViewConfigShape $config */
+        $config = self::get($container);
+        $suffix = $config['view_manager']['default_template_suffix'] ?? null;
+        $suffix = $config['templates']['extension'] ?? $suffix;
+
+        return is_string($suffix) ? $suffix : $fallbackDefault;
     }
 }

--- a/src/Helper/Service/Configuration.php
+++ b/src/Helper/Service/Configuration.php
@@ -57,18 +57,16 @@ final class Configuration
     /**
      * Retrieve the default template suffix from conventional locations
      *
-     * @param non-empty-string $fallbackDefault
      * @return non-empty-string
      */
     public static function defaultTemplateSuffix(
-        ContainerInterface $container,
-        string $fallbackDefault = self::DEFAULT_TEMPLATE_SUFFIX,
+        ContainerInterface $container
     ): string {
         /** @var ViewConfigShape $config */
         $config = self::get($container);
         $suffix = $config['view_manager']['default_template_suffix'] ?? null;
         $suffix = $config['templates']['extension'] ?? $suffix;
 
-        return is_string($suffix) ? $suffix : $fallbackDefault;
+        return is_string($suffix) ? $suffix : self::DEFAULT_TEMPLATE_SUFFIX;
     }
 }

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -14,6 +14,7 @@ use Laminas\View\HelperPluginManager;
 use Laminas\View\Model\ModelInterface as Model;
 use Laminas\View\Renderer\RendererInterface as Renderer;
 use Laminas\View\Resolver\ResolverInterface as Resolver;
+use Laminas\View\Resolver\TemplateCannotBeFound;
 use Laminas\View\Resolver\TemplatePathStack;
 use Laminas\View\Variables;
 use Throwable;
@@ -192,17 +193,18 @@ class PhpRenderer implements Renderer, TreeRendererInterface
     /**
      * Retrieve template name or template resolver
      *
-     * @param  null|string $name
-     * @return string|Resolver
+     * @param non-empty-string|null $name
+     * @return ($name is null ? Resolver : non-empty-string)
+     * @throws TemplateCannotBeFound
      */
-    public function resolver($name = null)
+    public function resolver(string|null $name = null): string|Resolver
     {
-        if (null === $this->__templateResolver) {
-            $this->setResolver(new TemplatePathStack());
+        if ($this->__templateResolver === null) {
+            $this->__templateResolver = new TemplatePathStack();
         }
 
-        if (null !== $name) {
-            return $this->__templateResolver->resolve($name, $this);
+        if ($name !== null) {
+            return $this->__templateResolver->resolve($name);
         }
 
         return $this->__templateResolver;

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -14,7 +14,6 @@ use Laminas\View\HelperPluginManager;
 use Laminas\View\Model\ModelInterface as Model;
 use Laminas\View\Renderer\RendererInterface as Renderer;
 use Laminas\View\Resolver\ResolverInterface as Resolver;
-use Laminas\View\Resolver\TemplateCannotBeFound;
 use Laminas\View\Resolver\TemplatePathStack;
 use Laminas\View\Variables;
 use Throwable;
@@ -194,10 +193,9 @@ class PhpRenderer implements Renderer, TreeRendererInterface
      * Retrieve template name or template resolver
      *
      * @param non-empty-string|null $name
-     * @return ($name is null ? Resolver : non-empty-string)
-     * @throws TemplateCannotBeFound
+     * @return ($name is null ? Resolver : non-empty-string|false)
      */
-    public function resolver(string|null $name = null): string|Resolver
+    public function resolver(string|null $name = null): string|Resolver|false
     {
         if ($this->__templateResolver === null) {
             $this->__templateResolver = new TemplatePathStack();

--- a/src/Resolver/AggregateResolver.php
+++ b/src/Resolver/AggregateResolver.php
@@ -50,25 +50,15 @@ final class AggregateResolver implements Countable, IteratorAggregate, ResolverI
         return $this;
     }
 
-    public function resolve(string $name): string
+    public function resolve(string $name): string|false
     {
         foreach ($this->queue as $resolver) {
-            if (! $resolver->has($name)) {
+            $path = $resolver->resolve($name);
+            if ($path === false) {
                 continue;
             }
 
-            return $resolver->resolve($name);
-        }
-
-        throw TemplateCannotBeFound::byName($name);
-    }
-
-    public function has(string $name): bool
-    {
-        foreach ($this->queue as $resolver) {
-            if ($resolver->has($name)) {
-                return true;
-            }
+            return $path;
         }
 
         return false;

--- a/src/Resolver/AggregateResolver.php
+++ b/src/Resolver/AggregateResolver.php
@@ -53,13 +53,24 @@ final class AggregateResolver implements Countable, IteratorAggregate, ResolverI
     public function resolve(string $name): string
     {
         foreach ($this->queue as $resolver) {
-            try {
-                return $resolver->resolve($name);
-            } catch (TemplateCannotBeFound) {
+            if (! $resolver->has($name)) {
                 continue;
             }
+
+            return $resolver->resolve($name);
         }
 
         throw TemplateCannotBeFound::byName($name);
+    }
+
+    public function has(string $name): bool
+    {
+        foreach ($this->queue as $resolver) {
+            if ($resolver->has($name)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Resolver/AggregateResolver.php
+++ b/src/Resolver/AggregateResolver.php
@@ -7,62 +7,29 @@ namespace Laminas\View\Resolver;
 use Countable;
 use IteratorAggregate;
 use Laminas\Stdlib\PriorityQueue;
-use Laminas\View\Renderer\RendererInterface as Renderer;
-use Laminas\View\Resolver\ResolverInterface as Resolver;
-use ReturnTypeWillChange;
 use Traversable;
 
-use function count;
-use function is_string;
-
-/**
- * @final
- * @implements IteratorAggregate<int, ResolverInterface>
- */
-class AggregateResolver implements Countable, IteratorAggregate, Resolver
+/** @implements IteratorAggregate<int, ResolverInterface> */
+final class AggregateResolver implements Countable, IteratorAggregate, ResolverInterface
 {
-    public const FAILURE_NO_RESOLVERS = 'AggregateResolver_Failure_No_Resolvers';
-    public const FAILURE_NOT_FOUND    = 'AggregateResolver_Failure_Not_Found';
-
-    /**
-     * Last lookup failure
-     *
-     * @deprecated This property will be removed in v3.0 of this component.
-     *
-     * @var false|string
-     */
-    protected $lastLookupFailure = false;
-
-    /**
-     * @deprecated This property will be removed in v3.0 of this component.
-     *
-     * @var Resolver|null
-     */
-    protected $lastSuccessfulResolver;
-
     /** @var PriorityQueue<ResolverInterface, int> */
-    protected $queue;
+    private PriorityQueue $queue;
 
     /**
-     * Constructor
-     *
-     * Instantiate the internal priority queue
+     * @param list<ResolverInterface> $resolvers
      */
-    public function __construct()
+    public function __construct(array $resolvers = [])
     {
         /** @var PriorityQueue<ResolverInterface, int> $priorityQueue */
         $priorityQueue = new PriorityQueue();
 
         $this->queue = $priorityQueue;
+        foreach ($resolvers as $resolver) {
+            $this->attach($resolver);
+        }
     }
 
-    /**
-     * Return count of attached resolvers
-     *
-     * @return int
-     */
-    #[ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return $this->queue->count();
     }
@@ -72,77 +39,27 @@ class AggregateResolver implements Countable, IteratorAggregate, Resolver
      *
      * @return Traversable<int, ResolverInterface>
      */
-    #[ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return $this->queue;
     }
 
-    /**
-     * Attach a resolver
-     *
-     * @param  int $priority
-     * @return $this
-     */
-    public function attach(Resolver $resolver, $priority = 1)
+    public function attach(ResolverInterface $resolver, int $priority = 1): self
     {
         $this->queue->insert($resolver, $priority);
         return $this;
     }
 
-    /**
-     * Resolve a template/pattern name to a resource the renderer can consume
-     *
-     * @param  string $name
-     * @return false|string
-     */
-    public function resolve($name, ?Renderer $renderer = null)
+    public function resolve(string $name): string
     {
-        $this->lastLookupFailure      = false;
-        $this->lastSuccessfulResolver = null;
-
-        if (0 === count($this->queue)) {
-            $this->lastLookupFailure = static::FAILURE_NO_RESOLVERS;
-            return false;
-        }
-
         foreach ($this->queue as $resolver) {
-            /**
-             * @todo This loop should be modified to try { return resolve } catch { continue } in v3.0
-             */
-            $resource = $resolver->resolve($name, $renderer);
-            if (is_string($resource)) {
-                // Resource found; return it
-                $this->lastSuccessfulResolver = $resolver;
-                return $resource;
+            try {
+                return $resolver->resolve($name);
+            } catch (TemplateCannotBeFound) {
+                continue;
             }
         }
 
-        $this->lastLookupFailure = static::FAILURE_NOT_FOUND;
-        return false;
-    }
-
-    /**
-     * Return the last successful resolver, if any
-     *
-     * @deprecated This method will be removed in v3.0 of this component
-     *
-     * @return Resolver|null
-     */
-    public function getLastSuccessfulResolver()
-    {
-        return $this->lastSuccessfulResolver;
-    }
-
-    /**
-     * Get last lookup failure
-     *
-     * @deprecated This method will be removed in v3.0 of this component
-     *
-     * @return false|string
-     */
-    public function getLastLookupFailure()
-    {
-        return $this->lastLookupFailure;
+        throw TemplateCannotBeFound::byName($name);
     }
 }

--- a/src/Resolver/Factory/AggregateResolverFactory.php
+++ b/src/Resolver/Factory/AggregateResolverFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View\Resolver\Factory;
+
+use Laminas\View\Helper\ViewModel;
+use Laminas\View\HelperPluginManager;
+use Laminas\View\Resolver\AggregateResolver;
+use Laminas\View\Resolver\PrefixPathStackResolver;
+use Laminas\View\Resolver\RelativeFallbackResolver;
+use Laminas\View\Resolver\TemplateMapResolver;
+use Laminas\View\Resolver\TemplatePathStack;
+use Psr\Container\ContainerInterface;
+
+final class AggregateResolverFactory
+{
+    public function __invoke(ContainerInterface $container): AggregateResolver
+    {
+        $mapResolver     = $container->get(TemplateMapResolver::class);
+        $stackResolver   = $container->get(TemplatePathStack::class);
+        $prefixResolver  = $container->get(PrefixPathStackResolver::class);
+        $pluginManager   = $container->get(HelperPluginManager::class);
+        $viewModelHelper = $pluginManager->get(ViewModel::class);
+
+        return new AggregateResolver([
+            $mapResolver,
+            $stackResolver,
+            $prefixResolver,
+            new RelativeFallbackResolver($mapResolver, $viewModelHelper),
+            new RelativeFallbackResolver($stackResolver, $viewModelHelper),
+            new RelativeFallbackResolver($prefixResolver, $viewModelHelper),
+        ]);
+    }
+}

--- a/src/Resolver/Factory/AggregateResolverFactory.php
+++ b/src/Resolver/Factory/AggregateResolverFactory.php
@@ -13,6 +13,10 @@ use Laminas\View\Resolver\TemplateMapResolver;
 use Laminas\View\Resolver\TemplatePathStack;
 use Psr\Container\ContainerInterface;
 
+/**
+ * @psalm-internal Laminas\View
+ * @psalm-internal LaminasTest\View
+ */
 final class AggregateResolverFactory
 {
     public function __invoke(ContainerInterface $container): AggregateResolver

--- a/src/Resolver/Factory/PrefixPathStackResolverFactory.php
+++ b/src/Resolver/Factory/PrefixPathStackResolverFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View\Resolver\Factory;
+
+use Laminas\View\Helper\Service\Configuration;
+use Laminas\View\Resolver\PrefixPathStackResolver;
+use Psr\Container\ContainerInterface;
+
+use function is_array;
+
+final class PrefixPathStackResolverFactory
+{
+    public function __invoke(ContainerInterface $container): PrefixPathStackResolver
+    {
+        $config = Configuration::get($container);
+        /** @var mixed $paths */
+        $paths = $config['view_manager']['prefix_template_path_stack'] ?? [];
+        /**
+         * Forcing this type to avoid runtime validation of configuration
+         *
+         * @var array<non-empty-string, non-empty-string> $paths
+         */
+        $paths = is_array($paths) ? $paths : [];
+
+        return new PrefixPathStackResolver(
+            $paths,
+            Configuration::defaultTemplateSuffix($container),
+        );
+    }
+}

--- a/src/Resolver/Factory/PrefixPathStackResolverFactory.php
+++ b/src/Resolver/Factory/PrefixPathStackResolverFactory.php
@@ -4,25 +4,23 @@ declare(strict_types=1);
 
 namespace Laminas\View\Resolver\Factory;
 
+use Laminas\View\ConfigProvider;
 use Laminas\View\Helper\Service\Configuration;
 use Laminas\View\Resolver\PrefixPathStackResolver;
 use Psr\Container\ContainerInterface;
 
-use function is_array;
-
+/**
+ * @psalm-internal Laminas\View
+ * @psalm-internal LaminasTest\View
+ * @psalm-import-type ViewConfigShape from ConfigProvider
+ */
 final class PrefixPathStackResolverFactory
 {
     public function __invoke(ContainerInterface $container): PrefixPathStackResolver
     {
+        /** @var ViewConfigShape $config */
         $config = Configuration::get($container);
-        /** @var mixed $paths */
-        $paths = $config['view_manager']['prefix_template_path_stack'] ?? [];
-        /**
-         * Forcing this type to avoid runtime validation of configuration
-         *
-         * @var array<non-empty-string, non-empty-string> $paths
-         */
-        $paths = is_array($paths) ? $paths : [];
+        $paths  = $config['view_manager']['prefix_template_path_stack'] ?? [];
 
         return new PrefixPathStackResolver(
             $paths,

--- a/src/Resolver/Factory/TemplateMapResolverFactory.php
+++ b/src/Resolver/Factory/TemplateMapResolverFactory.php
@@ -4,47 +4,36 @@ declare(strict_types=1);
 
 namespace Laminas\View\Resolver\Factory;
 
+use Laminas\View\ConfigProvider;
 use Laminas\View\Helper\Service\Configuration;
 use Laminas\View\Resolver\TemplateMapResolver;
 use Psr\Container\ContainerInterface;
 
-use function is_iterable;
-
+/**
+ * @psalm-internal Laminas\View
+ * @psalm-internal LaminasTest\View
+ * @psalm-import-type ViewConfigShape from ConfigProvider
+ */
 final class TemplateMapResolverFactory
 {
     public function __invoke(ContainerInterface $container): TemplateMapResolver
     {
+        /** @var ViewConfigShape $config */
         $config = Configuration::get($container);
 
         /**
          * In laminas MVC applications, we find the template map under `view_manager.template_map`
-         *
-         * @psalm-var mixed $mvcMap
          */
         $mvcMap = $config['view_manager']['template_map'] ?? [];
 
         /**
          * In Mezzio applications, the template map can be found under `templates.map`
-         *
-         * @psalm-var mixed $mezzioMap
          */
         $mezzioMap = $config['templates']['map'] ?? [];
 
         $mapResolver = new TemplateMapResolver();
-
-        /**
-         * Iterable types are forced here because the resolver will crash for invalid maps
-         */
-
-        if (is_iterable($mvcMap)) {
-            /** @psalm-var iterable<string, string> $mvcMap */
-            $mapResolver->add($mvcMap);
-        }
-
-        if (is_iterable($mezzioMap)) {
-            /** @psalm-var iterable<string, string> $mezzioMap */
-            $mapResolver->add($mezzioMap);
-        }
+        $mapResolver->add($mvcMap);
+        $mapResolver->add($mezzioMap);
 
         return $mapResolver;
     }

--- a/src/Resolver/Factory/TemplateMapResolverFactory.php
+++ b/src/Resolver/Factory/TemplateMapResolverFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View\Resolver\Factory;
+
+use Laminas\View\Helper\Service\Configuration;
+use Laminas\View\Resolver\TemplateMapResolver;
+use Psr\Container\ContainerInterface;
+
+use function is_iterable;
+
+final class TemplateMapResolverFactory
+{
+    public function __invoke(ContainerInterface $container): TemplateMapResolver
+    {
+        $config = Configuration::get($container);
+
+        /**
+         * In laminas MVC applications, we find the template map under `view_manager.template_map`
+         *
+         * @psalm-var mixed $mvcMap
+         */
+        $mvcMap = $config['view_manager']['template_map'] ?? [];
+
+        /**
+         * In Mezzio applications, the template map can be found under `templates.map`
+         *
+         * @psalm-var mixed $mezzioMap
+         */
+        $mezzioMap = $config['templates']['map'] ?? [];
+
+        $mapResolver = new TemplateMapResolver();
+
+        /**
+         * Iterable types are forced here because the resolver will crash for invalid maps
+         */
+
+        if (is_iterable($mvcMap)) {
+            /** @psalm-var iterable<string, string> $mvcMap */
+            $mapResolver->add($mvcMap);
+        }
+
+        if (is_iterable($mezzioMap)) {
+            /** @psalm-var iterable<string, string> $mezzioMap */
+            $mapResolver->add($mezzioMap);
+        }
+
+        return $mapResolver;
+    }
+}

--- a/src/Resolver/Factory/TemplatePathStackResolverFactory.php
+++ b/src/Resolver/Factory/TemplatePathStackResolverFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View\Resolver\Factory;
+
+use Laminas\View\Helper\Service\Configuration;
+use Laminas\View\Resolver\TemplatePathStack;
+use Psr\Container\ContainerInterface;
+
+use function is_array;
+
+final class TemplatePathStackResolverFactory
+{
+    /** @psalm-suppress MixedAssignment */
+    public function __invoke(ContainerInterface $container): TemplatePathStack
+    {
+        $config = Configuration::get($container);
+
+        $paths = $config['view_manager']['template_path_stack'] ?? [];
+        /** @psalm-var list<non-empty-string> $paths */
+        $paths = is_array($paths) ? $paths : [];
+
+        return new TemplatePathStack([
+            'default_suffix' => Configuration::defaultTemplateSuffix($container),
+            'script_paths'   => $paths,
+        ]);
+    }
+}

--- a/src/Resolver/Factory/TemplatePathStackResolverFactory.php
+++ b/src/Resolver/Factory/TemplatePathStackResolverFactory.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace Laminas\View\Resolver\Factory;
 
+use Laminas\View\ConfigProvider;
 use Laminas\View\Helper\Service\Configuration;
 use Laminas\View\Resolver\TemplatePathStack;
 use Psr\Container\ContainerInterface;
 
-use function is_array;
-
+/**
+ * @psalm-internal Laminas\View
+ * @psalm-internal LaminasTest\View
+ * @psalm-import-type ViewConfigShape from ConfigProvider
+ */
 final class TemplatePathStackResolverFactory
 {
-    /** @psalm-suppress MixedAssignment */
     public function __invoke(ContainerInterface $container): TemplatePathStack
     {
+        /** @var ViewConfigShape $config */
         $config = Configuration::get($container);
-
-        $paths = $config['view_manager']['template_path_stack'] ?? [];
-        /** @psalm-var list<non-empty-string> $paths */
-        $paths = is_array($paths) ? $paths : [];
+        $paths  = $config['view_manager']['template_path_stack'] ?? [];
 
         return new TemplatePathStack([
             'default_suffix' => Configuration::defaultTemplateSuffix($container),

--- a/src/Resolver/PrefixPathStackResolver.php
+++ b/src/Resolver/PrefixPathStackResolver.php
@@ -54,16 +54,34 @@ final class PrefixPathStackResolver implements ResolverInterface
 
             $template = substr($name, strlen($prefix));
             if ($template === '') {
-                break;
+                continue;
             }
 
-            try {
+            if ($resolver->has($template)) {
                 return $resolver->resolve($template);
-            } catch (TemplateCannotBeFound) {
-                continue;
             }
         }
 
         throw TemplateCannotBeFound::byName($name);
+    }
+
+    public function has(string $name): bool
+    {
+        foreach ($this->resolvers as $prefix => $resolver) {
+            if (! str_starts_with($name, $prefix)) {
+                continue;
+            }
+
+            $template = substr($name, strlen($prefix));
+            if ($template === '') {
+                continue;
+            }
+
+            if ($resolver->has($template)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Resolver/PrefixPathStackResolver.php
+++ b/src/Resolver/PrefixPathStackResolver.php
@@ -19,8 +19,9 @@ final class PrefixPathStackResolver implements ResolverInterface
      *                  prefixes to be matched (array keys), with either a path or an array of paths
      *                  to use for matching as in the {@see TemplatePathStack},
      *                  or a {@see ResolverInterface} to use for view path starting with that prefix
+     * @param non-empty-string $defaultSuffix
      */
-    public function __construct(array $prefixes = [])
+    public function __construct(array $prefixes = [], string $defaultSuffix = 'phtml')
     {
         $resolvers = [];
         foreach ($prefixes as $prefix => $path) {
@@ -35,7 +36,8 @@ final class PrefixPathStackResolver implements ResolverInterface
             }
 
             $resolvers[$prefix] = new TemplatePathStack([
-                'script_paths' => $path,
+                'default_suffix' => $defaultSuffix,
+                'script_paths'   => $path,
             ]);
         }
 

--- a/src/Resolver/PrefixPathStackResolver.php
+++ b/src/Resolver/PrefixPathStackResolver.php
@@ -45,7 +45,7 @@ final class PrefixPathStackResolver implements ResolverInterface
     }
 
     /** @inheritDoc */
-    public function resolve(string $name): string
+    public function resolve(string $name): string|false
     {
         foreach ($this->resolvers as $prefix => $resolver) {
             if (! str_starts_with($name, $prefix)) {
@@ -57,29 +57,12 @@ final class PrefixPathStackResolver implements ResolverInterface
                 continue;
             }
 
-            if ($resolver->has($template)) {
-                return $resolver->resolve($template);
-            }
-        }
-
-        throw TemplateCannotBeFound::byName($name);
-    }
-
-    public function has(string $name): bool
-    {
-        foreach ($this->resolvers as $prefix => $resolver) {
-            if (! str_starts_with($name, $prefix)) {
+            $path = $resolver->resolve($template);
+            if ($path === false) {
                 continue;
             }
 
-            $template = substr($name, strlen($prefix));
-            if ($template === '') {
-                continue;
-            }
-
-            if ($resolver->has($template)) {
-                return true;
-            }
+            return $path;
         }
 
         return false;

--- a/src/Resolver/PrefixPathStackResolver.php
+++ b/src/Resolver/PrefixPathStackResolver.php
@@ -4,66 +4,64 @@ declare(strict_types=1);
 
 namespace Laminas\View\Resolver;
 
-use Laminas\View\Renderer\RendererInterface as Renderer;
-
 use function is_string;
+use function str_starts_with;
 use function strlen;
-use function strpos;
 use function substr;
 
-/** @final */
 final class PrefixPathStackResolver implements ResolverInterface
 {
-    /**
-     * Array containing prefix as key and "template path stack array" as value
-     *
-     * @var array<string, list<string>|string|ResolverInterface>
-     */
-    private array $prefixes = [];
+    /** @var array<non-empty-string, ResolverInterface> */
+    private readonly array $resolvers;
 
     /**
-     * Constructor
-     *
-     * @param array<string, list<string>|string|ResolverInterface> $prefixes Set of path prefixes
-     *     to be matched (array keys), with either a path or an array of paths
-     *     to use for matching as in the {@see TemplatePathStack},
-     *     or a {@see ResolverInterface}
-     *     to use for view path starting with that prefix
+     * @param array<non-empty-string, list<non-empty-string>|non-empty-string|ResolverInterface> $prefixes Set of path
+     *                  prefixes to be matched (array keys), with either a path or an array of paths
+     *                  to use for matching as in the {@see TemplatePathStack},
+     *                  or a {@see ResolverInterface} to use for view path starting with that prefix
      */
     public function __construct(array $prefixes = [])
     {
-        $this->prefixes = $prefixes;
-    }
+        $resolvers = [];
+        foreach ($prefixes as $prefix => $path) {
+            if ($path instanceof ResolverInterface) {
+                $resolvers[$prefix] = $path;
 
-    /**
-     * {@inheritDoc}
-     */
-    public function resolve($name, ?Renderer $renderer = null)
-    {
-        foreach ($this->prefixes as $prefix => &$resolver) {
-            if (strpos($name, (string) $prefix) !== 0) {
                 continue;
             }
 
-            if (! $resolver instanceof ResolverInterface) {
-                $resolver = new TemplatePathStack(['script_paths' => (array) $resolver]);
+            if (is_string($path)) {
+                $path = [$path];
             }
 
-            /**
-             * @todo In V3, this should just try,return and catch,continue.
-             *       It relies on internal knowledge that some resolvers return false when really
-             *       they should always return a string or throw an exception.
-             */
-            $result = $resolver->resolve(substr($name, strlen($prefix)), $renderer);
-            if (is_string($result)) {
-                return $result;
+            $resolvers[$prefix] = new TemplatePathStack([
+                'script_paths' => $path,
+            ]);
+        }
+
+        $this->resolvers = $resolvers;
+    }
+
+    /** @inheritDoc */
+    public function resolve(string $name): string
+    {
+        foreach ($this->resolvers as $prefix => $resolver) {
+            if (! str_starts_with($name, $prefix)) {
+                continue;
+            }
+
+            $template = substr($name, strlen($prefix));
+            if ($template === '') {
+                break;
+            }
+
+            try {
+                return $resolver->resolve($template);
+            } catch (TemplateCannotBeFound) {
+                continue;
             }
         }
 
-        /**
-         * @todo This should be exceptional. All resolvers are exhausted and no template can be found.
-         *       It further deviates from the previously un-documented norm, that the return type is false-able
-         */
-        return; // phpcs:ignore
+        throw TemplateCannotBeFound::byName($name);
     }
 }

--- a/src/Resolver/RelativeFallbackResolver.php
+++ b/src/Resolver/RelativeFallbackResolver.php
@@ -4,66 +4,49 @@ declare(strict_types=1);
 
 namespace Laminas\View\Resolver;
 
-use Laminas\View\Helper\ViewModel as ViewModelHelper;
+use Laminas\View\Helper\ViewModel;
 use Laminas\View\Model\ModelInterface;
-use Laminas\View\Renderer\RendererInterface;
-use Laminas\View\Resolver\ResolverInterface;
 
-use function call_user_func;
-use function is_callable;
 use function strrpos;
 use function substr;
 
 /**
  * Relative fallback resolver - resolves to view templates in a sub-path of the
- * currently set view model's template (if the current renderer has the `view_model` plugin set).
+ * currently set view model's template.
+ *
+ * The current view model is retrieved from the ViewModel view helper
  *
  * This allows for usage of partial template paths such as `some/partial`, resolving to
  * `my/module/script/path/some/partial.phtml`, while rendering template `my/module/script/path/my-view`
- *
- * @final
  */
-class RelativeFallbackResolver implements ResolverInterface
+final class RelativeFallbackResolver implements ResolverInterface
 {
     public const NS_SEPARATOR = '/';
 
-    private ResolverInterface $resolver;
-
-    public function __construct(ResolverInterface $resolver)
-    {
-        $this->resolver = $resolver;
+    public function __construct(
+        private readonly ResolverInterface $resolver,
+        private readonly ViewModel $viewModelHelper,
+    ) {
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function resolve($name, ?RendererInterface $renderer = null)
+    /** @inheritDoc */
+    public function resolve(string $name): string
     {
-        $plugin = [$renderer, 'plugin'];
-
-        if (! is_callable($plugin)) {
-            return false;
-        }
-
-        $helper = call_user_func($plugin, 'view_model');
-
-        if (! $helper instanceof ViewModelHelper) {
-            return false;
-        }
-
-        $currentModel = $helper->getCurrent();
+        $currentModel = $this->viewModelHelper->getCurrent();
 
         if (! $currentModel instanceof ModelInterface) {
-            return false;
+            throw TemplateCannotBeFound::byName($name);
         }
 
         $currentTemplate = $currentModel->getTemplate();
         $position        = strrpos($currentTemplate, self::NS_SEPARATOR);
 
         if ($position === false) {
-            return false;
+            throw TemplateCannotBeFound::byName($name);
         }
 
-        return $this->resolver->resolve(substr($currentTemplate, 0, $position) . self::NS_SEPARATOR . $name, $renderer);
+        $template = substr($currentTemplate, 0, $position) . self::NS_SEPARATOR . $name;
+
+        return $this->resolver->resolve($template);
     }
 }

--- a/src/Resolver/RelativeFallbackResolver.php
+++ b/src/Resolver/RelativeFallbackResolver.php
@@ -32,21 +32,43 @@ final class RelativeFallbackResolver implements ResolverInterface
     /** @inheritDoc */
     public function resolve(string $name): string
     {
+        $template = $this->resolveTemplateName($name);
+        if ($template === false) {
+            throw TemplateCannotBeFound::byName($name);
+        }
+
+        return $this->resolver->resolve($template);
+    }
+
+    public function has(string $name): bool
+    {
+        $template = $this->resolveTemplateName($name);
+        if ($template === false) {
+            return false;
+        }
+
+        return $this->resolver->has($template);
+    }
+
+    /**
+     * @param non-empty-string $name
+     * @return non-empty-string|false
+     */
+    private function resolveTemplateName(string $name): string|false
+    {
         $currentModel = $this->viewModelHelper->getCurrent();
 
         if (! $currentModel instanceof ModelInterface) {
-            throw TemplateCannotBeFound::byName($name);
+            return false;
         }
 
         $currentTemplate = $currentModel->getTemplate();
         $position        = strrpos($currentTemplate, self::NS_SEPARATOR);
 
         if ($position === false) {
-            throw TemplateCannotBeFound::byName($name);
+            return false;
         }
 
-        $template = substr($currentTemplate, 0, $position) . self::NS_SEPARATOR . $name;
-
-        return $this->resolver->resolve($template);
+        return substr($currentTemplate, 0, $position) . self::NS_SEPARATOR . $name;
     }
 }

--- a/src/Resolver/RelativeFallbackResolver.php
+++ b/src/Resolver/RelativeFallbackResolver.php
@@ -30,24 +30,14 @@ final class RelativeFallbackResolver implements ResolverInterface
     }
 
     /** @inheritDoc */
-    public function resolve(string $name): string
-    {
-        $template = $this->resolveTemplateName($name);
-        if ($template === false) {
-            throw TemplateCannotBeFound::byName($name);
-        }
-
-        return $this->resolver->resolve($template);
-    }
-
-    public function has(string $name): bool
+    public function resolve(string $name): string|false
     {
         $template = $this->resolveTemplateName($name);
         if ($template === false) {
             return false;
         }
 
-        return $this->resolver->has($template);
+        return $this->resolver->resolve($template);
     }
 
     /**

--- a/src/Resolver/ResolverInterface.php
+++ b/src/Resolver/ResolverInterface.php
@@ -14,4 +14,11 @@ interface ResolverInterface
      * @throws TemplateCannotBeFound If the given template cannot be found/resolved.
      */
     public function resolve(string $name): string;
+
+    /**
+     * Whether this resolver can resolve the template specified by $name
+     *
+     * @param non-empty-string $name
+     */
+    public function has(string $name): bool;
 }

--- a/src/Resolver/ResolverInterface.php
+++ b/src/Resolver/ResolverInterface.php
@@ -10,15 +10,7 @@ interface ResolverInterface
      * Resolve a template/pattern name to a resource the renderer can consume
      *
      * @param non-empty-string $name
-     * @return non-empty-string
-     * @throws TemplateCannotBeFound If the given template cannot be found/resolved.
+     * @return non-empty-string|false
      */
-    public function resolve(string $name): string;
-
-    /**
-     * Whether this resolver can resolve the template specified by $name
-     *
-     * @param non-empty-string $name
-     */
-    public function has(string $name): bool;
+    public function resolve(string $name): string|false;
 }

--- a/src/Resolver/ResolverInterface.php
+++ b/src/Resolver/ResolverInterface.php
@@ -4,17 +4,14 @@ declare(strict_types=1);
 
 namespace Laminas\View\Resolver;
 
-use Laminas\View\Renderer\RendererInterface as Renderer;
-
 interface ResolverInterface
 {
     /**
      * Resolve a template/pattern name to a resource the renderer can consume
      *
-     * In version 3.0 of this component, this method will guarantee a string return type or an exception will be thrown.
-     *
-     * @param  string $name
-     * @return string|false
+     * @param non-empty-string $name
+     * @return non-empty-string
+     * @throws TemplateCannotBeFound If the given template cannot be found/resolved.
      */
-    public function resolve($name, ?Renderer $renderer = null);
+    public function resolve(string $name): string;
 }

--- a/src/Resolver/TemplateCannotBeFound.php
+++ b/src/Resolver/TemplateCannotBeFound.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Laminas\View\Resolver;
 
-use Laminas\View\Exception\ExceptionInterface;
-use RuntimeException;
+use Laminas\View\Exception\RuntimeException;
 
 use function sprintf;
 
 /**
  * phpcs:disable WebimpressCodingStandard.NamingConventions.Exception
  */
-final class TemplateCannotBeFound extends RuntimeException implements ExceptionInterface
+final class TemplateCannotBeFound extends RuntimeException
 {
     public static function byName(string $name): self
     {

--- a/src/Resolver/TemplateCannotBeFound.php
+++ b/src/Resolver/TemplateCannotBeFound.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View\Resolver;
+
+use Laminas\View\Exception\ExceptionInterface;
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * phpcs:disable WebimpressCodingStandard.NamingConventions.Exception
+ */
+final class TemplateCannotBeFound extends RuntimeException implements ExceptionInterface
+{
+    public static function byName(string $name): self
+    {
+        return new self(sprintf(
+            'The template "%s" cannot be resolved',
+            $name,
+        ));
+    }
+}

--- a/src/Resolver/TemplateMapResolver.php
+++ b/src/Resolver/TemplateMapResolver.php
@@ -6,50 +6,31 @@ namespace Laminas\View\Resolver;
 
 use ArrayIterator;
 use IteratorAggregate;
-use Laminas\Stdlib\ArrayUtils;
-use Laminas\View\Exception;
-use Laminas\View\Renderer\RendererInterface as Renderer;
-use ReturnTypeWillChange;
+use Laminas\View\Exception\InvalidArgumentException;
 use Traversable;
 
 use function array_key_exists;
 use function array_replace_recursive;
-use function get_debug_type;
+use function is_array;
 use function is_iterable;
 use function is_string;
+use function iterator_to_array;
 use function sprintf;
-use function trigger_error;
 
-use const E_USER_DEPRECATED;
-
-/**
- * @implements IteratorAggregate<string, string>
- * @final
- */
-class TemplateMapResolver implements IteratorAggregate, ResolverInterface
+/** @implements IteratorAggregate<non-empty-string, non-empty-string> */
+final class TemplateMapResolver implements IteratorAggregate, ResolverInterface
 {
-    /** @var array<string, string> */
-    protected $map = [];
+    /** @var array<non-empty-string, non-empty-string> */
+    private array $map = [];
 
-    /**
-     * Constructor
-     *
-     * Instantiate and optionally populate template map.
-     *
-     * @param iterable<string, string> $map
-     */
-    public function __construct($map = [])
+    /** @param iterable<non-empty-string, non-empty-string> $map */
+    public function __construct(iterable $map = [])
     {
         $this->setMap($map);
     }
 
-    /**
-     * IteratorAggregate: return internal iterator
-     *
-     * @return Traversable<string, string>
-     */
-    #[ReturnTypeWillChange]
-    public function getIterator()
+    /** @return Traversable<non-empty-string, non-empty-string> */
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->map);
     }
@@ -57,99 +38,92 @@ class TemplateMapResolver implements IteratorAggregate, ResolverInterface
     /**
      * Set (overwrite) template map
      *
-     * Maps should be arrays or Traversable objects with name => path pairs
+     * Maps should be arrays with name => path pairs
      *
      * @param iterable<string, string> $map
-     * @throws Exception\InvalidArgumentException
-     * @return $this
+     * @throws InvalidArgumentException
      */
-    public function setMap($map)
+    public function setMap(iterable $map): void
     {
-        if (! is_iterable($map)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s: expects an array or Traversable, received "%s"',
-                __METHOD__,
-                get_debug_type($map),
+        foreach ($map as $name => $value) {
+            $this->assertMap($name, $value);
+        }
+
+        /** @psalm-var iterable<non-empty-string, non-empty-string> $map */
+
+        $this->map = is_array($map) ? $map : iterator_to_array($map);
+    }
+
+    /**
+     * @psalm-assert non-empty-string $name
+     * @psalm-assert non-empty-string $value
+     * @throws InvalidArgumentException
+     */
+    private function assertMap(int|string $name, mixed $value): void
+    {
+        if (! is_string($name) || ! is_string($value) || $name === '' || $value === '') {
+            throw new InvalidArgumentException(sprintf(
+                'Template names and values should be non-empty strings. Received `%s => %s`',
+                $name,
+                (string) $value,
             ));
         }
-
-        if ($map instanceof Traversable) {
-            $map = ArrayUtils::iteratorToArray($map);
-        }
-
-        $this->map = $map;
-        return $this;
     }
 
     /**
      * Add an entry to the map
      *
+     * A hash map can be passed as the first argument to perform a merge
+     *
      * @param string|iterable<string, string> $nameOrMap
-     * @param null|string $path
-     * @throws Exception\InvalidArgumentException
-     * @return $this
+     * @throws InvalidArgumentException
      */
-    public function add($nameOrMap, $path = null)
+    public function add(string|iterable $nameOrMap, string|null $path = null): void
     {
-        if (is_string($nameOrMap) && ($path === null || $path === '')) {
-            trigger_error(
-                'Using add() to remove individual templates is deprecated and will be removed in version 3.0',
-                E_USER_DEPRECATED,
-            );
-            unset($this->map[$nameOrMap]);
+        if (is_string($nameOrMap) && is_string($path)) {
+            $this->assertMap($nameOrMap, $path);
+            $this->merge([$nameOrMap => $path]);
 
-            return $this;
+            return;
         }
 
-        $map = is_string($nameOrMap) && is_string($path)
-            ? [$nameOrMap => $path]
-            : $nameOrMap;
+        if (is_iterable($nameOrMap)) {
+            $this->merge($nameOrMap);
 
-        if (! is_iterable($map)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s: expects a string, array, or Traversable for the first argument; received "%s"',
-                __METHOD__,
-                get_debug_type($map),
-            ));
+            return;
         }
 
-        $this->merge($map);
-
-        return $this;
+        throw new InvalidArgumentException(
+            'Either specify both $nameOrMap and $path as strings, or, $nameOrMap as an iterable'
+        );
     }
 
     /**
      * Merge internal map with provided map
      *
-     * @param  iterable<string, string> $map
-     * @throws Exception\InvalidArgumentException
-     * @return $this
+     * @param iterable<string, string> $map
+     * @throws InvalidArgumentException
      */
-    public function merge($map)
+    public function merge(iterable $map): void
     {
-        if (! is_iterable($map)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s: expects an array or Traversable, received "%s"',
-                __METHOD__,
-                get_debug_type($map),
-            ));
+        foreach ($map as $name => $value) {
+            $this->assertMap($name, $value);
         }
 
-        if ($map instanceof Traversable) {
-            $map = ArrayUtils::iteratorToArray($map);
-        }
+        $map = is_array($map) ? $map : iterator_to_array($map);
 
-        $this->map = array_replace_recursive($this->map, $map);
-        return $this;
+        /** @psalm-var array<non-empty-string, non-empty-string> $result */
+        $result = array_replace_recursive($this->map, $map);
+
+        $this->map = $result;
     }
 
     /**
      * Does the resolver contain an entry for the given name?
      *
-     * @param  string $name
-     * @return bool
+     * @param non-empty-string $name
      */
-    public function has($name)
+    public function has(string $name): bool
     {
         return array_key_exists($name, $this->map);
     }
@@ -157,15 +131,14 @@ class TemplateMapResolver implements IteratorAggregate, ResolverInterface
     /**
      * Retrieve a template path by name
      *
-     * @param  string $name
-     * @return false|string
-     * @throws Exception\DomainException If no entry exists.
+     * @param non-empty-string $name
+     * @return non-empty-string
+     * @throws TemplateCannotBeFound If no entry exists.
      */
-    public function get($name)
+    public function get(string $name): string
     {
         if (! $this->has($name)) {
-            // @TODO This should be exceptional
-            return false;
+            throw TemplateCannotBeFound::byName($name);
         }
 
         return $this->map[$name];
@@ -174,20 +147,14 @@ class TemplateMapResolver implements IteratorAggregate, ResolverInterface
     /**
      * Retrieve the template map
      *
-     * @return array<string, string>
+     * @return array<non-empty-string, non-empty-string>
      */
-    public function getMap()
+    public function getMap(): array
     {
         return $this->map;
     }
 
-    /**
-     * Resolve a template/pattern name to a resource the renderer can consume
-     *
-     * @param string $name
-     * @return false|string
-     */
-    public function resolve($name, ?Renderer $renderer = null)
+    public function resolve(string $name): string
     {
         return $this->get($name);
     }

--- a/src/Resolver/TemplateMapResolver.php
+++ b/src/Resolver/TemplateMapResolver.php
@@ -154,8 +154,8 @@ final class TemplateMapResolver implements IteratorAggregate, ResolverInterface
         return $this->map;
     }
 
-    public function resolve(string $name): string
+    public function resolve(string $name): string|false
     {
-        return $this->get($name);
+        return $this->map[$name] ?? false;
     }
 }

--- a/src/Resolver/TemplatePathStack.php
+++ b/src/Resolver/TemplatePathStack.php
@@ -145,6 +145,19 @@ final class TemplatePathStack implements ResolverInterface
     }
 
     /**
+     * Turn a template name into a possible filename based on configuration
+     */
+    private function normalizeTemplateName(string $name): string
+    {
+        // Ensure we have the expected file extension
+        if (pathinfo($name, PATHINFO_EXTENSION) === '') {
+            $name .= '.' . $this->defaultSuffix;
+        }
+
+        return $name;
+    }
+
+    /**
      * Retrieve the filesystem path to a view script
      *
      * @throws DomainException If the template requested includes directory traversal and LFI protection is on.
@@ -154,7 +167,7 @@ final class TemplatePathStack implements ResolverInterface
     {
         if ($this->lfiProtectionOn && preg_match('#\.\.[\\\/]#', $name)) {
             throw new DomainException(
-                'Requested scripts may not include parent directory traversal ("../", "..\\" notation)'
+                'Requested scripts may not include parent directory traversal ("../", "..\\" notation)',
             );
         }
 
@@ -162,11 +175,23 @@ final class TemplatePathStack implements ResolverInterface
             throw TemplateCannotBeFound::byName($name);
         }
 
-        // Ensure we have the expected file extension
-        if (pathinfo($name, PATHINFO_EXTENSION) === '') {
-            $name .= '.' . $this->defaultSuffix;
+        $name = $this->normalizeTemplateName($name);
+        $path = $this->resolveToPath($name);
+        if ($path !== false) {
+            return $path;
         }
 
+        throw TemplateCannotBeFound::byName($name);
+    }
+
+    public function has(string $name): bool
+    {
+        return $this->resolveToPath($this->normalizeTemplateName($name)) !== false;
+    }
+
+    /** @return non-empty-string|false */
+    private function resolveToPath(string $name): string|false
+    {
         foreach ($this->paths as $path) {
             $file = new SplFileInfo($path . $name);
             if ($file->isReadable()) {
@@ -184,6 +209,6 @@ final class TemplatePathStack implements ResolverInterface
             }
         }
 
-        throw TemplateCannotBeFound::byName($name);
+        return false;
     }
 }

--- a/src/Resolver/TemplatePathStack.php
+++ b/src/Resolver/TemplatePathStack.php
@@ -4,26 +4,20 @@ declare(strict_types=1);
 
 namespace Laminas\View\Resolver;
 
-use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\SplStack;
 use Laminas\View\Exception;
-use Laminas\View\Renderer\RendererInterface as Renderer;
+use Laminas\View\Exception\DomainException;
 use SplFileInfo;
-use Traversable;
 
-use function array_change_key_case;
+use function assert;
 use function count;
 use function file_exists;
-use function get_debug_type;
-use function gettype;
 use function is_array;
-use function is_string;
 use function ltrim;
 use function pathinfo;
 use function preg_match;
 use function rtrim;
-use function sprintf;
-use function strpos;
+use function str_starts_with;
 
 use const DIRECTORY_SEPARATOR;
 use const PATHINFO_EXTENSION;
@@ -31,126 +25,57 @@ use const PATHINFO_EXTENSION;
 /**
  * Resolves view scripts based on a stack of paths
  *
- * @psalm-type PathStack = SplStack<string>
+ * @psalm-type PathStack = SplStack<non-empty-string>
  * @psalm-type Options = array{
  *     lfi_protection?: bool,
- *     script_paths?: list<string>,
- *     default_suffix?: string,
- *     use_stream_wrapper?: bool,
+ *     script_paths?: list<non-empty-string>,
+ *     default_suffix?: non-empty-string,
  * }
- * @final
  */
-class TemplatePathStack implements ResolverInterface
+final class TemplatePathStack implements ResolverInterface
 {
-    /** @deprecated */
-    public const FAILURE_NO_PATHS = 'TemplatePathStack_Failure_No_Paths';
-    /** @deprecated */
-    public const FAILURE_NOT_FOUND = 'TemplatePathStack_Failure_Not_Found';
-
     /**
      * Default suffix to use
      *
      * Appends this suffix if the template requested does not use it.
      *
-     * @var string
+     * @var non-empty-string
      */
-    protected $defaultSuffix = 'phtml';
+    private string $defaultSuffix;
 
     /** @var PathStack */
-    protected $paths;
+    private SplStack $paths;
 
     /**
-     * Reason for last lookup failure
-     *
-     * @deprecated This property will be removed in v3.0 of this component.
-     *
-     * @var false|string
+     * Flag indicating whether LFI protection for rendering view scripts is enabled
      */
-    protected $lastLookupFailure = false;
+    private bool $lfiProtectionOn;
 
-    /**
-     * Flag indicating whether or not LFI protection for rendering view scripts is enabled
-     *
-     * @var bool
-     */
-    protected $lfiProtectionOn = true;
-
-    /**@-*/
-
-    /** @param  null|Options|Traversable<string, mixed> $options */
-    public function __construct($options = null)
+    /** @param Options $options */
+    public function __construct(array $options = [])
     {
+        $suffix = ltrim($options['default_suffix'] ?? 'phtml', '.');
+        assert($suffix !== '');
+        $this->defaultSuffix   = $suffix;
+        $this->lfiProtectionOn = $options['lfi_protection'] ?? true;
+
         /** @psalm-var PathStack $paths */
         $paths       = new SplStack();
         $this->paths = $paths;
-        if (null !== $options) {
-            $this->setOptions($options);
+
+        $addPaths = $options['script_paths'] ?? null;
+        if (is_array($addPaths)) {
+            $this->addPaths($addPaths);
         }
-    }
-
-    /**
-     * Configure object
-     *
-     * @param  Options|Traversable<string, mixed> $options
-     * @return void
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setOptions($options)
-    {
-        /** @psalm-suppress DocblockTypeContradiction */
-        if (! is_array($options) && ! $options instanceof Traversable) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'Expected array or Traversable object; received "%s"',
-                get_debug_type($options),
-            ));
-        }
-
-        $options = $options instanceof Traversable ? ArrayUtils::iteratorToArray($options) : $options;
-        $options = array_change_key_case($options);
-
-        if (isset($options['lfi_protection'])) {
-            $this->setLfiProtection($options['lfi_protection']);
-        }
-
-        if (isset($options['script_paths'])) {
-            $this->addPaths($options['script_paths']);
-        }
-
-        if (isset($options['default_suffix'])) {
-            $this->setDefaultSuffix($options['default_suffix']);
-        }
-    }
-
-    /**
-     * Set default file suffix
-     *
-     * @param  string $defaultSuffix
-     * @return $this
-     */
-    public function setDefaultSuffix($defaultSuffix)
-    {
-        $this->defaultSuffix = (string) $defaultSuffix;
-        $this->defaultSuffix = ltrim($this->defaultSuffix, '.');
-        return $this;
-    }
-
-    /**
-     * Get default file suffix
-     *
-     * @return string
-     */
-    public function getDefaultSuffix()
-    {
-        return $this->defaultSuffix;
     }
 
     /**
      * Add many paths to the stack at once
      *
-     * @param  list<string> $paths
+     * @param  list<non-empty-string> $paths
      * @return $this
      */
-    public function addPaths(array $paths)
+    public function addPaths(array $paths): self
     {
         foreach ($paths as $path) {
             $this->addPath($path);
@@ -161,70 +86,48 @@ class TemplatePathStack implements ResolverInterface
     /**
      * Reset the path stack to the paths provided
      *
-     * @param  PathStack|list<string> $paths
+     * @param list<non-empty-string> $paths
      * @return TemplatePathStack
      * @throws Exception\InvalidArgumentException
      */
-    public function setPaths($paths)
+    public function setPaths(array $paths): self
     {
-        if ($paths instanceof SplStack) {
-            $this->paths = $paths;
+        $this->clearPaths();
+        $this->addPaths($paths);
 
-            return $this;
-        }
-
-        /** @psalm-suppress RedundantConditionGivenDocblockType */
-        if (is_array($paths)) {
-            $this->clearPaths();
-            $this->addPaths($paths);
-
-            return $this;
-        }
-
-        throw new Exception\InvalidArgumentException(
-            "Invalid argument provided for \$paths, expecting either an array or SplStack object"
-        );
+        return $this;
     }
 
     /**
      * Normalize a path for insertion in the stack
      *
-     * @param  string $path
-     * @return string
+     * @return non-empty-string
      */
-    public static function normalizePath($path)
+    private static function normalizePath(string $path): string
     {
-        $path  = rtrim($path, '/');
-        $path  = rtrim($path, '\\');
+        $path  = rtrim($path, '/\\');
         $path .= DIRECTORY_SEPARATOR;
+
         return $path;
     }
 
     /**
      * Add a single path to the stack
      *
-     * @param  string $path
+     * @param non-empty-string $path
      * @return $this
-     * @throws Exception\InvalidArgumentException
      */
-    public function addPath($path)
+    public function addPath(string $path): self
     {
-        if (! is_string($path)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'Invalid path provided; must be a string, received %s',
-                gettype($path)
-            ));
-        }
-        $this->paths->push(static::normalizePath($path));
+        $this->paths->push(self::normalizePath($path));
+
         return $this;
     }
 
     /**
      * Clear all paths
-     *
-     * @return void
      */
-    public function clearPaths()
+    public function clearPaths(): void
     {
         /** @psalm-var PathStack $paths */
         $paths       = new SplStack();
@@ -236,67 +139,40 @@ class TemplatePathStack implements ResolverInterface
      *
      * @return PathStack
      */
-    public function getPaths()
+    public function getPaths(): SplStack
     {
         return $this->paths;
     }
 
     /**
-     * Set LFI protection flag
-     *
-     * @param  bool $flag
-     * @return TemplatePathStack
-     */
-    public function setLfiProtection($flag)
-    {
-        $this->lfiProtectionOn = (bool) $flag;
-        return $this;
-    }
-
-    /**
-     * Return status of LFI protection flag
-     *
-     * @return bool
-     */
-    public function isLfiProtectionOn()
-    {
-        return $this->lfiProtectionOn;
-    }
-
-    /**
      * Retrieve the filesystem path to a view script
      *
-     * @param  string $name
-     * @return string
-     * @throws Exception\DomainException
+     * @throws DomainException If the template requested includes directory traversal and LFI protection is on.
+     * @throws TemplateCannotBeFound
      */
-    public function resolve($name, ?Renderer $renderer = null)
+    public function resolve(string $name): string
     {
-        $this->lastLookupFailure = false;
-
-        if ($this->isLfiProtectionOn() && preg_match('#\.\.[\\\/]#', $name)) {
-            throw new Exception\DomainException(
+        if ($this->lfiProtectionOn && preg_match('#\.\.[\\\/]#', $name)) {
+            throw new DomainException(
                 'Requested scripts may not include parent directory traversal ("../", "..\\" notation)'
             );
         }
 
         if (! count($this->paths)) {
-            $this->lastLookupFailure = static::FAILURE_NO_PATHS;
-            // @TODO In version 3, this should become an exception
-            return false;
+            throw TemplateCannotBeFound::byName($name);
         }
 
         // Ensure we have the expected file extension
-        $defaultSuffix = $this->getDefaultSuffix();
         if (pathinfo($name, PATHINFO_EXTENSION) === '') {
-            $name .= '.' . $defaultSuffix;
+            $name .= '.' . $this->defaultSuffix;
         }
 
         foreach ($this->paths as $path) {
             $file = new SplFileInfo($path . $name);
             if ($file->isReadable()) {
                 // Found! Return it.
-                if (($filePath = $file->getRealPath()) === false && 0 === strpos($path, 'phar://')) {
+                $filePath = $file->getRealPath();
+                if ($filePath === false && str_starts_with($path, 'phar://')) {
                     // Do not try to expand phar paths (realpath + phars == fail)
                     $filePath = $path . $name;
                     if (! file_exists($filePath)) {
@@ -308,21 +184,6 @@ class TemplatePathStack implements ResolverInterface
             }
         }
 
-        $this->lastLookupFailure = static::FAILURE_NOT_FOUND;
-        // @TODO This should become an exception in v3.0
-        return false;
-    }
-
-    /**
-     * Get the last lookup failure message, if any
-     *
-     * @deprecated In version 3.0, this resolver will throw exceptions instead of
-     *             incorrectly returning false from resolve()
-     *
-     * @return false|string
-     */
-    public function getLastLookupFailure()
-    {
-        return $this->lastLookupFailure;
+        throw TemplateCannotBeFound::byName($name);
     }
 }

--- a/src/Resolver/TemplatePathStack.php
+++ b/src/Resolver/TemplatePathStack.php
@@ -161,9 +161,8 @@ final class TemplatePathStack implements ResolverInterface
      * Retrieve the filesystem path to a view script
      *
      * @throws DomainException If the template requested includes directory traversal and LFI protection is on.
-     * @throws TemplateCannotBeFound
      */
-    public function resolve(string $name): string
+    public function resolve(string $name): string|false
     {
         if ($this->lfiProtectionOn && preg_match('#\.\.[\\\/]#', $name)) {
             throw new DomainException(
@@ -172,21 +171,12 @@ final class TemplatePathStack implements ResolverInterface
         }
 
         if (! count($this->paths)) {
-            throw TemplateCannotBeFound::byName($name);
+            return false;
         }
 
         $name = $this->normalizeTemplateName($name);
-        $path = $this->resolveToPath($name);
-        if ($path !== false) {
-            return $path;
-        }
 
-        throw TemplateCannotBeFound::byName($name);
-    }
-
-    public function has(string $name): bool
-    {
-        return $this->resolveToPath($this->normalizeTemplateName($name)) !== false;
+        return $this->resolveToPath($name);
     }
 
     /** @return non-empty-string|false */

--- a/test/Helper/PaginationControlTest.php
+++ b/test/Helper/PaginationControlTest.php
@@ -109,9 +109,7 @@ final class PaginationControlTest extends TestCase
     public function testAcceptsViewPartialInOtherModule(): void
     {
         $this->expectException(Exception\RuntimeException::class);
-        $this->expectExceptionMessage(
-            'Unable to render template "partial.phtml"; resolver could not resolve to a file',
-        );
+        $this->expectExceptionMessage('"partial.phtml"');
         $this->viewHelper->__invoke($this->paginator, null, ['partial.phtml', 'test']);
     }
 

--- a/test/PhpRendererTest.php
+++ b/test/PhpRendererTest.php
@@ -348,13 +348,12 @@ final class PhpRendererTest extends TestCase
     {
         $this->renderer->vars()->assign(['foo' => '10 > 9']);
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('could not resolve');
+        $this->expectExceptionMessage('"should-not-find-this"');
         $this->renderer->render('should-not-find-this');
     }
 
     /**
-     * @return string[][]
-     * @psalm-return array{0: array{0: '/does/not/exists'}, 1: array{0: '.'}}
+     * @return list<array{0: non-empty-string}>
      */
     public static function invalidTemplateFiles(): array
     {
@@ -364,6 +363,7 @@ final class PhpRendererTest extends TestCase
         ];
     }
 
+    /** @param non-empty-string $template */
     #[DataProvider('invalidTemplateFiles')]
     public function testRendererRaisesExceptionIfResolvedTemplateIsInvalid(string $template): void
     {

--- a/test/Resolver/AggregateResolverTest.php
+++ b/test/Resolver/AggregateResolverTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LaminasTest\View\Resolver;
 
 use Laminas\View\Resolver\AggregateResolver;
-use Laminas\View\Resolver\TemplateCannotBeFound;
 use Laminas\View\Resolver\TemplateMapResolver;
 use PHPUnit\Framework\TestCase;
 
@@ -37,8 +36,7 @@ final class AggregateResolverTest extends TestCase
         $resolver->attach(new TemplateMapResolver([
             'bar' => 'baz',
         ]));
-        self::assertTrue($resolver->has('bar'));
-        self::assertTrue($resolver->has('foo'));
+
         self::assertEquals('baz', $resolver->resolve('bar'));
     }
 
@@ -48,9 +46,7 @@ final class AggregateResolverTest extends TestCase
         $resolver->attach(new TemplateMapResolver([
             'foo' => 'bar',
         ]));
-        self::assertFalse($resolver->has('bar'));
-        $this->expectException(TemplateCannotBeFound::class);
-        $resolver->resolve('bar');
+        self::assertFalse($resolver->resolve('bar'));
     }
 
     public function testResolvesInOrderOfPriorityProvided(): void
@@ -69,15 +65,13 @@ final class AggregateResolverTest extends TestCase
                  ->attach($barResolver, 100)
                  ->attach($bazResolver);
 
-        self::assertTrue($resolver->has('bar'));
         self::assertSame('bar', $resolver->resolve('bar'));
     }
 
     public function testExceptionThrownWhenAttemptingToResolveWhenNoResolversAreAttached(): void
     {
         $resolver = new AggregateResolver();
-        $this->expectException(TemplateCannotBeFound::class);
-        $resolver->resolve('foo');
+        self::assertFalse($resolver->resolve('foo'));
     }
 
     public function testResolversCanBeSuppliedInTheConstructor(): void

--- a/test/Resolver/AggregateResolverTest.php
+++ b/test/Resolver/AggregateResolverTest.php
@@ -4,106 +4,63 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Resolver;
 
-use Exception;
-use Laminas\View\Resolver;
+use Laminas\View\Resolver\AggregateResolver;
+use Laminas\View\Resolver\TemplateCannotBeFound;
+use Laminas\View\Resolver\TemplateMapResolver;
 use PHPUnit\Framework\TestCase;
 
 final class AggregateResolverTest extends TestCase
 {
     public function testAggregateIsEmptyByDefault(): void
     {
-        $resolver = new Resolver\AggregateResolver();
+        $resolver = new AggregateResolver();
         $this->assertCount(0, $resolver);
     }
 
     public function testCanAttachResolvers(): void
     {
-        $resolver = new Resolver\AggregateResolver();
-        $resolver->attach(new Resolver\TemplateMapResolver());
+        $resolver = new AggregateResolver();
+        $resolver->attach(new TemplateMapResolver());
         $this->assertCount(1, $resolver);
-        $resolver->attach(new Resolver\TemplateMapResolver());
+        $resolver->attach(new TemplateMapResolver());
         $this->assertCount(2, $resolver);
+
+        self::assertContainsOnlyInstancesOf(TemplateMapResolver::class, $resolver);
     }
 
     public function testReturnsNonFalseValueWhenAtLeastOneResolverSucceeds(): void
     {
-        $resolver = new Resolver\AggregateResolver();
-        $resolver->attach(new Resolver\TemplateMapResolver([
+        $resolver = new AggregateResolver();
+        $resolver->attach(new TemplateMapResolver([
             'foo' => 'bar',
         ]));
-        $resolver->attach(new Resolver\TemplateMapResolver([
+        $resolver->attach(new TemplateMapResolver([
             'bar' => 'baz',
         ]));
         $test = $resolver->resolve('bar');
         $this->assertEquals('baz', $test);
     }
 
-    public function testLastSuccessfulResolverIsNullInitially(): void
+    public function testExceptionThrownWhenNoResolverSucceeds(): void
     {
-        $resolver = new Resolver\AggregateResolver();
-        $this->assertNull($resolver->getLastSuccessfulResolver());
-    }
-
-    public function testCanAccessResolverThatLastSucceeded(): void
-    {
-        $resolver    = new Resolver\AggregateResolver();
-        $fooResolver = new Resolver\TemplateMapResolver([
-            'foo' => 'bar',
-        ]);
-        $barResolver = new Resolver\TemplateMapResolver([
-            'bar' => 'baz',
-        ]);
-        $bazResolver = new Resolver\TemplateMapResolver([
-            'baz' => 'bat',
-        ]);
-        $resolver->attach($fooResolver)
-                 ->attach($barResolver)
-                 ->attach($bazResolver);
-
-        $test = $resolver->resolve('bar');
-        $this->assertEquals('baz', $test);
-        $this->assertSame($barResolver, $resolver->getLastSuccessfulResolver());
-    }
-
-    public function testReturnsFalseWhenNoResolverSucceeds(): void
-    {
-        $resolver = new Resolver\AggregateResolver();
-        $resolver->attach(new Resolver\TemplateMapResolver([
+        $resolver = new AggregateResolver();
+        $resolver->attach(new TemplateMapResolver([
             'foo' => 'bar',
         ]));
-        $this->assertFalse($resolver->resolve('bar'));
-        $this->assertEquals(Resolver\AggregateResolver::FAILURE_NOT_FOUND, $resolver->getLastLookupFailure());
-    }
-
-    public function testLastSuccessfulResolverIsNullWhenNoResolverSucceeds(): void
-    {
-        $resolver    = new Resolver\AggregateResolver();
-        $fooResolver = new Resolver\TemplateMapResolver([
-            'foo' => 'bar',
-        ]);
-        $resolver->attach($fooResolver);
-        $resolver->resolve('foo');
-        $this->assertSame($fooResolver, $resolver->getLastSuccessfulResolver());
-
-        try {
-            $resolver->resolve('bar');
-            $this->fail('Should not have resolved!');
-        } catch (Exception $e) {
-            // exception is expected
-        }
-        $this->assertNull($resolver->getLastSuccessfulResolver());
+        $this->expectException(TemplateCannotBeFound::class);
+        $resolver->resolve('bar');
     }
 
     public function testResolvesInOrderOfPriorityProvided(): void
     {
-        $resolver    = new Resolver\AggregateResolver();
-        $fooResolver = new Resolver\TemplateMapResolver([
+        $resolver    = new AggregateResolver();
+        $fooResolver = new TemplateMapResolver([
             'bar' => 'foo',
         ]);
-        $barResolver = new Resolver\TemplateMapResolver([
+        $barResolver = new TemplateMapResolver([
             'bar' => 'bar',
         ]);
-        $bazResolver = new Resolver\TemplateMapResolver([
+        $bazResolver = new TemplateMapResolver([
             'bar' => 'baz',
         ]);
         $resolver->attach($fooResolver, -1)
@@ -114,10 +71,44 @@ final class AggregateResolverTest extends TestCase
         $this->assertEquals('bar', $test);
     }
 
-    public function testReturnsFalseWhenAttemptingToResolveWhenNoResolversAreAttached(): void
+    public function testExceptionThrownWhenAttemptingToResolveWhenNoResolversAreAttached(): void
     {
-        $resolver = new Resolver\AggregateResolver();
-        $this->assertFalse($resolver->resolve('foo'));
-        $this->assertEquals(Resolver\AggregateResolver::FAILURE_NO_RESOLVERS, $resolver->getLastLookupFailure());
+        $resolver = new AggregateResolver();
+        $this->expectException(TemplateCannotBeFound::class);
+        $resolver->resolve('foo');
+    }
+
+    public function testResolversCanBeSuppliedInTheConstructor(): void
+    {
+        $fooResolver = new TemplateMapResolver([
+            'bar' => 'foo',
+        ]);
+        $barResolver = new TemplateMapResolver([
+            'bar' => 'bar',
+        ]);
+
+        $resolver = new AggregateResolver([
+            $barResolver,
+            $fooResolver,
+        ]);
+
+        self::assertSame('bar', $resolver->resolve('bar'));
+    }
+
+    public function testConstructorResolversAreResolvedInFIFOOrder(): void
+    {
+        $a = new TemplateMapResolver([
+            'bar' => '1',
+        ]);
+        $b = new TemplateMapResolver([
+            'bar' => '2',
+        ]);
+        $c = new TemplateMapResolver([
+            'bar' => '3',
+        ]);
+
+        $resolver = new AggregateResolver([$c, $b, $a]);
+
+        self::assertSame('3', $resolver->resolve('bar'));
     }
 }

--- a/test/Resolver/AggregateResolverTest.php
+++ b/test/Resolver/AggregateResolverTest.php
@@ -14,21 +14,21 @@ final class AggregateResolverTest extends TestCase
     public function testAggregateIsEmptyByDefault(): void
     {
         $resolver = new AggregateResolver();
-        $this->assertCount(0, $resolver);
+        self::assertCount(0, $resolver);
     }
 
     public function testCanAttachResolvers(): void
     {
         $resolver = new AggregateResolver();
         $resolver->attach(new TemplateMapResolver());
-        $this->assertCount(1, $resolver);
+        self::assertCount(1, $resolver);
         $resolver->attach(new TemplateMapResolver());
-        $this->assertCount(2, $resolver);
+        self::assertCount(2, $resolver);
 
         self::assertContainsOnlyInstancesOf(TemplateMapResolver::class, $resolver);
     }
 
-    public function testReturnsNonFalseValueWhenAtLeastOneResolverSucceeds(): void
+    public function testSuccessfulResolution(): void
     {
         $resolver = new AggregateResolver();
         $resolver->attach(new TemplateMapResolver([
@@ -37,8 +37,9 @@ final class AggregateResolverTest extends TestCase
         $resolver->attach(new TemplateMapResolver([
             'bar' => 'baz',
         ]));
-        $test = $resolver->resolve('bar');
-        $this->assertEquals('baz', $test);
+        self::assertTrue($resolver->has('bar'));
+        self::assertTrue($resolver->has('foo'));
+        self::assertEquals('baz', $resolver->resolve('bar'));
     }
 
     public function testExceptionThrownWhenNoResolverSucceeds(): void
@@ -47,6 +48,7 @@ final class AggregateResolverTest extends TestCase
         $resolver->attach(new TemplateMapResolver([
             'foo' => 'bar',
         ]));
+        self::assertFalse($resolver->has('bar'));
         $this->expectException(TemplateCannotBeFound::class);
         $resolver->resolve('bar');
     }
@@ -67,8 +69,8 @@ final class AggregateResolverTest extends TestCase
                  ->attach($barResolver, 100)
                  ->attach($bazResolver);
 
-        $test = $resolver->resolve('bar');
-        $this->assertEquals('bar', $test);
+        self::assertTrue($resolver->has('bar'));
+        self::assertSame('bar', $resolver->resolve('bar'));
     }
 
     public function testExceptionThrownWhenAttemptingToResolveWhenNoResolversAreAttached(): void

--- a/test/Resolver/Factory/AggregateResolverFactoryTest.php
+++ b/test/Resolver/Factory/AggregateResolverFactoryTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Resolver\Factory;
+
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\View\ConfigProvider;
+use Laminas\View\Helper\ViewModel;
+use Laminas\View\HelperPluginManager;
+use Laminas\View\Model\ViewModel as Model;
+use Laminas\View\Resolver\Factory\AggregateResolverFactory;
+use PHPUnit\Framework\TestCase;
+
+use function array_merge_recursive;
+use function realpath;
+
+final class AggregateResolverFactoryTest extends TestCase
+{
+    private static function containerWithConfig(array $config): ServiceManager
+    {
+        $config                             = array_merge_recursive(
+            (new ConfigProvider())->__invoke(),
+            $config,
+        );
+        $config['dependencies']['services'] = ['config' => $config];
+
+        return new ServiceManager($config['dependencies']);
+    }
+
+    public function testMapsAreResolvedFirstByDefault(): void
+    {
+        $templates = realpath(__DIR__ . '/../../_templates');
+        self::assertNotFalse($templates);
+
+        $container = self::containerWithConfig([
+            'view_manager' => [
+                'template_map'        => [
+                    'layout' => $templates . '/name-space/bar.phtml',
+                ],
+                'template_path_stack' => [
+                    $templates, // layout.phtml is in this directory and would otherwise resolve.
+                ],
+            ],
+        ]);
+
+        $factory  = new AggregateResolverFactory();
+        $resolver = $factory($container);
+
+        self::assertSame(
+            $templates . '/name-space/bar.phtml',
+            $resolver->resolve('layout'),
+        );
+    }
+
+    public function testPathStackResolvesBeforePrefixStack(): void
+    {
+        $templates = realpath(__DIR__ . '/../../_templates');
+        self::assertNotFalse($templates);
+
+        // Both directories contain a file named 'bar.phtml'
+        $container = self::containerWithConfig([
+            'view_manager' => [
+                'template_path_stack'        => [
+                    $templates,
+                ],
+                'prefix_template_path_stack' => [
+                    'name-space' => $templates . '/prefix-path-stack-resolver',
+                ],
+            ],
+        ]);
+
+        $factory  = new AggregateResolverFactory();
+        $resolver = $factory($container);
+
+        self::assertSame(
+            $templates . '/name-space/bar.phtml',
+            $resolver->resolve('name-space/bar'),
+        );
+    }
+
+    public function testRelativeFallbackResolversAreUsedAndTheViewModelPluginIsCorrectlyComposed(): void
+    {
+        $container = self::containerWithConfig([
+            'templates' => [
+                'map' => [
+                    'view/relative' => 'expect.phtml',
+                ],
+            ],
+        ]);
+
+        $view = new Model();
+        $view->setTemplate('view/some-file.phtml');
+
+        $factory  = new AggregateResolverFactory();
+        $resolver = $factory($container);
+
+        $helper = $container->get(HelperPluginManager::class)->get(ViewModel::class);
+        $helper->setCurrent($view);
+
+        self::assertSame(
+            'expect.phtml',
+            $resolver->resolve('relative'),
+        );
+    }
+}

--- a/test/Resolver/Factory/AggregateResolverFactoryTest.php
+++ b/test/Resolver/Factory/AggregateResolverFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Resolver\Factory;
+namespace LaminasTest\View\Resolver\Factory;
 
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\ConfigProvider;

--- a/test/Resolver/Factory/PrefixPathStackResolverFactoryTest.php
+++ b/test/Resolver/Factory/PrefixPathStackResolverFactoryTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Resolver\Factory;
+
+use Laminas\View\Resolver\Factory\PrefixPathStackResolverFactory;
+use Laminas\View\Resolver\TemplateCannotBeFound;
+use LaminasTest\View\TestAsset\InMemoryContainer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function is_string;
+use function realpath;
+
+final class PrefixPathStackResolverFactoryTest extends TestCase
+{
+    /** @return array<string, array{0: array, 1: non-empty-string, 2: null|string}> */
+    public static function configProvider(): array
+    {
+        $templates = realpath(__DIR__ . '/../../_templates/prefix-path-stack-resolver');
+        self::assertNotFalse($templates);
+
+        return [
+            'Typical MVC Config'    => [
+                [
+                    'view_manager' => [
+                        'prefix_template_path_stack' => [
+                            'muppets' => $templates,
+                        ],
+                    ],
+                ],
+                'muppets/bar',
+                $templates . '/bar.phtml',
+            ],
+            'Mezzio Default Suffix' => [
+                [
+                    'view_manager' => [
+                        'prefix_template_path_stack' => [
+                            'muppets' => $templates,
+                        ],
+                    ],
+                    'templates'    => [
+                        'extension' => 'php',
+                    ],
+                ],
+                'muppets/foo',
+                $templates . '/foo.php',
+            ],
+            'MVC Default Suffix'    => [
+                [
+                    'view_manager' => [
+                        'default_template_suffix'    => 'php',
+                        'prefix_template_path_stack' => [
+                            'muppets' => $templates,
+                        ],
+                    ],
+                ],
+                'muppets/foo',
+                $templates . '/foo.php',
+            ],
+            'Empty Config'          => [
+                [],
+                'foo',
+                null,
+            ],
+        ];
+    }
+
+    /** @param non-empty-string $input */
+    #[DataProvider('configProvider')]
+    public function testFactory(array $config, string $input, string|null $expect): void
+    {
+        $container = new InMemoryContainer();
+        $container->set('config', $config);
+
+        $factory  = new PrefixPathStackResolverFactory();
+        $resolver = $factory->__invoke($container);
+
+        if (is_string($expect)) {
+            self::assertSame($expect, $resolver->resolve($input));
+
+            return;
+        }
+
+        $this->expectException(TemplateCannotBeFound::class);
+        $resolver->resolve($input);
+    }
+}

--- a/test/Resolver/Factory/PrefixPathStackResolverFactoryTest.php
+++ b/test/Resolver/Factory/PrefixPathStackResolverFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Resolver\Factory;
+namespace LaminasTest\View\Resolver\Factory;
 
 use Laminas\View\Resolver\Factory\PrefixPathStackResolverFactory;
 use Laminas\View\Resolver\TemplateCannotBeFound;

--- a/test/Resolver/Factory/PrefixPathStackResolverFactoryTest.php
+++ b/test/Resolver/Factory/PrefixPathStackResolverFactoryTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LaminasTest\View\Resolver\Factory;
 
 use Laminas\View\Resolver\Factory\PrefixPathStackResolverFactory;
-use Laminas\View\Resolver\TemplateCannotBeFound;
 use LaminasTest\View\TestAsset\InMemoryContainer;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -83,7 +82,6 @@ final class PrefixPathStackResolverFactoryTest extends TestCase
             return;
         }
 
-        $this->expectException(TemplateCannotBeFound::class);
-        $resolver->resolve($input);
+        self::assertFalse($resolver->resolve($input));
     }
 }

--- a/test/Resolver/Factory/TemplateMapResolverFactoryTest.php
+++ b/test/Resolver/Factory/TemplateMapResolverFactoryTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Resolver\Factory;
+
+use Laminas\View\Resolver\Factory\TemplateMapResolverFactory;
+use Laminas\View\Resolver\TemplateCannotBeFound;
+use LaminasTest\View\TestAsset\InMemoryContainer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function is_string;
+
+final class TemplateMapResolverFactoryTest extends TestCase
+{
+    /** @return array<string, array{0: array, 1: non-empty-string, 2: null|string}> */
+    public static function configProvider(): array
+    {
+        return [
+            'Typical MVC Config'         => [
+                [
+                    'view_manager' => [
+                        'template_map' => [
+                            'foo' => 'bar',
+                        ],
+                    ],
+                ],
+                'foo',
+                'bar',
+            ],
+            'Typical Mezzio Config'      => [
+                [
+                    'templates' => [
+                        'map' => [
+                            'foo' => 'bar',
+                        ],
+                    ],
+                ],
+                'foo',
+                'bar',
+            ],
+            'Empty Config'               => [
+                [],
+                'foo',
+                null,
+            ],
+            'Both specified means merge' => [
+                [
+                    'view_manager' => [
+                        'template_map' => [
+                            'foo' => 'mvc',
+                        ],
+                    ],
+                    'templates'    => [
+                        'map' => [
+                            'foo' => 'mezzio',
+                        ],
+                    ],
+                ],
+                'foo',
+                'mezzio',
+            ],
+        ];
+    }
+
+    /** @param non-empty-string $input */
+    #[DataProvider('configProvider')]
+    public function testFactory(array $config, string $input, string|null $expect): void
+    {
+        $container = new InMemoryContainer();
+        $container->set('config', $config);
+
+        $factory  = new TemplateMapResolverFactory();
+        $resolver = $factory->__invoke($container);
+
+        if (is_string($expect)) {
+            self::assertSame($expect, $resolver->resolve($input));
+
+            return;
+        }
+
+        $this->expectException(TemplateCannotBeFound::class);
+        $resolver->resolve($input);
+    }
+}

--- a/test/Resolver/Factory/TemplateMapResolverFactoryTest.php
+++ b/test/Resolver/Factory/TemplateMapResolverFactoryTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LaminasTest\View\Resolver\Factory;
 
 use Laminas\View\Resolver\Factory\TemplateMapResolverFactory;
-use Laminas\View\Resolver\TemplateCannotBeFound;
 use LaminasTest\View\TestAsset\InMemoryContainer;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -80,7 +79,6 @@ final class TemplateMapResolverFactoryTest extends TestCase
             return;
         }
 
-        $this->expectException(TemplateCannotBeFound::class);
-        $resolver->resolve($input);
+        self::assertFalse($resolver->resolve($input));
     }
 }

--- a/test/Resolver/Factory/TemplateMapResolverFactoryTest.php
+++ b/test/Resolver/Factory/TemplateMapResolverFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Resolver\Factory;
+namespace LaminasTest\View\Resolver\Factory;
 
 use Laminas\View\Resolver\Factory\TemplateMapResolverFactory;
 use Laminas\View\Resolver\TemplateCannotBeFound;

--- a/test/Resolver/Factory/TemplatePathStackResolverFactoryTest.php
+++ b/test/Resolver/Factory/TemplatePathStackResolverFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Resolver\Factory;
+namespace LaminasTest\View\Resolver\Factory;
 
 use Laminas\View\Resolver\Factory\TemplatePathStackResolverFactory;
 use Laminas\View\Resolver\TemplateCannotBeFound;

--- a/test/Resolver/Factory/TemplatePathStackResolverFactoryTest.php
+++ b/test/Resolver/Factory/TemplatePathStackResolverFactoryTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LaminasTest\View\Resolver\Factory;
 
 use Laminas\View\Resolver\Factory\TemplatePathStackResolverFactory;
-use Laminas\View\Resolver\TemplateCannotBeFound;
 use LaminasTest\View\TestAsset\InMemoryContainer;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -86,7 +85,6 @@ final class TemplatePathStackResolverFactoryTest extends TestCase
             return;
         }
 
-        $this->expectException(TemplateCannotBeFound::class);
-        $resolver->resolve($input);
+        self::assertFalse($resolver->resolve($input));
     }
 }

--- a/test/Resolver/Factory/TemplatePathStackResolverFactoryTest.php
+++ b/test/Resolver/Factory/TemplatePathStackResolverFactoryTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Resolver\Factory;
+
+use Laminas\View\Resolver\Factory\TemplatePathStackResolverFactory;
+use Laminas\View\Resolver\TemplateCannotBeFound;
+use LaminasTest\View\TestAsset\InMemoryContainer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function is_string;
+use function realpath;
+
+final class TemplatePathStackResolverFactoryTest extends TestCase
+{
+    /** @return array<string, array{0: array, 1: non-empty-string, 2: null|string}> */
+    public static function configProvider(): array
+    {
+        $templates = realpath(__DIR__ . '/../../_templates');
+        self::assertNotFalse($templates);
+
+        return [
+            'Typical MVC Config'    => [
+                [
+                    'view_manager' => [
+                        'template_path_stack' => [
+                            $templates,
+                        ],
+                    ],
+                ],
+                'empty',
+                $templates . '/empty.phtml',
+            ],
+            'Mezzio Default Suffix' => [
+                [
+                    'view_manager' => [
+                        'template_path_stack' => [
+                            $templates . '/prefix-path-stack-resolver',
+                        ],
+                    ],
+                    'templates'    => [
+                        'extension' => 'php',
+                    ],
+                ],
+                'foo',
+                $templates . '/prefix-path-stack-resolver/foo.php',
+            ],
+            'MVC Default Suffix'    => [
+                [
+                    'view_manager' => [
+                        'default_template_suffix' => 'php',
+                        'template_path_stack'     => [
+                            $templates . '/prefix-path-stack-resolver',
+                        ],
+                    ],
+                    'templates'    => [
+                        'extension' => 'php',
+                    ],
+                ],
+                'foo',
+                $templates . '/prefix-path-stack-resolver/foo.php',
+            ],
+            'Empty Config'          => [
+                [],
+                'foo',
+                null,
+            ],
+        ];
+    }
+
+    /** @param non-empty-string $input */
+    #[DataProvider('configProvider')]
+    public function testFactory(array $config, string $input, string|null $expect): void
+    {
+        $container = new InMemoryContainer();
+        $container->set('config', $config);
+
+        $factory  = new TemplatePathStackResolverFactory();
+        $resolver = $factory->__invoke($container);
+
+        if (is_string($expect)) {
+            self::assertSame($expect, $resolver->resolve($input));
+
+            return;
+        }
+
+        $this->expectException(TemplateCannotBeFound::class);
+        $resolver->resolve($input);
+    }
+}

--- a/test/Resolver/PrefixPathStackResolverTest.php
+++ b/test/Resolver/PrefixPathStackResolverTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace LaminasTest\View\Resolver;
 
 use Laminas\View\Resolver\PrefixPathStackResolver;
+use Laminas\View\Resolver\TemplateCannotBeFound;
 use Laminas\View\Resolver\TemplateMapResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function realpath;
@@ -14,37 +16,58 @@ use function realpath;
 #[CoversClass(PrefixPathStackResolver::class)]
 final class PrefixPathStackResolverTest extends TestCase
 {
+    /** @var non-empty-string */
     private string $basePath;
 
-    /**
-     * {@inheritDoc}
-     */
     protected function setUp(): void
     {
-        $this->basePath = realpath(__DIR__ . '/../_templates/prefix-path-stack-resolver');
+        $realpath = realpath(__DIR__ . '/../_templates/prefix-path-stack-resolver');
+        self::assertNotFalse($realpath);
+        self::assertNotEmpty($realpath);
+        $this->basePath = $realpath;
     }
 
-    public function testResolveWithoutPathPrefixes(): void
+    /** @return list<array{0: non-empty-string}> */
+    public static function willNotResolveByDefaultProvider(): array
+    {
+        return [
+            [__DIR__],
+            [__FILE__],
+            ['path/to/foo'],
+            ['path/to/bar'],
+        ];
+    }
+
+    /** @param non-empty-string $name */
+    #[DataProvider('willNotResolveByDefaultProvider')]
+    public function testResolveWithoutPathPrefixes(string $name): void
     {
         $resolver = new PrefixPathStackResolver();
-
-        $this->assertNull($resolver->resolve(__DIR__));
-        $this->assertNull($resolver->resolve(__FILE__));
-        $this->assertNull($resolver->resolve('path/to/foo'));
-        $this->assertNull($resolver->resolve('path/to/bar'));
+        $this->expectException(TemplateCannotBeFound::class);
+        $resolver->resolve($name);
     }
 
-    public function testResolve(): void
+    public function testSuccessfulResolve(): void
     {
         $resolver = new PrefixPathStackResolver([
             'base1' => $this->basePath,
             'base2' => $this->basePath . '/baz',
         ]);
 
-        $this->assertEmpty($resolver->resolve('base1/foo'));
         $this->assertSame(realpath($this->basePath . '/bar.phtml'), $resolver->resolve('base1/bar'));
-        $this->assertEmpty($resolver->resolve('base2/tab'));
         $this->assertSame(realpath($this->basePath . '/baz/taz.phtml'), $resolver->resolve('base2/taz'));
+    }
+
+    public function testUnprefixedNameResolvingToEmptyStringCausesException(): void
+    {
+        $resolver = new PrefixPathStackResolver([
+            'base1' => $this->basePath,
+            'base2' => $this->basePath . '/baz',
+        ]);
+
+        $this->expectException(TemplateCannotBeFound::class);
+
+        $resolver->resolve('base2');
     }
 
     public function testResolveWithCongruentPrefix(): void
@@ -69,6 +92,5 @@ final class PrefixPathStackResolverTest extends TestCase
 
         $this->assertSame('1111', $resolver->resolve('foo/bar'));
         $this->assertSame('2222', $resolver->resolve('foo/baz'));
-        $this->assertNull($resolver->resolve('foo/tab'));
     }
 }

--- a/test/Resolver/PrefixPathStackResolverTest.php
+++ b/test/Resolver/PrefixPathStackResolverTest.php
@@ -58,6 +58,15 @@ final class PrefixPathStackResolverTest extends TestCase
         $this->assertSame(realpath($this->basePath . '/baz/taz.phtml'), $resolver->resolve('base2/taz'));
     }
 
+    public function testTheDefaultSuffixIsPassedToTheUnderlyingResolver(): void
+    {
+        $resolver = new PrefixPathStackResolver([
+            'whatever' => $this->basePath,
+        ], 'php');
+
+        self::assertSame($this->basePath . '/foo.php', $resolver->resolve('whatever/foo'));
+    }
+
     public function testUnprefixedNameResolvingToEmptyStringCausesException(): void
     {
         $resolver = new PrefixPathStackResolver([

--- a/test/Resolver/PrefixPathStackResolverTest.php
+++ b/test/Resolver/PrefixPathStackResolverTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LaminasTest\View\Resolver;
 
 use Laminas\View\Resolver\PrefixPathStackResolver;
-use Laminas\View\Resolver\TemplateCannotBeFound;
 use Laminas\View\Resolver\TemplateMapResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -43,9 +42,7 @@ final class PrefixPathStackResolverTest extends TestCase
     public function testResolveWithoutPathPrefixes(string $name): void
     {
         $resolver = new PrefixPathStackResolver();
-        self::assertFalse($resolver->has($name));
-        $this->expectException(TemplateCannotBeFound::class);
-        $resolver->resolve($name);
+        self::assertFalse($resolver->resolve($name));
     }
 
     public function testSuccessfulResolve(): void
@@ -54,9 +51,6 @@ final class PrefixPathStackResolverTest extends TestCase
             'base1' => $this->basePath,
             'base2' => $this->basePath . '/baz',
         ]);
-
-        self::assertTrue($resolver->has('base1/bar'));
-        self::assertTrue($resolver->has('base2/taz'));
 
         $this->assertSame(realpath($this->basePath . '/bar.phtml'), $resolver->resolve('base1/bar'));
         $this->assertSame(realpath($this->basePath . '/baz/taz.phtml'), $resolver->resolve('base2/taz'));
@@ -68,7 +62,6 @@ final class PrefixPathStackResolverTest extends TestCase
             'whatever' => $this->basePath,
         ], 'php');
 
-        self::assertTrue($resolver->has('whatever/foo'));
         self::assertSame($this->basePath . '/foo.php', $resolver->resolve('whatever/foo'));
     }
 
@@ -79,10 +72,7 @@ final class PrefixPathStackResolverTest extends TestCase
             'base2' => $this->basePath . '/baz',
         ]);
 
-        self::assertFalse($resolver->has('base2'));
-        $this->expectException(TemplateCannotBeFound::class);
-
-        $resolver->resolve('base2');
+        self::assertFalse($resolver->resolve('base2'));
     }
 
     public function testResolveWithCongruentPrefix(): void
@@ -104,9 +94,6 @@ final class PrefixPathStackResolverTest extends TestCase
                 '/baz' => '2222',
             ]),
         ]);
-
-        self::assertTrue($resolver->has('foo/bar'));
-        self::assertTrue($resolver->has('foo/baz'));
 
         $this->assertSame('1111', $resolver->resolve('foo/bar'));
         $this->assertSame('2222', $resolver->resolve('foo/baz'));

--- a/test/Resolver/PrefixPathStackResolverTest.php
+++ b/test/Resolver/PrefixPathStackResolverTest.php
@@ -43,6 +43,7 @@ final class PrefixPathStackResolverTest extends TestCase
     public function testResolveWithoutPathPrefixes(string $name): void
     {
         $resolver = new PrefixPathStackResolver();
+        self::assertFalse($resolver->has($name));
         $this->expectException(TemplateCannotBeFound::class);
         $resolver->resolve($name);
     }
@@ -54,6 +55,9 @@ final class PrefixPathStackResolverTest extends TestCase
             'base2' => $this->basePath . '/baz',
         ]);
 
+        self::assertTrue($resolver->has('base1/bar'));
+        self::assertTrue($resolver->has('base2/taz'));
+
         $this->assertSame(realpath($this->basePath . '/bar.phtml'), $resolver->resolve('base1/bar'));
         $this->assertSame(realpath($this->basePath . '/baz/taz.phtml'), $resolver->resolve('base2/taz'));
     }
@@ -64,6 +68,7 @@ final class PrefixPathStackResolverTest extends TestCase
             'whatever' => $this->basePath,
         ], 'php');
 
+        self::assertTrue($resolver->has('whatever/foo'));
         self::assertSame($this->basePath . '/foo.php', $resolver->resolve('whatever/foo'));
     }
 
@@ -74,6 +79,7 @@ final class PrefixPathStackResolverTest extends TestCase
             'base2' => $this->basePath . '/baz',
         ]);
 
+        self::assertFalse($resolver->has('base2'));
         $this->expectException(TemplateCannotBeFound::class);
 
         $resolver->resolve('base2');
@@ -98,6 +104,9 @@ final class PrefixPathStackResolverTest extends TestCase
                 '/baz' => '2222',
             ]),
         ]);
+
+        self::assertTrue($resolver->has('foo/bar'));
+        self::assertTrue($resolver->has('foo/baz'));
 
         $this->assertSame('1111', $resolver->resolve('foo/bar'));
         $this->assertSame('2222', $resolver->resolve('foo/baz'));

--- a/test/Resolver/RelativeFallbackResolverTest.php
+++ b/test/Resolver/RelativeFallbackResolverTest.php
@@ -6,10 +6,11 @@ namespace LaminasTest\View\Resolver;
 
 use Laminas\View\Helper\ViewModel as ViewModelHelper;
 use Laminas\View\Model\ViewModel;
-use Laminas\View\Renderer\PhpRenderer;
+use Laminas\View\Renderer\RendererInterface;
 use Laminas\View\Resolver\AggregateResolver;
 use Laminas\View\Resolver\RelativeFallbackResolver;
 use Laminas\View\Resolver\ResolverInterface;
+use Laminas\View\Resolver\TemplateCannotBeFound;
 use Laminas\View\Resolver\TemplateMapResolver;
 use Laminas\View\Resolver\TemplatePathStack;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -23,97 +24,93 @@ final class RelativeFallbackResolverTest extends TestCase
 {
     public function testReturnsResourceFromTheSameNameSpaceWithMapResolver(): void
     {
+        $helper         = new ViewModelHelper();
         $tplMapResolver = new TemplateMapResolver([
             'foo/bar' => 'foo/baz',
         ]);
-        $resolver       = new RelativeFallbackResolver($tplMapResolver);
-        $renderer       = new PhpRenderer();
+        $resolver       = new RelativeFallbackResolver($tplMapResolver, $helper);
         $view           = new ViewModel();
         $view->setTemplate('foo/zaz');
-        $helper = $renderer->plugin(ViewModelHelper::class);
         $helper->setCurrent($view);
 
-        $test = $resolver->resolve('bar', $renderer);
+        $test = $resolver->resolve('bar');
         $this->assertEquals('foo/baz', $test);
     }
 
     public function testReturnsResourceFromTheSameNameSpaceWithPathStack(): void
     {
-        $pathStack = new TemplatePathStack();
-        $pathStack->addPath(__DIR__ . '/../_templates');
-        $resolver = new RelativeFallbackResolver($pathStack);
-        $renderer = new PhpRenderer();
-        $view     = new ViewModel();
+        $view = new ViewModel();
         $view->setTemplate('name-space/any-view');
-        $helper = $renderer->plugin(ViewModelHelper::class);
+        $helper = new ViewModelHelper();
         $helper->setCurrent($view);
 
-        $test = $resolver->resolve('bar', $renderer);
+        $pathStack = new TemplatePathStack();
+        $pathStack->addPath(__DIR__ . '/../_templates');
+        $resolver = new RelativeFallbackResolver($pathStack, $helper);
+
+        $test = $resolver->resolve('bar');
         $this->assertEquals(realpath(__DIR__ . '/../_templates/name-space/bar.phtml'), $test);
     }
 
     public function testReturnsResourceFromTopLevelIfExistsInsteadOfTheSameNameSpace(): void
     {
+        $view = new ViewModel();
+        $view->setTemplate('foo/zaz');
+        $helper = new ViewModelHelper();
+        $helper->setCurrent($view);
+
         $tplMapResolver = new TemplateMapResolver([
             'foo/bar' => 'foo/baz',
             'bar'     => 'baz',
         ]);
         $resolver       = new AggregateResolver();
         $resolver->attach($tplMapResolver);
-        $resolver->attach(new RelativeFallbackResolver($tplMapResolver));
-        $renderer = new PhpRenderer();
-        $view     = new ViewModel();
-        $view->setTemplate('foo/zaz');
-        $helper = $renderer->plugin(ViewModelHelper::class);
-        $helper->setCurrent($view);
+        $resolver->attach(new RelativeFallbackResolver($tplMapResolver, $helper));
 
-        $test = $resolver->resolve('bar', $renderer);
+        $test = $resolver->resolve('bar');
         $this->assertEquals('baz', $test);
     }
 
-    public function testSkipsResolutionOnViewRendererWithoutPlugins(): void
+    public function testResolutionFailsWhenTheHelperDoesNotKnowTheRuntimeCurrentModel(): void
     {
         $baseResolver = $this->createMock(ResolverInterface::class);
         $baseResolver->expects(self::never())
             ->method('resolve');
 
-        $fallback = new RelativeFallbackResolver($baseResolver);
+        $fallback = new RelativeFallbackResolver($baseResolver, new ViewModelHelper());
 
-        $renderer = $this->createMock(PhpRenderer::class);
-
-        $this->assertFalse($fallback->resolve('foo/bar', $renderer));
+        $this->expectException(TemplateCannotBeFound::class);
+        $fallback->resolve('foo/bar');
     }
 
-    public function testSkipsResolutionOnViewRendererWithoutCorrectCurrentPlugin(): void
+    public function testResolutionFailsWhenTheComposedResolverFails(): void
     {
-        $baseResolver = $this->createMock(ResolverInterface::class);
-        $baseResolver->expects(self::never())
-            ->method('resolve');
+        $view = new ViewModel();
+        $view->setTemplate('name-space/any-view');
+        $helper = new ViewModelHelper();
+        $helper->setCurrent($view);
 
-        $fallback = new RelativeFallbackResolver($baseResolver);
+        $pathStack = new TemplatePathStack();
+        $pathStack->addPath(__DIR__ . '/../_templates');
+        $resolver = new RelativeFallbackResolver($pathStack, $helper);
 
-        $renderer = $this->createMock(PhpRenderer::class);
-        $renderer->expects(self::once())
-            ->method('plugin')
-            ->willReturn(new stdClass());
-
-        $this->assertFalse($fallback->resolve('foo/bar', $renderer));
+        // The foo.phtml file should not exist in ../_templates/name-space/
+        $this->expectException(TemplateCannotBeFound::class);
+        $resolver->resolve('foo');
     }
 
-    public function testSkipsResolutionOnNonExistingCurrentViewModel(): void
+    public function testResolutionFailsWhenTheCurrentTemplateHasZeroDepth(): void
     {
-        $baseResolver = $this->createMock(ResolverInterface::class);
-        $baseResolver->expects(self::never())
-            ->method('resolve');
+        $view = new ViewModel();
+        $view->setTemplate('empty'); // Known template in ../_templates/
+        $helper = new ViewModelHelper();
+        $helper->setCurrent($view);
 
-        $fallback  = new RelativeFallbackResolver($baseResolver);
-        $viewModel = new ViewModelHelper();
+        $pathStack = new TemplatePathStack();
+        $pathStack->addPath(__DIR__ . '/../_templates');
+        $resolver = new RelativeFallbackResolver($pathStack, $helper);
 
-        $renderer = $this->createMock(PhpRenderer::class);
-        $renderer->expects(self::once())
-            ->method('plugin')
-            ->willReturn($viewModel);
-
-        $this->assertFalse($fallback->resolve('foo/bar', $renderer));
+        $this->expectException(TemplateCannotBeFound::class);
+        $resolver->resolve('test'); // Can actually be found in ../_templates/test.phtml
     }
 }

--- a/test/Resolver/RelativeFallbackResolverTest.php
+++ b/test/Resolver/RelativeFallbackResolverTest.php
@@ -31,6 +31,7 @@ final class RelativeFallbackResolverTest extends TestCase
         $view->setTemplate('foo/zaz');
         $helper->setCurrent($view);
 
+        self::assertTrue($resolver->has('bar'));
         $test = $resolver->resolve('bar');
         $this->assertEquals('foo/baz', $test);
     }
@@ -46,6 +47,7 @@ final class RelativeFallbackResolverTest extends TestCase
         $pathStack->addPath(__DIR__ . '/../_templates');
         $resolver = new RelativeFallbackResolver($pathStack, $helper);
 
+        self::assertTrue($resolver->has('bar'));
         $test = $resolver->resolve('bar');
         $this->assertEquals(realpath(__DIR__ . '/../_templates/name-space/bar.phtml'), $test);
     }
@@ -65,6 +67,7 @@ final class RelativeFallbackResolverTest extends TestCase
         $resolver->attach($tplMapResolver);
         $resolver->attach(new RelativeFallbackResolver($tplMapResolver, $helper));
 
+        self::assertTrue($resolver->has('bar'));
         $test = $resolver->resolve('bar');
         $this->assertEquals('baz', $test);
     }
@@ -74,6 +77,8 @@ final class RelativeFallbackResolverTest extends TestCase
         $baseResolver = $this->createMock(ResolverInterface::class);
         $baseResolver->expects(self::never())
             ->method('resolve');
+        $baseResolver->expects(self::never())
+            ->method('has');
 
         $fallback = new RelativeFallbackResolver($baseResolver, new ViewModelHelper());
 
@@ -92,6 +97,8 @@ final class RelativeFallbackResolverTest extends TestCase
         $pathStack->addPath(__DIR__ . '/../_templates');
         $resolver = new RelativeFallbackResolver($pathStack, $helper);
 
+        self::assertFalse($resolver->has('foo'));
+
         // The foo.phtml file should not exist in ../_templates/name-space/
         $this->expectException(TemplateCannotBeFound::class);
         $resolver->resolve('foo');
@@ -107,6 +114,7 @@ final class RelativeFallbackResolverTest extends TestCase
         $pathStack = new TemplatePathStack();
         $pathStack->addPath(__DIR__ . '/../_templates');
         $resolver = new RelativeFallbackResolver($pathStack, $helper);
+        self::assertFalse($resolver->has('test'));
 
         $this->expectException(TemplateCannotBeFound::class);
         $resolver->resolve('test'); // Can actually be found in ../_templates/test.phtml

--- a/test/Resolver/RelativeFallbackResolverTest.php
+++ b/test/Resolver/RelativeFallbackResolverTest.php
@@ -9,7 +9,6 @@ use Laminas\View\Model\ViewModel;
 use Laminas\View\Resolver\AggregateResolver;
 use Laminas\View\Resolver\RelativeFallbackResolver;
 use Laminas\View\Resolver\ResolverInterface;
-use Laminas\View\Resolver\TemplateCannotBeFound;
 use Laminas\View\Resolver\TemplateMapResolver;
 use Laminas\View\Resolver\TemplatePathStack;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -31,7 +30,6 @@ final class RelativeFallbackResolverTest extends TestCase
         $view->setTemplate('foo/zaz');
         $helper->setCurrent($view);
 
-        self::assertTrue($resolver->has('bar'));
         $test = $resolver->resolve('bar');
         $this->assertEquals('foo/baz', $test);
     }
@@ -47,7 +45,6 @@ final class RelativeFallbackResolverTest extends TestCase
         $pathStack->addPath(__DIR__ . '/../_templates');
         $resolver = new RelativeFallbackResolver($pathStack, $helper);
 
-        self::assertTrue($resolver->has('bar'));
         $test = $resolver->resolve('bar');
         $this->assertEquals(realpath(__DIR__ . '/../_templates/name-space/bar.phtml'), $test);
     }
@@ -67,7 +64,6 @@ final class RelativeFallbackResolverTest extends TestCase
         $resolver->attach($tplMapResolver);
         $resolver->attach(new RelativeFallbackResolver($tplMapResolver, $helper));
 
-        self::assertTrue($resolver->has('bar'));
         $test = $resolver->resolve('bar');
         $this->assertEquals('baz', $test);
     }
@@ -77,13 +73,10 @@ final class RelativeFallbackResolverTest extends TestCase
         $baseResolver = $this->createMock(ResolverInterface::class);
         $baseResolver->expects(self::never())
             ->method('resolve');
-        $baseResolver->expects(self::never())
-            ->method('has');
 
         $fallback = new RelativeFallbackResolver($baseResolver, new ViewModelHelper());
 
-        $this->expectException(TemplateCannotBeFound::class);
-        $fallback->resolve('foo/bar');
+        self::assertFalse($fallback->resolve('foo/bar'));
     }
 
     public function testResolutionFailsWhenTheComposedResolverFails(): void
@@ -97,11 +90,8 @@ final class RelativeFallbackResolverTest extends TestCase
         $pathStack->addPath(__DIR__ . '/../_templates');
         $resolver = new RelativeFallbackResolver($pathStack, $helper);
 
-        self::assertFalse($resolver->has('foo'));
-
         // The foo.phtml file should not exist in ../_templates/name-space/
-        $this->expectException(TemplateCannotBeFound::class);
-        $resolver->resolve('foo');
+        self::assertFalse($resolver->resolve('foo'));
     }
 
     public function testResolutionFailsWhenTheCurrentTemplateHasZeroDepth(): void
@@ -114,9 +104,7 @@ final class RelativeFallbackResolverTest extends TestCase
         $pathStack = new TemplatePathStack();
         $pathStack->addPath(__DIR__ . '/../_templates');
         $resolver = new RelativeFallbackResolver($pathStack, $helper);
-        self::assertFalse($resolver->has('test'));
 
-        $this->expectException(TemplateCannotBeFound::class);
-        $resolver->resolve('test'); // Can actually be found in ../_templates/test.phtml
+        self::assertFalse($resolver->resolve('test')); // Can actually be found in ../_templates/test.phtml
     }
 }

--- a/test/Resolver/RelativeFallbackResolverTest.php
+++ b/test/Resolver/RelativeFallbackResolverTest.php
@@ -6,7 +6,6 @@ namespace LaminasTest\View\Resolver;
 
 use Laminas\View\Helper\ViewModel as ViewModelHelper;
 use Laminas\View\Model\ViewModel;
-use Laminas\View\Renderer\RendererInterface;
 use Laminas\View\Resolver\AggregateResolver;
 use Laminas\View\Resolver\RelativeFallbackResolver;
 use Laminas\View\Resolver\ResolverInterface;
@@ -15,7 +14,6 @@ use Laminas\View\Resolver\TemplateMapResolver;
 use Laminas\View\Resolver\TemplatePathStack;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 use function realpath;
 

--- a/test/Resolver/TemplateMapResolverTest.php
+++ b/test/Resolver/TemplateMapResolverTest.php
@@ -188,12 +188,11 @@ final class TemplateMapResolverTest extends TestCase
         $this->assertEquals($map['foo/bar'], $resolver->resolve('foo/bar'));
     }
 
-    public function testResolveThrowsExceptionWhenNameHasNoMatch(): void
+    public function testResolveReturnsFalseWhenNameHasNoMatch(): void
     {
         $map      = ['foo/bar' => __DIR__ . '/foo/bar.phtml'];
         $resolver = new TemplateMapResolver($map);
-        $this->expectException(TemplateCannotBeFound::class);
-        $resolver->resolve('bar/baz');
+        self::assertFalse($resolver->resolve('bar/baz'));
     }
 
     public function testExceptionThrownAddingStringNameWithoutPath(): void

--- a/test/Resolver/TemplateMapResolverTest.php
+++ b/test/Resolver/TemplateMapResolverTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace LaminasTest\View\Resolver;
 
 use ArrayObject;
+use Laminas\View\Exception\InvalidArgumentException;
+use Laminas\View\Resolver\TemplateCannotBeFound;
 use Laminas\View\Resolver\TemplateMapResolver;
 use PHPUnit\Framework\TestCase;
 
@@ -171,11 +173,12 @@ final class TemplateMapResolverTest extends TestCase
         $this->assertEquals($map['foo/bar'], $resolver->get('foo/bar'));
     }
 
-    public function testGetReturnsFalseWhenNameHasNoMatch(): void
+    public function testGetThrowsExceptionWhenNameHasNoMatch(): void
     {
         $map      = ['foo/bar' => __DIR__ . '/foo/bar.phtml'];
         $resolver = new TemplateMapResolver($map);
-        $this->assertFalse($resolver->get('bar/baz'));
+        $this->expectException(TemplateCannotBeFound::class);
+        $resolver->get('bar/baz');
     }
 
     public function testResolveReturnsPathWhenNameHasMatch(): void
@@ -185,10 +188,28 @@ final class TemplateMapResolverTest extends TestCase
         $this->assertEquals($map['foo/bar'], $resolver->resolve('foo/bar'));
     }
 
-    public function testResolveReturnsFalseWhenNameHasNoMatch(): void
+    public function testResolveThrowsExceptionWhenNameHasNoMatch(): void
     {
         $map      = ['foo/bar' => __DIR__ . '/foo/bar.phtml'];
         $resolver = new TemplateMapResolver($map);
-        $this->assertFalse($resolver->resolve('bar/baz'));
+        $this->expectException(TemplateCannotBeFound::class);
+        $resolver->resolve('bar/baz');
+    }
+
+    public function testExceptionThrownAddingStringNameWithoutPath(): void
+    {
+        $resolver = new TemplateMapResolver();
+        $this->expectException(InvalidArgumentException::class);
+        $resolver->add('foo');
+    }
+
+    public function testInvalidHasMapsCauseExceptions(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        /** @psalm-suppress InvalidArgument */
+        new TemplateMapResolver([
+            'foo' => 1,
+        ]);
     }
 }

--- a/test/Resolver/TemplatePathStackTest.php
+++ b/test/Resolver/TemplatePathStackTest.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Resolver;
 
-use ArrayObject;
-use Laminas\View\Exception;
+use Laminas\View\Exception\DomainException;
+use Laminas\View\Resolver\TemplateCannotBeFound;
 use Laminas\View\Resolver\TemplatePathStack;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use TypeError;
 
 use function array_reverse;
 use function array_unshift;
@@ -24,124 +25,113 @@ final class TemplatePathStackTest extends TestCase
 {
     private TemplatePathStack $stack;
 
-    /** @var list<string> */
-    private array $paths;
-
+    /** @var non-empty-string */
     private string $baseDir;
 
     protected function setUp(): void
     {
-        $this->baseDir = realpath(__DIR__ . '/..');
+        $dir = realpath(__DIR__ . '/..');
+        self::assertNotFalse($dir);
+        $this->baseDir = $dir . '/';
         $this->stack   = new TemplatePathStack();
-        $this->paths   = [
-            TemplatePathStack::normalizePath($this->baseDir),
-            TemplatePathStack::normalizePath($this->baseDir . '/_templates'),
-        ];
     }
 
     public function testAddPathAddsPathToStack(): void
     {
         $this->stack->addPath($this->baseDir);
         $paths = $this->stack->getPaths();
-        $this->assertCount(1, $paths);
-        $this->assertEquals(TemplatePathStack::normalizePath($this->baseDir), $paths->pop());
+        self::assertCount(1, $paths);
+        self::assertEquals($this->baseDir, $paths->pop());
     }
 
     public function testPathsAreProcessedAsStack(): void
     {
         $paths = [
-            TemplatePathStack::normalizePath($this->baseDir),
-            TemplatePathStack::normalizePath($this->baseDir . '/_files'),
+            $this->baseDir,
+            $this->baseDir . '_files/',
         ];
         foreach ($paths as $path) {
             $this->stack->addPath($path);
         }
         $test = $this->stack->getPaths()->toArray();
-        $this->assertEquals(array_reverse($paths), $test);
+        self::assertEquals(array_reverse($paths), $test);
     }
 
     public function testAddPathsAddsPathsToStack(): void
     {
-        $this->stack->addPath($this->baseDir . '/Helper');
+        $this->stack->addPath($this->baseDir . 'Helper/');
         $paths = [
-            TemplatePathStack::normalizePath($this->baseDir),
-            TemplatePathStack::normalizePath($this->baseDir . '/_files'),
+            $this->baseDir,
+            $this->baseDir . '_files/',
         ];
         $this->stack->addPaths($paths);
-        array_unshift($paths, TemplatePathStack::normalizePath($this->baseDir . '/Helper'));
-        $this->assertEquals(array_reverse($paths), $this->stack->getPaths()->toArray());
+        array_unshift($paths, $this->baseDir . 'Helper/');
+        self::assertEquals(array_reverse($paths), $this->stack->getPaths()->toArray());
     }
 
     public function testSetPathsOverwritesStack(): void
     {
-        $this->stack->addPath($this->baseDir . '/Helper');
+        $this->stack->addPath($this->baseDir . 'Helper/');
         $paths = [
-            TemplatePathStack::normalizePath($this->baseDir),
-            TemplatePathStack::normalizePath($this->baseDir . '/_files'),
+            $this->baseDir,
+            $this->baseDir . '_files/',
         ];
         $this->stack->setPaths($paths);
-        $this->assertEquals(array_reverse($paths), $this->stack->getPaths()->toArray());
+        self::assertEquals(array_reverse($paths), $this->stack->getPaths()->toArray());
     }
 
     public function testClearPathsClearsStack(): void
     {
         $paths = [
             $this->baseDir,
-            $this->baseDir . '/_files',
+            $this->baseDir . '_files/',
         ];
         $this->stack->setPaths($paths);
         $this->stack->clearPaths();
-        $this->assertEquals(0, $this->stack->getPaths()->count());
-    }
-
-    public function testLfiProtectionEnabledByDefault(): void
-    {
-        $this->assertTrue($this->stack->isLfiProtectionOn());
-    }
-
-    public function testMayDisableLfiProtection(): void
-    {
-        $this->stack->setLfiProtection(false);
-        $this->assertFalse($this->stack->isLfiProtectionOn());
+        self::assertEquals(0, $this->stack->getPaths()->count());
     }
 
     public function testDoesNotAllowParentDirectoryTraversalByDefault(): void
     {
-        $this->stack->addPath($this->baseDir . '/_templates');
+        $this->stack->addPath($this->baseDir . '_templates/');
 
-        $this->expectException(Exception\ExceptionInterface::class);
+        $this->expectException(DomainException::class);
         $this->expectExceptionMessage('parent directory traversal');
         $this->stack->resolve('../_stubs/scripts/LfiProtectionCheck.phtml');
     }
 
     public function testDisablingLfiProtectionAllowsParentDirectoryTraversal(): void
     {
-        $this->stack->setLfiProtection(false)
-                    ->addPath($this->baseDir . '/_templates');
+        $stack = new TemplatePathStack([
+            'lfi_protection' => false,
+            'script_paths'   => [
+                $this->baseDir . '_templates/',
+            ],
+        ]);
 
-        $test = $this->stack->resolve('../_stubs/scripts/LfiProtectionCheck.phtml');
-        $this->assertStringContainsString('LfiProtectionCheck.phtml', $test);
+        $test = $stack->resolve('../_stubs/scripts/LfiProtectionCheck.phtml');
+        self::assertStringContainsString('LfiProtectionCheck.phtml', $test);
     }
 
     public function testReturnsFalseWhenRetrievingScriptIfNoPathsRegistered(): void
     {
-        $this->assertFalse($this->stack->resolve('test.phtml'));
-        $this->assertEquals(TemplatePathStack::FAILURE_NO_PATHS, $this->stack->getLastLookupFailure());
+        $this->expectException(TemplateCannotBeFound::class);
+        $this->stack->resolve('test.phtml');
     }
 
     public function testReturnsFalseWhenUnableToResolveScriptToPath(): void
     {
-        $this->stack->addPath($this->baseDir . '/_templates');
-        $this->assertFalse($this->stack->resolve('bogus-script.txt'));
-        $this->assertEquals(TemplatePathStack::FAILURE_NOT_FOUND, $this->stack->getLastLookupFailure());
+        $this->stack->addPath($this->baseDir . '_templates/');
+        $this->expectException(TemplateCannotBeFound::class);
+        $this->stack->resolve('bogus-script.txt');
     }
 
     public function testReturnsFullPathNameWhenAbleToResolveScriptPath(): void
     {
-        $this->stack->addPath($this->baseDir . '/_templates');
-        $expected = realpath($this->baseDir . '/_templates/test.phtml');
+        $this->stack->addPath($this->baseDir . '_templates/');
+        $expected = realpath($this->baseDir . '_templates/test.phtml');
         $test     = $this->stack->resolve('test.phtml');
-        $this->assertEquals($expected, $test);
+        self::assertSame($expected, $test);
     }
 
     /**
@@ -161,82 +151,36 @@ final class TemplatePathStackTest extends TestCase
     #[DataProvider('invalidOptions')]
     public function testSettingOptionsWithInvalidArgumentRaisesException(mixed $options): void
     {
-        $this->expectException(Exception\ExceptionInterface::class);
+        $this->expectException(TypeError::class);
         /** @psalm-suppress MixedArgument */
-        $this->stack->setOptions($options);
-    }
-
-    /**
-     * @return array<array-key, array{0: Options|ArrayObject}>
-     */
-    public static function validOptions(): array
-    {
-        $options = [
-            'lfi_protection' => false,
-            'default_suffix' => 'php',
-        ];
-        return [
-            [$options],
-            [new ArrayObject($options)],
-        ];
-    }
-
-    /**
-     * @param Options $options
-     */
-    #[DataProvider('validOptions')]
-    public function testAllowsSettingOptions($options): void
-    {
-        $options['script_paths'] = $this->paths;
-        $this->stack->setOptions($options);
-        $this->assertFalse($this->stack->isLfiProtectionOn());
-
-        $this->assertSame('php', $this->stack->getDefaultSuffix());
-
-        $this->assertEquals(array_reverse($this->paths), $this->stack->getPaths()->toArray());
-    }
-
-    /**
-     * @param Options $options
-     */
-    #[DataProvider('validOptions')]
-    public function testAllowsPassingOptionsToConstructor($options): void
-    {
-        $options['script_paths'] = $this->paths;
-        $stack                   = new TemplatePathStack($options);
-        $this->assertFalse($stack->isLfiProtectionOn());
-
-        $this->assertEquals(array_reverse($this->paths), $stack->getPaths()->toArray());
+        new TemplatePathStack($options);
     }
 
     public function testAllowsRelativePharPath(): void
     {
         $path = 'phar://' . $this->baseDir
-            . DIRECTORY_SEPARATOR . '_templates'
+            . '_templates'
             . DIRECTORY_SEPARATOR . 'view.phar'
             . DIRECTORY_SEPARATOR . 'start'
             . DIRECTORY_SEPARATOR . '..'
-            . DIRECTORY_SEPARATOR . 'views';
+            . DIRECTORY_SEPARATOR . 'views'
+            . DIRECTORY_SEPARATOR;
 
         $this->stack->addPath($path);
         $test = $this->stack->resolve('foo' . DIRECTORY_SEPARATOR . 'hello.phtml');
-        $this->assertEquals($path . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR . 'hello.phtml', $test);
-    }
-
-    public function testDefaultFileSuffixIsPhtml(): void
-    {
-        $this->assertEquals('phtml', $this->stack->getDefaultSuffix());
-    }
-
-    public function testDefaultFileSuffixIsMutable(): void
-    {
-        $this->stack->setDefaultSuffix('php');
-        $this->assertEquals('php', $this->stack->getDefaultSuffix());
+        self::assertEquals($path . 'foo' . DIRECTORY_SEPARATOR . 'hello.phtml', $test);
     }
 
     public function testSettingDefaultSuffixStripsLeadingDot(): void
     {
-        $this->stack->setDefaultSuffix('.config.php');
-        $this->assertEquals('config.php', $this->stack->getDefaultSuffix());
+        $stack = new TemplatePathStack([
+            'default_suffix' => '.phtml',
+            'script_paths'   => [
+                $this->baseDir . '_templates',
+            ],
+        ]);
+
+        $result = $stack->resolve('test');
+        self::assertStringEndsWith('test.phtml', $result);
     }
 }

--- a/test/Resolver/TemplatePathStackTest.php
+++ b/test/Resolver/TemplatePathStackTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LaminasTest\View\Resolver;
 
 use Laminas\View\Exception\DomainException;
-use Laminas\View\Resolver\TemplateCannotBeFound;
 use Laminas\View\Resolver\TemplatePathStack;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -110,20 +109,19 @@ final class TemplatePathStackTest extends TestCase
         ]);
 
         $test = $stack->resolve('../_stubs/scripts/LfiProtectionCheck.phtml');
+        self::assertIsString($test);
         self::assertStringContainsString('LfiProtectionCheck.phtml', $test);
     }
 
     public function testReturnsFalseWhenRetrievingScriptIfNoPathsRegistered(): void
     {
-        $this->expectException(TemplateCannotBeFound::class);
-        $this->stack->resolve('test.phtml');
+        self::assertFalse($this->stack->resolve('test.phtml'));
     }
 
     public function testReturnsFalseWhenUnableToResolveScriptToPath(): void
     {
         $this->stack->addPath($this->baseDir . '_templates/');
-        $this->expectException(TemplateCannotBeFound::class);
-        $this->stack->resolve('bogus-script.txt');
+        self::assertFalse($this->stack->resolve('bogus-script.txt'));
     }
 
     public function testReturnsFullPathNameWhenAbleToResolveScriptPath(): void
@@ -181,6 +179,7 @@ final class TemplatePathStackTest extends TestCase
         ]);
 
         $result = $stack->resolve('test');
+        self::assertNotFalse($result);
         self::assertStringEndsWith('test.phtml', $result);
     }
 }


### PR DESCRIPTION
Amends the `ResolverInterface` to `resolve(non-empty-string): non-empty-string` with failure conditions meaning an exception is thrown.

Resolvers are largely intact but they all now correctly implement the interface and expected behaviour.

TODO:

- [x] Decide how we will expect template maps and directory lists to be configured
- [x] Add factories for the resolvers and wire them up in ConfigProvider
- [x] Decide what fetching `ResolverInterface` from the container will provide by default
- [x] Refactor documentation for v3 with less MVC emphasis
