### PR TITLE
Deprecate the `DeclareVars` helper for removal in 3.0

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2111,6 +2111,9 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="test/Helper/DeclareVarsTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[DeclareVars::class]]></code>
+    </DeprecatedClass>
     <PossiblyInvalidMethodCall>
       <code><![CDATA[addPath]]></code>
     </PossiblyInvalidMethodCall>

--- a/src/Helper/DeclareVars.php
+++ b/src/Helper/DeclareVars.php
@@ -12,6 +12,10 @@ use function is_array;
 /**
  * Helper for declaring default values of template variables
  *
+ * @deprecated Since 2.40.0 This un-documented helper should not be used to initialise view variables. This should
+ *             be the responsibility of a controller or middleware and as such this helper will be removed in 3.0
+ *             without replacement.
+ *
  * @final
  */
 class DeclareVars extends AbstractHelper


### PR DESCRIPTION
See #282 