### PR TITLE
Make use of `EscaperInterface`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "ext-dom": "*",
         "ext-filter": "*",
         "ext-json": "*",
-        "laminas/laminas-escaper": "^2.5",
+        "laminas/laminas-escaper": "^2.17.0",
         "laminas/laminas-eventmanager": "^3.4",
         "laminas/laminas-servicemanager": "^4.4.0",
         "laminas/laminas-stdlib": "^3.10.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2065f3c1c6ba61aacef170d9e1d9a1c",
+    "content-hash": "74b48be3124977362050068a469b707f",
     "packages": [
         {
             "name": "brick/varexporter",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -268,6 +268,9 @@
       <code><![CDATA[$content]]></code>
       <code><![CDATA[$content]]></code>
     </PossiblyFalseArgument>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$attributes]]></code>
+    </PossiblyInvalidArgument>
     <PossiblyNullArgument>
       <code><![CDATA[$index]]></code>
     </PossiblyNullArgument>
@@ -525,16 +528,15 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/HtmlAttributesSet.php">
-    <MissingTemplateParam>
-      <code><![CDATA[HtmlAttributesSet]]></code>
-    </MissingTemplateParam>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$value]]></code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment>
-      <code><![CDATA[$storeValue]]></code>
+    <PossiblyInvalidCast>
       <code><![CDATA[$value]]></code>
-    </MixedAssignment>
+    </PossiblyInvalidCast>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(string) $key]]></code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Model/ClearableModelInterface.php">
     <MissingReturnType>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\View;
 
 use Laminas\Escaper\Escaper;
+use Laminas\Escaper\EscaperInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Helper\Doctype;
 use Laminas\View\Helper\Service\EscaperFactory;
@@ -129,6 +130,7 @@ final class ConfigProvider
                 Resolver\TemplatePathStack::class       => Resolver\Factory\TemplatePathStackResolverFactory::class,
             ],
             'aliases'   => [
+                EscaperInterface::class           => Escaper::class,
                 Renderer\RendererInterface::class => Renderer\PhpRenderer::class,
                 Resolver\ResolverInterface::class => Resolver\AggregateResolver::class,
             ],

--- a/src/Helper/Escaper/AbstractHelper.php
+++ b/src/Helper/Escaper/AbstractHelper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper\Escaper;
 
-use Laminas\Escaper\Escaper;
+use Laminas\Escaper\EscaperInterface;
 use Laminas\View\Exception;
 
 use function is_array;
@@ -22,7 +22,7 @@ abstract class AbstractHelper
     public const RECURSE_ARRAY  = 0x01;
     public const RECURSE_OBJECT = 0x02;
 
-    public function __construct(protected readonly Escaper $escaper)
+    public function __construct(protected readonly EscaperInterface $escaper)
     {
     }
 

--- a/src/Helper/GravatarImage.php
+++ b/src/Helper/GravatarImage.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper;
 
-use Laminas\Escaper\Escaper;
+use Laminas\Escaper\EscaperInterface;
 use Laminas\View\HtmlAttributesSet;
 
 use function md5;
@@ -61,7 +61,7 @@ final class GravatarImage
         self::DEFAULT_BLANK,
     ];
 
-    public function __construct(private readonly Escaper $escaper)
+    public function __construct(private readonly EscaperInterface $escaper)
     {
     }
 

--- a/src/Helper/HeadTitle.php
+++ b/src/Helper/HeadTitle.php
@@ -6,6 +6,7 @@ namespace Laminas\View\Helper;
 
 use Closure;
 use Laminas\Escaper\Escaper;
+use Laminas\Escaper\EscaperInterface;
 use Laminas\Translator\TranslatorInterface;
 use Stringable;
 
@@ -23,7 +24,7 @@ final class HeadTitle implements Stringable, StatefulHelperInterface
 {
     /** @var list<string> $items */
     private array $items = [];
-    private readonly Escaper $escaper;
+    private readonly EscaperInterface $escaper;
     private string|null $separator;
     private string|null $indent;
     private string|null $prefix;
@@ -33,7 +34,7 @@ final class HeadTitle implements Stringable, StatefulHelperInterface
      * @param non-empty-string $translatorTextDomain
      */
     public function __construct(
-        Escaper|null $escaper = null,
+        EscaperInterface|null $escaper = null,
         private readonly bool $autoEscape = true,
         private readonly string $defaultSeparator = '',
         private readonly string $defaultIndent = '',

--- a/src/Helper/HtmlAttributes.php
+++ b/src/Helper/HtmlAttributes.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper;
 
-use Laminas\Escaper\Escaper;
+use Laminas\Escaper\EscaperInterface;
 use Laminas\View\HtmlAttributesSet;
 
 /**
@@ -12,7 +12,7 @@ use Laminas\View\HtmlAttributesSet;
  */
 final class HtmlAttributes
 {
-    public function __construct(private readonly Escaper $escaper)
+    public function __construct(private readonly EscaperInterface $escaper)
     {
     }
 

--- a/src/Helper/HtmlList.php
+++ b/src/Helper/HtmlList.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper;
 
-use Laminas\Escaper\Escaper;
+use Laminas\Escaper\EscaperInterface;
 use Laminas\View\Exception;
 use Laminas\View\HtmlAttributesSet;
 
@@ -22,7 +22,7 @@ use const PHP_EOL;
  */
 final class HtmlList
 {
-    public function __construct(private readonly Escaper $escaper)
+    public function __construct(private readonly EscaperInterface $escaper)
     {
     }
 

--- a/src/Helper/Service/EscapeHelperFactory.php
+++ b/src/Helper/Service/EscapeHelperFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\View\Helper\Service;
 
 use Laminas\Escaper\Escaper;
+use Laminas\Escaper\EscaperInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\View\Exception\InvalidArgumentException;
 use Laminas\View\Helper\EscapeCss;
@@ -53,8 +54,8 @@ final class EscapeHelperFactory implements FactoryInterface
             ));
         }
 
-        $escaper = $container->has(Escaper::class)
-            ? $container->get(Escaper::class)
+        $escaper = $container->has(EscaperInterface::class)
+            ? $container->get(EscaperInterface::class)
             : new Escaper();
 
         return new $type($escaper);

--- a/src/Helper/Service/HeadTitleFactory.php
+++ b/src/Helper/Service/HeadTitleFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\View\Helper\Service;
 
 use Laminas\Escaper\Escaper;
+use Laminas\Escaper\EscaperInterface;
 use Laminas\View\Helper\HeadTitle;
 use Psr\Container\ContainerInterface;
 
@@ -25,8 +26,8 @@ final class HeadTitleFactory
 
         $options = $this->resolveOptions($config);
 
-        $escaper = $container->has(Escaper::class)
-            ? $container->get(Escaper::class)
+        $escaper = $container->has(EscaperInterface::class)
+            ? $container->get(EscaperInterface::class)
             : new Escaper();
 
         return new HeadTitle(

--- a/src/HtmlAttributesSet.php
+++ b/src/HtmlAttributesSet.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laminas\View;
 
 use ArrayObject;
-use Laminas\Escaper\Escaper;
+use Laminas\Escaper\EscaperInterface;
 use Traversable;
 
 use function array_merge;
@@ -28,18 +28,16 @@ use const JSON_THROW_ON_ERROR;
  * Class for storing and processing HTML tag attributes.
  *
  * @psalm-type AttributeSet = array<string, scalar|array|null>
+ * @extends ArrayObject<string, scalar|array|null>
  */
 final class HtmlAttributesSet extends ArrayObject
 {
-    /**
-     * HTML escaper
-     */
-    private Escaper $escaper;
-
-    public function __construct(Escaper $escaper, iterable $attributes = [])
+    /** @param iterable<string, scalar|array|null> $attributes */
+    public function __construct(private readonly EscaperInterface $escaper, iterable $attributes = [])
     {
-        $attributes    = $attributes instanceof Traversable ? iterator_to_array($attributes, true) : $attributes;
-        $this->escaper = $escaper;
+        $attributes = $attributes instanceof Traversable
+            ? iterator_to_array($attributes, true)
+            : $attributes;
         parent::__construct($attributes);
     }
 


### PR DESCRIPTION
Amends already refactored view helpers to type hint on `EscaperInterface` from the upgraded `laminas-escaper@2.17.0`

