### PR TITLE
[RFC] Invokable View Variables are (should not be) Automatically Invoked

### DIFF
--- a/test/PhpRendererTest.php
+++ b/test/PhpRendererTest.php
@@ -35,6 +35,7 @@ use function realpath;
 use function restore_error_handler;
 use function set_error_handler;
 use function str_replace;
+use function trim;
 
 use const E_WARNING;
 
@@ -493,5 +494,39 @@ final class PhpRendererTest extends TestCase
         $actual = $this->renderer->render(false);
 
         $this->assertNotSame($previousOutput, $actual);
+    }
+
+    /**
+     * @see VariablesTest::testAllowsSpecifyingClosureValuesAndReturningTheValue()
+     * @see VariablesTest::testAllowsSpecifyingFunctorValuesAndReturningTheValue()
+     */
+    public function testInvokableViewVariablesAreNotAutomaticallyInvoked(): void
+    {
+        $renderer = new PhpRenderer();
+        $resolver = new TemplateMapResolver([
+            'template' => __DIR__ . '/_templates/invokable-view-variable.phtml',
+        ]);
+
+        $invokable = new class {
+            public function __invoke()
+            {
+                throw new RuntimeException('Not expected to be invoked');
+            }
+
+            public function doSomething(): string
+            {
+                return 'Something';
+            }
+        };
+
+        $model = new ViewModel([
+            'object' => $invokable,
+        ]);
+        $model->setTemplate('template');
+
+        $renderer->setResolver($resolver);
+        $output = $renderer->render($model);
+
+        self::assertSame('Something', trim($output));
     }
 }

--- a/test/_templates/invokable-view-variable.phtml
+++ b/test/_templates/invokable-view-variable.phtml
@@ -1,0 +1,7 @@
+<?php
+
+assert(isset($this->object));
+assert(is_object($this->object));
+assert(method_exists($this->object, 'doSomething'));
+
+echo $this->object->doSomething();


### PR DESCRIPTION
This PR is, for now, just a reminder that this behaviour should be either:

- Kept and documented
- Removed, or
- Made optional via configuration

I personally favour option 2 - Removing the behaviour so that invokable variables passed to the view model are just variables, therefore requiring explicit invokation.

Removal will not affect view helpers registered with the plugin manager.

Issue #18 brought this to my attention - it was behaviour I was unaware of.

CC @laminas/technical-steering-committee 