### PR TITLE
Refactor `RenderChildModel`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -569,32 +569,6 @@
       <code><![CDATA[new $this->containerClass()]]></code>
     </UnsafeInstantiation>
   </file>
-  <file src="src/Helper/RenderChildModel.php">
-    <MissingConstructor>
-      <code><![CDATA[$current]]></code>
-      <code><![CDATA[$viewModelHelper]]></code>
-    </MissingConstructor>
-    <MixedAssignment>
-      <code><![CDATA[$this->viewModelHelper]]></code>
-    </MixedAssignment>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->viewModelHelper]]></code>
-    </MixedReturnStatement>
-    <PossiblyNullArgument>
-      <code><![CDATA[$this->getView()]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue>
-      <code><![CDATA[$model = $this->getCurrent()]]></code>
-    </PossiblyNullPropertyAssignmentValue>
-    <PossiblyNullReference>
-      <code><![CDATA[getChildren]]></code>
-      <code><![CDATA[plugin]]></code>
-      <code><![CDATA[render]]></code>
-    </PossiblyNullReference>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$this->viewModelHelper]]></code>
-    </RedundantConditionGivenDocblockType>
-  </file>
   <file src="src/Helper/RenderToPlaceholder.php">
     <MixedAssignment>
       <code><![CDATA[$placeholderHelper]]></code>

--- a/src/Helper/RenderChildModel.php
+++ b/src/Helper/RenderChildModel.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper;
 
-use Laminas\View\Exception;
+use Laminas\View\Exception\RuntimeException;
 use Laminas\View\Model\ModelInterface as Model;
+use Laminas\View\Renderer\RendererInterface;
 
-use function method_exists;
+use function assert;
 use function sprintf;
 
 /**
@@ -15,61 +16,37 @@ use function sprintf;
  *
  * Finds children matching "capture-to" values, and renders them using the
  * composed view instance.
- *
- * @final
  */
-class RenderChildModel extends AbstractHelper
+final class RenderChildModel
 {
-    /**
-     * Current view model
-     *
-     * @var Model
-     */
-    protected $current;
-
-    /**
-     * View model helper instance
-     *
-     * @var ViewModel
-     */
-    protected $viewModelHelper;
-
-    /**
-     * Invoke as a function
-     *
-     * Proxies to {render()}.
-     *
-     * @param  string $child
-     * @return string
-     */
-    public function __invoke($child)
-    {
-        return $this->render($child);
+    public function __construct(
+        private readonly ViewModel $viewModelHelper,
+        private readonly RendererInterface $renderer,
+    ) {
     }
 
     /**
-     * Render a model
+     * Render the child model identified by $child
      *
-     * If a matching child model is found, it is rendered. If not, an empty
-     * string is returned.
+     * If a matching child model is found, it is rendered. If not, an empty string is returned.
      *
-     * @param  string $child
-     * @return string
+     * @param non-empty-string $child
      */
-    public function render($child)
+    public function __invoke(string $child): string
     {
         $model = $this->findChild($child);
-        if (! $model) {
+        if ($model === null) {
             return '';
         }
 
-        $current = $this->current;
-        $view    = $this->getView();
-        $return  = $view->render($model);
-        $helper  = $this->getViewModelHelper();
-        $helper->setCurrent($current);
+        $current = $this->viewModelHelper->getCurrent();
+        assert($current !== null);
 
-        return $return;
+        $content = $this->renderer->render($model);
+
+        $this->viewModelHelper->setCurrent($current);
+
+        return $content;
     }
 
     /**
@@ -79,55 +56,24 @@ class RenderChildModel extends AbstractHelper
      * has a captureTo value matching the requested $child. If found, that child
      * model is returned; otherwise, a boolean false is returned.
      *
-     * @param  string $child
-     * @return false|Model
+     * @throws RuntimeException If no model is currently present.
      */
-    protected function findChild($child)
+    private function findChild(string $child): Model|null
     {
-        $this->current = $model = $this->getCurrent();
+        $model = $this->viewModelHelper->getCurrent();
+        if ($model === null) {
+            throw new RuntimeException(sprintf(
+                '%s: no view model currently registered in renderer; cannot query for children',
+                __METHOD__,
+            ));
+        }
+
         foreach ($model->getChildren() as $childModel) {
             if ($childModel->captureTo() === $child) {
                 return $childModel;
             }
         }
 
-        return false;
-    }
-
-    /**
-     * Get the current view model
-     *
-     * @throws Exception\RuntimeException
-     * @return null|Model
-     */
-    protected function getCurrent()
-    {
-        $helper = $this->getViewModelHelper();
-        if (! $helper->hasCurrent()) {
-            throw new Exception\RuntimeException(sprintf(
-                '%s: no view model currently registered in renderer; cannot query for children',
-                __METHOD__
-            ));
-        }
-
-        return $helper->getCurrent();
-    }
-
-    /**
-     * Retrieve the view model helper
-     *
-     * @return ViewModel
-     */
-    protected function getViewModelHelper()
-    {
-        if ($this->viewModelHelper) {
-            return $this->viewModelHelper;
-        }
-
-        if (method_exists($this->getView(), 'plugin')) {
-            $this->viewModelHelper = $this->view->plugin('view_model');
-        }
-
-        return $this->viewModelHelper;
+        return null;
     }
 }

--- a/src/Helper/Service/RenderChildModelFactory.php
+++ b/src/Helper/Service/RenderChildModelFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View\Helper\Service;
+
+use Laminas\View\Helper\RenderChildModel;
+use Laminas\View\Helper\ViewModel;
+use Laminas\View\HelperPluginManager;
+use Laminas\View\Renderer\PhpRenderer;
+use Psr\Container\ContainerInterface;
+
+final class RenderChildModelFactory
+{
+    public function __invoke(ContainerInterface $container): RenderChildModel
+    {
+        $helpers = $container->get(HelperPluginManager::class);
+
+        return new RenderChildModel(
+            $helpers->get(ViewModel::class),
+            $container->get(PhpRenderer::class),
+        );
+    }
+}

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -170,7 +170,7 @@ class HelperPluginManager extends AbstractPluginManager
         Helper\PartialLoop::class         => InvokableFactory::class,
         Helper\Partial::class             => InvokableFactory::class,
         Helper\Placeholder::class         => InvokableFactory::class,
-        Helper\RenderChildModel::class    => InvokableFactory::class,
+        Helper\RenderChildModel::class    => Helper\Service\RenderChildModelFactory::class,
         Helper\RenderToPlaceholder::class => InvokableFactory::class,
         Helper\ServerUrl::class           => InvokableFactory::class,
         Helper\ViewModel::class           => InvokableFactory::class,

--- a/test/Helper/RenderChildModelTest.php
+++ b/test/Helper/RenderChildModelTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Helper;
 
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\View\ConfigProvider;
 use Laminas\View\Exception;
 use Laminas\View\Helper\RenderChildModel;
 use Laminas\View\Helper\ViewModel as ViewModelHelper;
+use Laminas\View\HelperPluginManager;
 use Laminas\View\Model\ViewModel;
 use Laminas\View\Renderer\PhpRenderer;
 use Laminas\View\Resolver\TemplateMapResolver;
@@ -22,21 +25,25 @@ final class RenderChildModelTest extends TestCase
 
     protected function setUp(): void
     {
+        $config                             = (new ConfigProvider())->__invoke();
+        $config['dependencies']['services'] = ['config' => $config];
+        $serviceManager                     = new ServiceManager($config['dependencies']);
+
         $this->resolver = new TemplateMapResolver([
             'layout'  => __DIR__ . '/../_templates/nested-view-model-layout.phtml',
             'child1'  => __DIR__ . '/../_templates/nested-view-model-content.phtml',
             'child2'  => __DIR__ . '/../_templates/nested-view-model-child2.phtml',
             'complex' => __DIR__ . '/../_templates/nested-view-model-complexlayout.phtml',
         ]);
-        $this->renderer = $renderer = new PhpRenderer();
-        $renderer->setCanRenderTrees(true);
-        $renderer->setResolver($this->resolver);
 
-        $helper                = $renderer->plugin(ViewModelHelper::class);
-        $this->viewModelHelper = $helper;
+        $this->renderer = $serviceManager->get(PhpRenderer::class);
+        $this->renderer->setCanRenderTrees(true);
+        $this->renderer->setResolver($this->resolver);
+        $plugins = $serviceManager->get(HelperPluginManager::class);
 
-        $helper       = $renderer->plugin(RenderChildModel::class);
-        $this->helper = $helper;
+        $this->viewModelHelper = $plugins->get(ViewModelHelper::class);
+
+        $this->helper = $plugins->get(RenderChildModel::class);
 
         $this->parent = new ViewModel();
         $this->parent->setTemplate('layout');
@@ -46,7 +53,7 @@ final class RenderChildModelTest extends TestCase
 
     public function testRendersEmptyStringWhenUnableToResolveChildModel(): void
     {
-        $result = $this->helper->render('child1');
+        $result = $this->helper->__invoke('child1');
         $this->assertSame('', $result);
     }
 
@@ -62,7 +69,7 @@ final class RenderChildModelTest extends TestCase
     public function testRendersChildTemplateWhenAbleToResolveChildModelByCaptureToValue(): void
     {
         $this->setupFirstChild();
-        $result = $this->helper->render('child1');
+        $result = $this->helper->__invoke('child1');
         $this->assertStringContainsString('Content for layout', $result, $result);
     }
 
@@ -79,9 +86,9 @@ final class RenderChildModelTest extends TestCase
     {
         $this->setupFirstChild();
         $this->setupSecondChild();
-        $result = $this->helper->render('child1');
+        $result = $this->helper->__invoke('child1');
         $this->assertStringContainsString('Content for layout', $result, $result);
-        $result = $this->helper->render('child2');
+        $result = $this->helper->__invoke('child2');
         $this->assertStringContainsString('Second child', $result, $result);
     }
 
@@ -94,7 +101,7 @@ final class RenderChildModelTest extends TestCase
         $child2->setCaptureTo('content');
         $child1->addChild($child2);
 
-        $result = $this->helper->render('child1');
+        $result = $this->helper->__invoke('child1');
         $this->assertStringContainsString('Layout start', $result, $result);
         $this->assertStringContainsString('Content for layout', $result, $result);
         $this->assertStringContainsString('Layout end', $result, $result);
@@ -125,10 +132,9 @@ final class RenderChildModelTest extends TestCase
 
     public function testAttemptingToRenderWithNoCurrentModelRaisesException(): void
     {
-        $renderer = new PhpRenderer();
-        $renderer->setResolver($this->resolver);
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('no view model');
-        $renderer->render('layout');
+        $this->viewModelHelper->resetState();
+        $this->renderer->render('layout');
     }
 }

--- a/test/ViewTest.php
+++ b/test/ViewTest.php
@@ -6,6 +6,8 @@ namespace LaminasTest\View;
 
 use Laminas\Http\Request;
 use Laminas\Http\Response;
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\View\ConfigProvider;
 use Laminas\View\Exception;
 use Laminas\View\Model\JsonModel;
 use Laminas\View\Model\ViewModel;
@@ -235,11 +237,15 @@ final class ViewTest extends TestCase
 
     public function testUsesTreeRendererInterfaceToDetermineWhetherOrNotToPassOnlyRootViewModelToPhpRenderer(): void
     {
+        $config                             = (new ConfigProvider())->__invoke();
+        $config['dependencies']['services'] = ['config' => $config];
+        $serviceManager                     = new ServiceManager($config['dependencies']);
+
         $resolver    = new Resolver\TemplateMapResolver([
             'layout'  => __DIR__ . '/_templates/nested-view-model-layout.phtml',
             'content' => __DIR__ . '/_templates/nested-view-model-content.phtml',
         ]);
-        $phpRenderer = new PhpRenderer();
+        $phpRenderer = $serviceManager->get(PhpRenderer::class);
         $phpRenderer->setCanRenderTrees(true);
         $phpRenderer->setResolver($resolver);
 


### PR DESCRIPTION
- Makes internal deps visible with constructor injection
- Adds factory for the helper
- Adds the final keyword
- Removes inheritance
- Removes `RenderChildModel::render()` in favour of `__invoke`