### PR TITLE
Refactor `HeadMeta` view helper

### DIFF
--- a/docs/book/v3/helpers/head-meta.md
+++ b/docs/book/v3/helpers/head-meta.md
@@ -1,82 +1,55 @@
 # HeadMeta
 
-The HTML `<meta>` element is used to provide meta information about your HTML
-document, typically keywords, document character set, caching pragmas, etc. Meta
-tags may be either of the `http-equiv` or `name` types, must contain a `content`
-attribute, and can also have either of the `lang` or `scheme` modifier
-attributes.
+The HTML `<meta>` element is used to provide meta information about your HTML document, typically keywords, document character set, caching pragmas, etc.
 
-The `HeadMeta` helper supports the following methods for setting and adding meta tags:
+Meta tags are typically be one of:
 
-- `appendName($keyValue, $content, $conditionalName)`
-- `offsetSetName($index, $keyValue, $content, $conditionalName)`
-- `prependName($keyValue, $content, $conditionalName)`
-- `setName($keyValue, $content, $modifiers)`
-- `appendHttpEquiv($keyValue, $content, $conditionalHttpEquiv)`
-- `offsetSetHttpEquiv($index, $keyValue, $content, $conditionalHttpEquiv)`
-- `prependHttpEquiv($keyValue, $content, $conditionalHttpEquiv)`
-- `setHttpEquiv($keyValue, $content, $modifiers)`
-- `setCharset($charset)`
+- `http-equiv`
+- `name`
+- `itemprop`
+- `property`
+- `charset`
 
-The following methods are also supported with `XHTML1_RDFA` doctype set with the
-[Doctype helper](doctype.md).
+Most of these types, must contain a `content` attribute, and can also have various additional attributes.
 
-- `appendProperty($property, $content, $modifiers)`
-- `offsetSetProperty($index, $property, $content, $modifiers)`
-- `prependProperty($property, $content, $modifiers)`
-- `setProperty($property, $content, $modifiers)`
-
-Finally, starting in 2.11.2, you can call the following method to determine
-whether or not to autoescape values used in meta tags:
-
-- `setAutoEscape(bool $autoEscape = true)` (enabled by default)
-
-<!-- markdownlint-disable-next-line heading-increment -->
-> ### AutoEscape
->
-> **Disable this flag at your own risk.** The one documented case where it is
-> necessary to disable the flag is when setting the `X-UA-Compatible`
-> `http-equiv` value to switch behavior for Internet Explorer, as escaped values
-> will not trigger correct representation.
-
-The `$keyValue` item is used to define a value for the `name` or `http-equiv`
-key; `$content` is the value for the 'content' key, and `$modifiers` is an
-optional associative array that can contain keys for `lang` and/or `scheme`.
-
-You may also set meta tags using the `headMeta()` helper method, which has the
-following signature: `headMeta($content, $keyValue, $keyType = 'name',
-$modifiers = [], $placement = 'APPEND')`.  `$keyValue` is the content for
-the key specified in `$keyType`, which should be either `name` or `http-equiv`.
-`$keyType` may also be specified as `property` if the doctype has been set to
-`XHTML1_RDFA`. `$placement` can be `SET` (overwrites all previously stored
-values), `APPEND` (added to end of stack), or `PREPEND` (added to top of stack).
-
-`HeadMeta` overrides each of `append()`, `offsetSet()`, `prepend()`, and `set()`
-to enforce usage of the special methods as listed above. Internally, it stores
-each item as a `stdClass` token, which it later serializes using the
-`itemToString()` method. This allows you to perform checks on the items in the
-stack, and optionally modify these items by simply modifying the object
-returned.
-
-The `HeadMeta` helper is a concrete implementation of the
-[Placeholder helper](placeholder.md).
+For detailed information about the `<meta>` tag and its various attributes, please consult [Mozilla's documentation](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/meta).
 
 ## Basic Usage
 
-You may specify a new meta tag at any time. Typically, you will specify
-client-side caching rules or SEO keywords.
+You can call the `headMeta()` view helper at any time from within any template to add items to the list of meta tags to render.
 
-For instance, if you wish to specify SEO keywords, you'd be creating a meta name
-tag with the name `keywords` and the content the keywords you wish to associate
-with your page:
+Here's an example for setting an SEO description and rendering the output immediately:
 
 ```php
-// setting meta keywords
-$this->headMeta()->appendName('keywords', 'framework, PHP, productivity');
+echo $this->headMeta()
+    ->appendName('description', 'This is a meta description');
+
+// Will output: <meta content="This is a meta description" name="description">
 ```
 
-If you wished to set some client-side caching rules, you'd set `http-equiv` tags
-with the rules you wish to enforce:
+You can control the order of meta tags by using either the `prepend` prefixed method names or `append` prefixed method names.
+Method names prefixed with `set`, for example `setName()` or `setHttpEquiv` will first delete any meta tag with a matching name prior to appending the item to the list.
+
+```php
+echo $this->headMeta()
+          ->appendName('author', 'Miss Piggy')
+          ->prependName('generator', 'Laminas')
+          ->setName('author', 'Kermit');
+
+// <meta content="Laminas" name="generator">
+// <meta content="Kermit" name="author">
+```
+
+Identical meta entries are ignored, so executing the following will yield only 1 entry.
+
+```php
+echo $this->headMeta()
+          ->appendName('generator', 'Fozzy Bear')
+          ->appendName('generator', 'Fozzy Bear');
+// <meta content="Fozzy Bear" name="generator">
+```
+
+If you wished to set some client-side caching rules, you'd set `http-equiv` tags with the rules you wish to enforce:
 
 ```php
 // disabling client-side cache
@@ -86,8 +59,7 @@ $this->headMeta()
     ->appendHttpEquiv('Cache-Control', 'no-cache');
 ```
 
-Another popular use for meta tags is setting the content type, character set,
-and language:
+You may wish to set the content type, character set, and language if this has not already been sent by HTTP headers.
 
 ```php
 // setting content type and character set
@@ -101,7 +73,8 @@ this:
 
 ```php
 // setting character set in HTML5
-$this->headMeta()->setCharset('UTF-8'); // Will look like <meta charset="UTF-8">
+echo $this->headMeta()->setCharset('UTF-8');
+// <meta charset="UTF-8">
 ```
 
 As a final example, an easy way to display a transitional message before a
@@ -110,7 +83,7 @@ redirect is using a "meta refresh":
 ```php
 // setting a meta refresh for 3 seconds to a new url:
 $this->headMeta()
-    ->appendHttpEquiv('Refresh', '3;URL=http://www.some.org/some.html');
+    ->appendHttpEquiv('Refresh', '3;URL=https://www.example.com/target.html');
 ```
 
 When you're ready to place your meta tags in the layout, echo the helper:
@@ -119,19 +92,17 @@ When you're ready to place your meta tags in the layout, echo the helper:
 <?= $this->headMeta() ?>
 ```
 
-## Usage with XHTML1\_RDFA doctype
+## Usage with RDFa Compatible Doctypes
 
-Enabling the RDFa doctype with the [Doctype helper](doctype.md) enables the use
-of the `property` attribute (in addition to the standard `name` and
-`http-equiv`) with `HeadMeta`.  This is commonly used with the Facebook [Open
-Graph Protocol](http://opengraphprotocol.org/).
+If you plan on emitting [Open Graph Protocol](http://opengraphprotocol.org/) meta tags for services such as Facebook or LinkedIn, then you _should_ be using an [RDFa](https://rdfa.info/) compatible doctype.
 
-For instance, you may specify an open graph page title and type as follows:
+The `HeadMeta` helper will not prohibit you from adding `<meta property="og:whatever">` tags, but if you are _not_ serving HTML5 documents, check that your doctype is set to something that is compatible with RDFa so that your emitted markup is valid.
+
+The methods `setProperty`, `appendProperty` and `prependProperty` provide convenient shortcuts for adding these tags:
 
 ```php
-$this->doctype(Laminas\View\Helper\Doctype::XHTML1_RDFA);
-$this->headMeta()->setProperty('og:title', 'my article title');
-$this->headMeta()->setProperty('og:type', 'article');
+$this->headMeta()->prependProperty('og:title', 'my article title');
+$this->headMeta()->appendProperty('og:type', 'article');
 echo $this->headMeta();
 
 // output is:
@@ -139,15 +110,13 @@ echo $this->headMeta();
 //   <meta property="og:type" content="article" />
 ```
 
-## Usage with HTML5 doctype
+## Adding Schema.org Structured Data as Meta tags
 
-Enabling the HTML5 doctype with the [Doctype helper](doctype.md) enables the use
-of the `itemprop` attribute (in addition to the standard `name` and
-`http-equiv`) with `HeadMeta`.  This is typically used to add
-[Microdata](https://schema.org) to the head of your document.
+With `setItemprop`, `appendItemprop` and `prependItemprop`, you can easily add structured data to your document as meta tags.
+
+To learn more about structured data, start with the [documentation at schema.org](https://schema.org/docs/documents.html).
 
 ```php
-$this->doctype(Laminas\View\Helper\Doctype::HTML5);
 $this->headMeta()->setItemprop('headline', 'My Article Headline');
 $this->headMeta()->setItemprop('dateCreated', $date->format('c'));
 echo $this->headMeta();
@@ -156,3 +125,37 @@ echo $this->headMeta();
 //   <meta itemprop="headline" content="My Article Headline">
 //   <meta itemprop="dateCreated" content="2018-07-12T22:19:06+00:00">
 ```
+
+## Support for Arbitrary Custom Meta Tags
+
+The `HeadMeta` helper does not validate the meta tags you configure - this is the task of a dedicated HTML validator such as [the one provided by the W3C](https://validator.w3.org/).
+
+As such, it is possible to add meta tags with any attribute/value pairs that you desire using the `append` and `prepend` methods:
+
+```php
+$this->headMeta()->append([
+    'muppet' => 'Gonzo',
+    'colour' => 'Blue',
+]);
+$this->headMeta()->prepend([
+    'muppet' => 'Kermit',
+    'colour' => 'Green',
+]);
+echo $this->headMeta();
+
+// <meta colour="Green" muppet="Kermit">
+// <meta colour="Blue" muppet="Gonzo">
+```
+
+## Attribute Escaping & Normalisation
+
+All attribute names are converted to lowercase and all values are escaped, it is therefore important not to provide already encoded values to the `HeadMeta` helper to avoid double encoding.
+
+## Further Reading
+
+- [The Doctype Helper](doctype.md) affects the output style of the meta tag and should be configured to match the meta types you intend to use
+- [Mozilla Documentation on the Meta tag](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/meta)
+- [Schema.org Documentation](https://schema.org/docs/documents.html) and the [`itemprop` global attribute](https://developer.mozilla.org/docs/Web/HTML/Reference/Global_attributes/itemprop)
+- [Open Graph Protocol](http://opengraphprotocol.org/)
+- [RDFa](https://rdfa.info/)
+- [W3C Markup Validator](https://validator.w3.org/)

--- a/docs/book/v3/migration/v2-to-v3.md
+++ b/docs/book/v3/migration/v2-to-v3.md
@@ -112,6 +112,28 @@ This means that a number of methods no longer exist, including, but not limited 
 
 Please consult the [updated documentation](../helpers/head-link.md) for further information.
 
+#### `HeadMeta`
+
+The `HeadMeta` helper's inheritance hierarchy has changed and it no longer extends from anything.
+This means that a number of methods no longer exist, including, but not limited to:
+
+- `getContainer`
+- `setContainer`
+- `getContainerClass`
+- `setContainerClass`
+- `getEscaper`
+- `setEscaper`
+- `getIndent`
+- `getSeparator`
+- `getPrefix`
+- `getPostfix`
+- `getView`
+- `setView`
+- `offsetGet|Set|Unset|Exists`
+- `count` and many more…
+
+Please consult the [updated documentation](../helpers/head-meta.md) for further information.
+
 #### `HtmlAttributes`
 
 This helper no longer inherits from a base class, therefore the following methods have been removed

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -70,73 +70,6 @@
       <code><![CDATA[$value[$k]]]></code>
     </MixedAssignment>
   </file>
-  <file src="src/Helper/HeadMeta.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$item]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </ArgumentTypeCoercion>
-    <MethodSignatureMustProvideReturnType>
-      <code><![CDATA[offsetSet]]></code>
-      <code><![CDATA[offsetUnset]]></code>
-    </MethodSignatureMustProvideReturnType>
-    <MixedArgument>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$index]]></code>
-      <code><![CDATA[$item->$type]]></code>
-      <code><![CDATA[$item->content]]></code>
-      <code><![CDATA[$item->type]]></code>
-      <code><![CDATA[$key]]></code>
-      <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($item->$type) : $item->$type]]></code>
-      <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($item->content) : $item->content]]></code>
-      <code><![CDATA[$this->autoEscape ? $this->escapeAttribute($value) : $value]]></code>
-      <code><![CDATA[$type]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$doctype]]></code>
-      <code><![CDATA[$index]]></code>
-      <code><![CDATA[$key]]></code>
-      <code><![CDATA[$type]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedAssignment>
-    <MixedMethodCall>
-      <code><![CDATA[isHtml5]]></code>
-      <code><![CDATA[isHtml5]]></code>
-      <code><![CDATA[isHtml5]]></code>
-      <code><![CDATA[isHtml5]]></code>
-      <code><![CDATA[isRdfa]]></code>
-      <code><![CDATA[isXhtml]]></code>
-    </MixedMethodCall>
-    <MixedReturnStatement>
-      <code><![CDATA[parent::__call($method, $args)]]></code>
-      <code><![CDATA[parent::__call($method, $args)]]></code>
-    </MixedReturnStatement>
-    <ParamNameMismatch>
-      <code><![CDATA[$index]]></code>
-    </ParamNameMismatch>
-    <PossiblyNullArgument>
-      <code><![CDATA[$index]]></code>
-      <code><![CDATA[$this->view]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullReference>
-      <code><![CDATA[plugin]]></code>
-      <code><![CDATA[plugin]]></code>
-      <code><![CDATA[plugin]]></code>
-    </PossiblyNullReference>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[AbstractContainer]]></code>
-      <code><![CDATA[AbstractContainer]]></code>
-    </PossiblyUnusedReturnValue>
-    <UndefinedInterfaceMethod>
-      <code><![CDATA[plugin]]></code>
-      <code><![CDATA[plugin]]></code>
-      <code><![CDATA[plugin]]></code>
-    </UndefinedInterfaceMethod>
-  </file>
   <file src="src/Helper/HeadScript.php">
     <MethodSignatureMustProvideReturnType>
       <code><![CDATA[offsetSet]]></code>
@@ -401,6 +334,7 @@
     <PossiblyUnusedMethod>
       <code><![CDATA[__get]]></code>
       <code><![CDATA[__set]]></code>
+      <code><![CDATA[escape]]></code>
       <code><![CDATA[getAutoEscape]]></code>
     </PossiblyUnusedMethod>
     <RedundantCastGivenDocblockType>
@@ -822,28 +756,6 @@
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(string) $this->helper->toString()]]></code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="test/Helper/HeadMetaTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[setService]]></code>
-    </DeprecatedMethod>
-    <InvalidArgument>
-      <code><![CDATA['foo']]></code>
-      <code><![CDATA['foo']]></code>
-      <code><![CDATA['foo']]></code>
-    </InvalidArgument>
-    <PossiblyNullPropertyFetch>
-      <code><![CDATA[$item->content]]></code>
-      <code><![CDATA[$item->name]]></code>
-      <code><![CDATA[$item->type]]></code>
-    </PossiblyNullPropertyFetch>
-    <UndefinedMagicMethod>
-      <code><![CDATA[offsetSetHttpEquiv]]></code>
-      <code><![CDATA[offsetSetHttpEquiv]]></code>
-      <code><![CDATA[offsetSetName]]></code>
-      <code><![CDATA[offsetSetName]]></code>
-      <code><![CDATA[offsetSetName]]></code>
-    </UndefinedMagicMethod>
   </file>
   <file src="test/Helper/HeadScriptTest.php">
     <DeprecatedMethod>

--- a/src/HTML/Tag.php
+++ b/src/HTML/Tag.php
@@ -4,20 +4,53 @@ declare(strict_types=1);
 
 namespace Laminas\View\HTML;
 
+use function array_change_key_case;
+use function array_key_exists;
+use function ksort;
+use function strtolower;
+
+use const CASE_LOWER;
+
 /**
  * This class is not part of the public API and has no BC guarantees
  *
- * @internal
+ * @psalm-internal Laminas\View
+ * @psalm-internal LaminasTest\View
  */
 final class Tag
 {
+    /** @var array<string, scalar> */
+    public readonly array $attributes;
+
     /**
      * @param non-empty-string $tag
      * @param array<string, scalar> $attributes
      */
     public function __construct(
         public readonly string $tag,
-        public array $attributes = [],
+        array $attributes = [],
     ) {
+        $attributes = array_change_key_case($attributes, CASE_LOWER);
+        ksort($attributes);
+
+        $this->attributes = $attributes;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->tag === $other->tag
+            && $this->attributes === $other->attributes;
+    }
+
+    public function hasAttribute(string $name): bool
+    {
+        return array_key_exists(strtolower($name), $this->attributes);
+    }
+
+    public function getAttribute(string $name): int|float|string|bool|null
+    {
+        $name = strtolower($name);
+
+        return $this->attributes[$name] ?? null;
     }
 }

--- a/src/Helper/HeadMeta.php
+++ b/src/Helper/HeadMeta.php
@@ -4,526 +4,286 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper;
 
-use Laminas\View;
-use Laminas\View\Exception;
-use Laminas\View\Helper\Placeholder\Container\AbstractContainer;
-use Laminas\View\Helper\Placeholder\Container\AbstractStandalone;
-use stdClass;
+use Laminas\Escaper\EscaperInterface;
+use Laminas\View\HTML\Tag;
+use Laminas\View\HtmlAttributesSet;
+use Stringable;
 
-use function array_shift;
+use function array_filter;
+use function array_map;
 use function array_unshift;
-use function assert;
-use function count;
+use function array_values;
 use function implode;
-use function in_array;
-use function is_object;
-use function is_string;
-use function method_exists;
-use function preg_match;
-use function rtrim;
+use function is_int;
 use function sprintf;
-use function str_replace;
-use function strtolower;
-use function trigger_error;
+use function str_repeat;
 
-use const E_USER_WARNING;
 use const PHP_EOL;
 
-/**
- * Laminas\View\Helper\HeadMeta
- *
- * @see http://www.w3.org/TR/xhtml1/dtds.html
- *
- * Allows the following 'virtual' methods:
- *
- * @method HeadMeta appendName($keyValue, $content, $modifiers = array())
- * @method HeadMeta offsetGetName($index, $keyValue, $content, $modifiers = array())
- * @method HeadMeta prependName($keyValue, $content, $modifiers = array())
- * @method HeadMeta setName($keyValue, $content, $modifiers = array())
- * @method HeadMeta appendHttpEquiv($keyValue, $content, $modifiers = array())
- * @method HeadMeta offsetGetHttpEquiv($index, $keyValue, $content, $modifiers = array())
- * @method HeadMeta prependHttpEquiv($keyValue, $content, $modifiers = array())
- * @method HeadMeta setHttpEquiv($keyValue, $content, $modifiers = array())
- * @method HeadMeta appendProperty($keyValue, $content, $modifiers = array())
- * @method HeadMeta offsetGetProperty($index, $keyValue, $content, $modifiers = array())
- * @method HeadMeta prependProperty($keyValue, $content, $modifiers = array())
- * @method HeadMeta setProperty($keyValue, $content, $modifiers = array())
- * @method HeadMeta appendItemprop($keyValue, $content, $modifiers = array())
- * @method HeadMeta offsetGetItemprop($index, $keyValue, $content, $modifiers = array())
- * @method HeadMeta prependItemprop($keyValue, $content, $modifiers = array())
- * @method HeadMeta setItemprop($keyValue, $content, $modifiers = array())
- *
- * @psalm-type ObjectShape = object{
- *     type: string,
- *     content: string,
- *     modifiers: array<string, mixed>,
- *     name?: string,
- *     http-equiv?: string,
- *     charset?: string,
- *     property?: string,
- *     itemprop?: string,
- * }
- * @extends AbstractStandalone<int, ObjectShape>
- * @final
- */
-class HeadMeta extends AbstractStandalone
+final class HeadMeta implements StatefulHelperInterface, Stringable
 {
-    /**
-     * Allowed key types
-     *
-     * @var list<string>
-     */
-    protected $typeKeys = ['name', 'http-equiv', 'charset', 'property', 'itemprop'];
+    /** @var list<Tag> */
+    private array $items = [];
+    private string $indent;
+    private string $separator;
 
-    /**
-     * Required attributes for meta tag
-     *
-     * @deprecated This property is unused and will be removed in version 3.0
-     *
-     * @var list<string>
-     */
-    protected $requiredKeys = ['content'];
+    public function __construct(
+        private readonly Doctype $doctype,
+        private readonly EscaperInterface $escaper,
+        private readonly string $defaultSeparator = PHP_EOL,
+        private readonly string $defaultIndent = '',
+    ) {
+        $this->indent    = $this->defaultIndent;
+        $this->separator = $this->defaultSeparator;
+    }
 
-    /**
-     * Allowed modifier keys
-     *
-     * @var list<string>
-     */
-    protected $modifierKeys = ['lang', 'scheme'];
-
-    public function __construct()
+    public function resetState(): void
     {
-        parent::__construct();
-
-        $this->getContainer()->setSeparator(PHP_EOL);
+        $this->items     = [];
+        $this->indent    = $this->defaultIndent;
+        $this->separator = $this->defaultSeparator;
     }
 
     /**
      * Retrieve object instance; optionally add meta tag
      *
-     * @param  string $content
-     * @param  string $keyValue
-     * @param  string $keyType
-     * @param  array  $modifiers
-     * @param  string $placement
-     * @return $this
+     * @param array<string, scalar> $attributes
      */
     public function __invoke(
-        $content = null,
-        $keyValue = null,
-        $keyType = 'name',
-        $modifiers = [],
-        $placement = AbstractContainer::APPEND
-    ) {
-        if ((null !== $content) && (null !== $keyValue)) {
-            $item   = $this->createData($keyType, $keyValue, $content, $modifiers);
-            $action = strtolower($placement);
-            switch ($action) {
-                case 'append':
-                case 'prepend':
-                case 'set':
-                    $this->$action($item);
-                    break;
-                default:
-                    $this->append($item);
-                    break;
+        string|null $name = null,
+        string|null $content = null,
+        array $attributes = [],
+    ): self {
+        if ($name !== null && $content !== null) {
+            return $this->appendName($name, $content, $attributes);
+        }
+
+        if ($attributes === []) {
+            return $this;
+        }
+
+        return $this->append($attributes);
+    }
+
+    /**
+     * Render placeholder as string
+     */
+    public function toString(string|int|null $indent = null): string
+    {
+        $indent   = is_int($indent) ? str_repeat(' ', $indent) : $indent;
+        $indent ??= $this->indent;
+        $indent   = $this->escaper->escapeHtml($indent);
+
+        return implode($this->escaper->escapeHtml($this->separator), array_map(
+            function (Tag $tag) use ($indent): string {
+                return $indent . $this->itemToString($tag);
+            },
+            $this->items,
+        ));
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+
+    private function itemToString(Tag $item): string
+    {
+        $attributes = new HtmlAttributesSet($this->escaper, $item->attributes);
+        $closing    = $this->doctype->isXhtml() ? ' /' : '';
+
+        return sprintf('<%s%s%s>', $item->tag, (string) $attributes, $closing);
+    }
+
+    /** @param array<string, scalar> $attributes */
+    public function append(array $attributes): self
+    {
+        if ($attributes === []) {
+            return $this;
+        }
+
+        $tag = new Tag('meta', $attributes);
+        foreach ($this->items as $item) {
+            if ($item->equals($tag)) {
+                return $this;
             }
         }
+
+        $this->items[] = $tag;
+
+        return $this;
+    }
+
+    /** @param array<string, scalar> $attributes */
+    public function prepend(array $attributes): self
+    {
+        if ($attributes === []) {
+            return $this;
+        }
+
+        $tag = new Tag('meta', $attributes);
+        foreach ($this->items as $item) {
+            if ($item->equals($tag)) {
+                return $this;
+            }
+        }
+
+        array_unshift($this->items, $tag);
 
         return $this;
     }
 
     /**
-     * Overload method access
-     *
-     * @param  string $method
-     * @param  array  $args
-     * @throws Exception\BadMethodCallException
-     * @return $this
-     */
-    public function __call($method, $args)
-    {
-        if (
-            preg_match(
-                '/^(?P<action>set|(pre|ap)pend|offsetSet)(?P<type>Name|HttpEquiv|Property|Itemprop)$/',
-                $method,
-                $matches
-            )
-        ) {
-            $action = $matches['action'];
-            $type   = $this->normalizeType($matches['type']);
-            $argc   = count($args);
-            $index  = null;
-
-            if ('offsetSet' === $action) {
-                if (0 < $argc) {
-                    $index = array_shift($args);
-                    --$argc;
-                }
-            }
-
-            if (2 > $argc) {
-                throw new Exception\BadMethodCallException(
-                    'Too few arguments provided; requires key value, and content'
-                );
-            }
-
-            if (3 > $argc) {
-                $args[] = [];
-            }
-
-            $item = $this->createData($type, $args[0], $args[1], $args[2]);
-
-            if ('offsetSet' === $action) {
-                $this->offsetSet($index, $item);
-
-                return $this;
-            }
-
-            $this->$action($item);
-
-            return $this;
-        }
-
-        return parent::__call($method, $args);
-    }
-
-    /**
-     * Render placeholder as string
-     *
-     * @param  string|int $indent
-     * @return string
-     */
-    public function toString($indent = null)
-    {
-        $container = $this->getContainer();
-        $indent    = null !== $indent
-            ? $container->getWhitespace($indent)
-            : $container->getIndent();
-
-        $items = [];
-        $container->ksort();
-
-        $doctype = $this->view->plugin('doctype');
-        assert($doctype instanceof Doctype);
-        $isHtml5 = $doctype->isHtml5();
-
-        try {
-            foreach ($container as $item) {
-                $content = $this->itemToString($item);
-
-                if ($isHtml5 && $item->type === 'charset') {
-                    array_unshift($items, $content);
-                    continue;
-                }
-
-                $items[] = $content;
-            }
-        } catch (Exception\InvalidArgumentException $e) {
-            trigger_error($e->getMessage(), E_USER_WARNING);
-            return '';
-        }
-
-        return $indent . implode($this->escape($container->getSeparator()) . $indent, $items);
-    }
-
-    /**
-     * Create data item for inserting into stack
-     *
-     * @internal This method will become private in version 3.0
-     *
-     * @param  string $type
-     * @param  string $typeValue
-     * @param  string $content
-     * @return object
-     */
-    public function createData($type, $typeValue, $content, array $modifiers)
-    {
-        return (object) [
-            'type'      => $type,
-            $type       => $typeValue,
-            'content'   => $content,
-            'modifiers' => $modifiers,
-        ];
-    }
-
-    /**
-     * Build meta HTML string
-     *
-     * @internal This method will become private in version 3.0
-     *
-     * @throws Exception\InvalidArgumentException
-     * @return string
-     */
-    public function itemToString(stdClass $item)
-    {
-        if (! in_array($item->type, $this->typeKeys)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'Invalid type "%s" provided for meta',
-                $item->type
-            ));
-        }
-        $type = $item->type;
-
-        $modifiersString = '';
-        foreach ($item->modifiers as $key => $value) {
-            if (
-                $this->view->plugin('doctype')->isHtml5()
-                && $key === 'scheme'
-            ) {
-                throw new Exception\InvalidArgumentException(
-                    'Invalid modifier "scheme" provided; not supported by HTML5'
-                );
-            }
-            if (! in_array($key, $this->modifierKeys)) {
-                continue;
-            }
-            $modifiersString .= sprintf('%s="%s"', $key, $this->autoEscape ? $this->escapeAttribute($value) : $value);
-        }
-
-        $modifiersString = rtrim($modifiersString);
-
-        if ('' !== $modifiersString) {
-            $modifiersString = ' ' . $modifiersString;
-        }
-
-        if (method_exists($this->view, 'plugin')) {
-            if (
-                $this->view->plugin('doctype')->isHtml5()
-                && $type === 'charset'
-            ) {
-                $tpl = $this->view->plugin('doctype')->isXhtml()
-                    ? '<meta %s="%s"/>'
-                    : '<meta %s="%s">';
-            } elseif ($this->view->plugin('doctype')->isXhtml()) {
-                $tpl = '<meta %s="%s" content="%s"%s />';
-            } else {
-                $tpl = '<meta %s="%s" content="%s"%s>';
-            }
-        } else {
-            $tpl = '<meta %s="%s" content="%s"%s />';
-        }
-
-        $meta = sprintf(
-            $tpl,
-            $type,
-            $this->autoEscape ? $this->escapeAttribute($item->$type) : $item->$type,
-            $this->autoEscape ? $this->escapeAttribute($item->content) : $item->content,
-            $modifiersString
-        );
-
-        if (
-            isset($item->modifiers['conditional'])
-            && ! empty($item->modifiers['conditional'])
-            && is_string($item->modifiers['conditional'])
-        ) {
-            // inner wrap with comment end and start if !IE
-            if (str_replace(' ', '', $item->modifiers['conditional']) === '!IE') {
-                $meta = '<!-->' . $meta . '<!--';
-            }
-            $meta = '<!--[if ' . $this->escape($item->modifiers['conditional']) . ']>' . $meta . '<![endif]-->';
-        }
-
-        return $meta;
-    }
-
-    /**
-     * Normalize type attribute of meta
-     *
-     * @internal This method will become private in version 3.0
-     *
-     * @param  string $type type in CamelCase
-     * @throws Exception\DomainException
-     * @return string
-     */
-    protected function normalizeType($type)
-    {
-        switch ($type) {
-            case 'Name':
-                return 'name';
-            case 'HttpEquiv':
-                return 'http-equiv';
-            case 'Property':
-                return 'property';
-            case 'Itemprop':
-                return 'itemprop';
-            default:
-                throw new Exception\DomainException(sprintf(
-                    'Invalid type "%s" passed to normalizeType',
-                    $type
-                ));
-        }
-    }
-
-    /**
-     * Determine if item is valid
-     *
-     * @internal This method will become private in version 3.0
-     *
-     * @param mixed $item
-     * @return bool
-     */
-    protected function isValid($item)
-    {
-        if (
-            ! is_object($item)
-            || ! isset($item->type)
-            || ! isset($item->modifiers)
-        ) {
-            return false;
-        }
-
-        $doctype = $this->view->plugin('doctype');
-        if ($item->type === 'charset' && $doctype->isXhtml()) {
-            return false;
-        }
-
-        if (
-            ! isset($item->content)
-            && (! $doctype->isHtml5()
-            || (! $doctype->isHtml5() && $item->type !== 'charset'))
-        ) {
-            return false;
-        }
-
-        // <meta itemprop= ... /> is only supported with doctype html
-        if (
-            ! $doctype->isHtml5()
-            && $item->type === 'itemprop'
-        ) {
-            return false;
-        }
-
-        // <meta property= ... /> is only supported with doctype RDFa
-        if (
-            ! $doctype->isRdfa()
-            && $item->type === 'property'
-        ) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Append
-     *
-     * @param  object $value
-     * @return View\Helper\Placeholder\Container\AbstractContainer
-     * @throws Exception\InvalidArgumentException
-     */
-    public function append($value)
-    {
-        if (! $this->isValid($value)) {
-            throw new Exception\InvalidArgumentException(
-                'Invalid value passed to append'
-            );
-        }
-
-        return $this->getContainer()->append($value);
-    }
-
-    /**
-     * OffsetSet
-     *
-     * @param  int $index
-     * @param  mixed $value
-     * @return void
-     * @throws Exception\InvalidArgumentException
-     */
-    public function offsetSet($index, $value)
-    {
-        if (! $this->isValid($value)) {
-            throw  new Exception\InvalidArgumentException(
-                'Invalid value passed to offsetSet; please use offsetSetName() or offsetSetHttpEquiv()'
-            );
-        }
-
-        $this->getContainer()->offsetSet($index, $value);
-    }
-
-    /**
-     * OffsetUnset
-     *
-     * @param  int $offset
-     * @return void
-     * @throws Exception\InvalidArgumentException
-     */
-    public function offsetUnset($offset)
-    {
-        if (! in_array($offset, $this->getContainer()->getKeys())) {
-            throw new Exception\InvalidArgumentException('Invalid index passed to offsetUnset()');
-        }
-
-        $this->getContainer()->offsetUnset($offset);
-    }
-
-    /**
-     * Prepend
-     *
-     * @param object $value
-     * @throws Exception\InvalidArgumentException
-     * @return AbstractContainer
-     */
-    public function prepend($value)
-    {
-        if (! $this->isValid($value)) {
-            throw new Exception\InvalidArgumentException(
-                'Invalid value passed to prepend'
-            );
-        }
-
-        return $this->getContainer()->prepend($value);
-    }
-
-    /**
-     * Set
-     *
-     * @param object $value
-     * @throws Exception\InvalidArgumentException
-     * @return AbstractContainer
-     */
-    public function set($value)
-    {
-        if (! $this->isValid($value)) {
-            throw new Exception\InvalidArgumentException('Invalid value passed to set');
-        }
-
-        $container = $this->getContainer();
-        foreach ($container->getArrayCopy() as $index => $item) {
-            if ($item->type === $value->type && $item->{$item->type} === $value->{$value->type}) {
-                $this->offsetUnset($index);
-            }
-        }
-
-        return $this->append($value);
-    }
-
-    /**
      * Create an HTML5-style meta charset tag. Something like <meta charset="utf-8">
-     *
-     * Not valid in a non-HTML5 doctype
-     *
-     * @param string $charset
-     * @throws Exception\InvalidArgumentException
-     * @return $this
      */
-    public function setCharset($charset)
+    public function setCharset(string $charset): self
     {
-        $item = (object) [
-            'type'      => 'charset',
-            'charset'   => $charset,
-            'content'   => null,
-            'modifiers' => [],
-        ];
+        $this->clearByAttribute('charset');
+        $this->prepend(['charset' => $charset]);
 
-        if (! $this->isValid($item)) {
-            throw new Exception\InvalidArgumentException(
-                'XHTML* doctype has no attribute charset; please use appendHttpEquiv()'
-            );
-        }
+        return $this;
+    }
 
-        $this->set($item);
+    /** @param array<string, scalar> $attributes */
+    public function setName(string $name, string $content, array $attributes = []): self
+    {
+        $this->clearByAttributeValue('name', $name);
+        $attributes['name']    = $name;
+        $attributes['content'] = $content;
+
+        return $this->append($attributes);
+    }
+
+    /** @param array<string, scalar> $attributes */
+    public function appendName(string $name, string $content, array $attributes = []): self
+    {
+        $attributes['name']    = $name;
+        $attributes['content'] = $content;
+
+        return $this->append($attributes);
+    }
+
+    /** @param array<string, scalar> $attributes */
+    public function prependName(string $name, string $content, array $attributes = []): self
+    {
+        $attributes['name']    = $name;
+        $attributes['content'] = $content;
+
+        return $this->prepend($attributes);
+    }
+
+    /** @param array<string, scalar> $attributes */
+    public function setItemprop(string $itemprop, string $content, array $attributes = []): self
+    {
+        $this->clearByAttributeValue('itemprop', $itemprop);
+        $attributes['itemprop'] = $itemprop;
+        $attributes['content']  = $content;
+
+        return $this->append($attributes);
+    }
+
+    /** @param array<string, scalar> $attributes */
+    public function appendItemprop(string $itemprop, string $content, array $attributes = []): self
+    {
+        $attributes['itemprop'] = $itemprop;
+        $attributes['content']  = $content;
+
+        return $this->append($attributes);
+    }
+
+    /** @param array<string, scalar> $attributes */
+    public function prependItemprop(string $itemprop, string $content, array $attributes = []): self
+    {
+        $attributes['itemprop'] = $itemprop;
+        $attributes['content']  = $content;
+
+        return $this->prepend($attributes);
+    }
+
+    /** @param array<string, scalar> $attributes */
+    public function setProperty(string $property, string $content, array $attributes = []): self
+    {
+        $this->clearByAttributeValue('property', $property);
+        $attributes['property'] = $property;
+        $attributes['content']  = $content;
+
+        return $this->append($attributes);
+    }
+
+    /** @param array<string, scalar> $attributes */
+    public function appendProperty(string $property, string $content, array $attributes = []): self
+    {
+        $attributes['property'] = $property;
+        $attributes['content']  = $content;
+
+        return $this->append($attributes);
+    }
+
+    /** @param array<string, scalar> $attributes */
+    public function prependProperty(string $property, string $content, array $attributes = []): self
+    {
+        $attributes['property'] = $property;
+        $attributes['content']  = $content;
+
+        return $this->prepend($attributes);
+    }
+
+    /** @param array<string, scalar> $attributes */
+    public function setHttpEquiv(string $httpEquiv, string $content, array $attributes = []): self
+    {
+        $this->clearByAttributeValue('http-equiv', $httpEquiv);
+        $attributes['http-equiv'] = $httpEquiv;
+        $attributes['content']    = $content;
+
+        return $this->append($attributes);
+    }
+
+    /** @param array<string, scalar> $attributes */
+    public function appendHttpEquiv(string $httpEquiv, string $content, array $attributes = []): self
+    {
+        $attributes['http-equiv'] = $httpEquiv;
+        $attributes['content']    = $content;
+
+        return $this->append($attributes);
+    }
+
+    /** @param array<string, scalar> $attributes */
+    public function prependHttpEquiv(string $httpEquiv, string $content, array $attributes = []): self
+    {
+        $attributes['http-equiv'] = $httpEquiv;
+        $attributes['content']    = $content;
+
+        return $this->prepend($attributes);
+    }
+
+    private function clearByAttribute(string $attribute): void
+    {
+        $this->items = array_values(array_filter(
+            $this->items,
+            static fn (Tag $item): bool => ! $item->hasAttribute($attribute),
+        ));
+    }
+
+    private function clearByAttributeValue(string $name, int|string|float|bool $value): void
+    {
+        $this->items = array_values(array_filter(
+            $this->items,
+            static fn (Tag $item): bool => (! $item->hasAttribute($name)) || $item->getAttribute($name) !== $value,
+        ));
+    }
+
+    public function setIndent(string|int $indent): self
+    {
+        $this->indent = is_int($indent)
+            ? str_repeat(' ', $indent)
+            : $indent;
+
+        return $this;
+    }
+
+    public function setSeparator(string $separator): self
+    {
+        $this->separator = $separator;
 
         return $this;
     }

--- a/src/Helper/Service/HeadMetaFactory.php
+++ b/src/Helper/Service/HeadMetaFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View\Helper\Service;
+
+use Laminas\Escaper\EscaperInterface;
+use Laminas\View\Helper\Doctype;
+use Laminas\View\Helper\HeadMeta;
+use Laminas\View\HelperPluginManager;
+use Psr\Container\ContainerInterface;
+
+/** @internal */
+final class HeadMetaFactory
+{
+    public function __invoke(ContainerInterface $container): HeadMeta
+    {
+        $helpers = $container->get(HelperPluginManager::class);
+
+        return new HeadMeta(
+            $helpers->get(Doctype::class),
+            $container->get(EscaperInterface::class),
+        );
+    }
+}

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -42,7 +42,7 @@ final class HelperPluginManager extends AbstractPluginManager
             Helper\EscapeUrl::class           => EscapeHelperFactory::class,
             Helper\GravatarImage::class       => EscapeHelperFactory::class,
             Helper\HeadLink::class            => Helper\Service\HeadLinkFactory::class,
-            Helper\HeadMeta::class            => InvokableFactory::class,
+            Helper\HeadMeta::class            => Helper\Service\HeadMetaFactory::class,
             Helper\HeadScript::class          => InvokableFactory::class,
             Helper\HeadStyle::class           => InvokableFactory::class,
             Helper\HeadTitle::class           => Helper\Service\HeadTitleFactory::class,

--- a/test/HTML/TagTest.php
+++ b/test/HTML/TagTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\View\HTML;
+
+use Laminas\View\HTML\Tag;
+use PHPUnit\Framework\TestCase;
+
+final class TagTest extends TestCase
+{
+    public function testEqualityWithSameAttributeOrder(): void
+    {
+        self::assertTrue(
+            (new Tag('foo', ['bar' => 'baz', 'bing' => 'bong']))->equals(
+                new Tag('foo', ['bar' => 'baz', 'bing' => 'bong']),
+            ),
+        );
+    }
+
+    public function testEqualityWithDifferentAttributeOrder(): void
+    {
+        self::assertTrue(
+            (new Tag('foo', ['bar' => 'baz', 'bing' => 'bong']))->equals(
+                new Tag('foo', ['bing' => 'bong', 'bar' => 'baz']),
+            ),
+        );
+    }
+
+    public function testEqualityWithDifferentTag(): void
+    {
+        self::assertFalse(
+            (new Tag('foo', ['bar' => 'baz', 'bing' => 'bong']))->equals(
+                new Tag('oof', ['bar' => 'baz', 'bing' => 'bong']),
+            ),
+        );
+    }
+
+    public function testEqualityWithDifferentAttributes(): void
+    {
+        self::assertFalse(
+            (new Tag('foo', ['bar' => 'baz', 'bing' => 'bong']))->equals(
+                new Tag('foo', ['bar' => 'baz']),
+            ),
+        );
+    }
+}

--- a/test/Helper/HeadLinkTest.php
+++ b/test/Helper/HeadLinkTest.php
@@ -60,7 +60,7 @@ final class HeadLinkTest extends TestCase
     {
         $this->helper->appendStylesheet('foo.css');
         self::assertSame(
-            '<link rel="stylesheet" href="foo.css" type="text&#x2F;css">',
+            '<link href="foo.css" rel="stylesheet" type="text&#x2F;css">',
             $this->helper->toString(),
         );
     }
@@ -69,7 +69,7 @@ final class HeadLinkTest extends TestCase
     {
         $this->helper->appendStylesheet('foo.css', ['data-baz' => 'bing']);
         self::assertSame(
-            '<link data-baz="bing" rel="stylesheet" href="foo.css" type="text&#x2F;css">',
+            '<link data-baz="bing" href="foo.css" rel="stylesheet" type="text&#x2F;css">',
             $this->helper->toString(),
         );
     }
@@ -81,9 +81,9 @@ final class HeadLinkTest extends TestCase
         $this->helper->appendStylesheet('c.css');
 
         $expect = <<<'HTML'
-            <link rel="stylesheet" href="b.css" type="text&#x2F;css">
-            <link rel="stylesheet" href="a.css" type="text&#x2F;css">
-            <link rel="stylesheet" href="c.css" type="text&#x2F;css">
+            <link href="b.css" rel="stylesheet" type="text&#x2F;css">
+            <link href="a.css" rel="stylesheet" type="text&#x2F;css">
+            <link href="c.css" rel="stylesheet" type="text&#x2F;css">
             HTML;
 
         self::assertSame($expect, $this->helper->toString());
@@ -96,7 +96,7 @@ final class HeadLinkTest extends TestCase
         $this->helper->setStylesheet('c.css');
 
         $expect = <<<'HTML'
-            <link rel="stylesheet" href="c.css" type="text&#x2F;css">
+            <link href="c.css" rel="stylesheet" type="text&#x2F;css">
             HTML;
 
         self::assertSame($expect, $this->helper->toString());
@@ -108,7 +108,7 @@ final class HeadLinkTest extends TestCase
         $this->helper->append(['rel' => 'preload', 'as' => 'font', 'href' => 'a.woff']);
 
         self::assertSame(
-            '<link rel="preload" as="font" href="a.woff" />',
+            '<link as="font" href="a.woff" rel="preload" />',
             $this->helper->toString(),
         );
     }
@@ -118,7 +118,7 @@ final class HeadLinkTest extends TestCase
         $this->helper->appendStylesheet('foo');
         $this->helper->appendStylesheet('foo');
         self::assertSame(
-            '<link rel="stylesheet" href="foo" type="text&#x2F;css">',
+            '<link href="foo" rel="stylesheet" type="text&#x2F;css">',
             $this->helper->toString(),
         );
     }
@@ -129,8 +129,8 @@ final class HeadLinkTest extends TestCase
         $this->helper->append(['rel' => 'b', 'href' => 'foo']);
 
         $expect = <<<'HTML'
-            <link rel="a" href="foo">
-            <link rel="b" href="foo">
+            <link href="foo" rel="a">
+            <link href="foo" rel="b">
             HTML;
 
         self::assertSame($expect, $this->helper->toString());
@@ -143,7 +143,7 @@ final class HeadLinkTest extends TestCase
         $this->helper->setSeparator('Kermit');
 
         $expect = <<<'HTML'
-            <link rel="a" href="foo">Kermit<link rel="b" href="foo">
+            <link href="foo" rel="a">Kermit<link href="foo" rel="b">
             HTML;
         self::assertSame($expect, $this->helper->toString());
     }

--- a/test/Helper/HeadMetaTest.php
+++ b/test/Helper/HeadMetaTest.php
@@ -5,23 +5,12 @@ declare(strict_types=1);
 namespace LaminasTest\View\Helper;
 
 use Laminas\Escaper\Escaper;
-use Laminas\View\Exception;
-use Laminas\View\Exception\ExceptionInterface as ViewException;
-use Laminas\View\Helper;
 use Laminas\View\Helper\Doctype;
 use Laminas\View\Helper\HeadMeta;
-use Laminas\View\Renderer\PhpRenderer as View;
 use PHPUnit\Framework\TestCase;
 
-use function array_shift;
-use function restore_error_handler;
-use function set_error_handler;
-use function sprintf;
-use function str_replace;
 use function substr_count;
-use function ucwords;
 
-use const E_USER_WARNING;
 use const PHP_EOL;
 
 /** @psalm-import-type DoctypeID from Doctype */
@@ -29,264 +18,90 @@ final class HeadMetaTest extends TestCase
 {
     private HeadMeta $helper;
     private Escaper $escaper;
-    private View $view;
 
-    /**
-     * Sets up the fixture, for example, open a network connection.
-     * This method is called before a test is executed.
-     */
     protected function setUp(): void
     {
-        $this->view = new View();
-        $this->setDoctype(Doctype::XHTML1_STRICT);
-        $this->helper = new HeadMeta();
-        $this->helper->setView($this->view);
         $this->escaper = new Escaper();
+        $this->helper  = new HeadMeta(
+            new Doctype(),
+            $this->escaper,
+        );
     }
 
     /** @param DoctypeID $doctype */
     private function setDoctype(string $doctype): void
     {
-        $helpers = $this->view->getHelperPluginManager();
-        $helpers->setAllowOverride(true);
         $doctype = new Doctype($doctype);
-        $helpers->setService(Doctype::class, $doctype);
+
+        $this->helper = new HeadMeta(
+            $doctype,
+            $this->escaper,
+        );
     }
 
     public function testHeadMetaReturnsObjectInstance(): void
     {
-        $placeholder = $this->helper->__invoke();
-        $this->assertInstanceOf(Helper\HeadMeta::class, $placeholder);
+        self::assertSame($this->helper, $this->helper->__invoke());
     }
 
-    public function testThatAppendThrowsExceptionWhenNonMetaValueIsProvided(): void
+    public function testBasicOperationOfNamedMeta(): void
     {
-        $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid value passed to append');
-        $this->helper->append('foo');
+        $this->helper->appendName('description', 'some description')
+            ->prependName('keywords', 'foo, bar')
+            ->setName('generator', 'laminas');
+
+        $expect = <<<'HTML'
+            <meta content="foo,&#x20;bar" name="keywords">
+            <meta content="some&#x20;description" name="description">
+            <meta content="laminas" name="generator">
+            HTML;
+
+        self::assertSame($expect, $this->helper->__toString());
     }
 
-    public function testThatOffsetSetThrowsExceptionWhenNonMetaValueIsProvided(): void
+    public function testBasicOperationOfHttpEquiv(): void
     {
-        $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid value passed to offsetSet');
-        $this->helper->offsetSet(3, 'foo');
+        $this->helper->appendHttpEquiv('Content-type', 'x-application/muppets')
+            ->setHttpEquiv('muppet', 'Miss Piggy')
+            ->prependHttpEquiv('refresh', '5; url=Kermit');
+
+        $expect = <<<'HTML'
+            <meta content="5&#x3B;&#x20;url&#x3D;Kermit" http-equiv="refresh">
+            <meta content="x-application&#x2F;muppets" http-equiv="Content-type">
+            <meta content="Miss&#x20;Piggy" http-equiv="muppet">
+            HTML;
+
+        self::assertSame($expect, $this->helper->__toString());
     }
 
-    public function testThatPrependThrowsExceptionWhenNonMetaValueIsProvided(): void
+    public function testBasicOperationOfItemprop(): void
     {
-        $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid value passed to prepend');
-        $this->helper->prepend('foo');
+        $this->helper->appendItemprop('name', 'Fred')
+            ->setItemprop('taxId', '123456')
+            ->prependItemprop('telephone', '+441234567890');
+
+        $expect = <<<'HTML'
+            <meta content="&#x2B;441234567890" itemprop="telephone">
+            <meta content="Fred" itemprop="name">
+            <meta content="123456" itemprop="taxId">
+            HTML;
+
+        self::assertSame($expect, $this->helper->toString());
     }
 
-    public function testThatSetThrowsExceptionWhenNonMetaValueIsProvided(): void
+    public function testBasicOperationOfProperty(): void
     {
-        $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid value passed to set');
-        $this->helper->set('foo');
-    }
+        $this->helper->appendProperty('og:title', 'Some Title')
+            ->setProperty('og:description', 'Some description')
+            ->prependProperty('og:image', 'https://example.com/foo.jpg');
 
-    private function inflectAction(string $type): string
-    {
-        $type = str_replace('-', ' ', $type);
-        $type = ucwords($type);
+        $expect = <<<'HTML'
+            <meta content="https&#x3A;&#x2F;&#x2F;example.com&#x2F;foo.jpg" property="og&#x3A;image">
+            <meta content="Some&#x20;Title" property="og&#x3A;title">
+            <meta content="Some&#x20;description" property="og&#x3A;description">
+            HTML;
 
-        return str_replace(' ', '', $type);
-    }
-
-    protected function executeOverloadAppend(string $type): void
-    {
-        $action = 'append' . $this->inflectAction($type);
-        $string = 'foo';
-        for ($i = 0; $i < 3; ++$i) {
-            $string .= ' foo';
-            $this->helper->$action('keywords', $string);
-            $values = $this->helper->getContainer()->getArrayCopy();
-            $this->assertCount($i + 1, $values);
-
-            $item = $values[$i];
-            $this->assertObjectHasProperty('type', $item);
-            $this->assertObjectHasProperty('modifiers', $item);
-            $this->assertObjectHasProperty('content', $item);
-            $this->assertObjectHasProperty($item->type, $item);
-            $this->assertEquals('keywords', $item->{$item->type});
-            $this->assertEquals($string, $item->content);
-        }
-    }
-
-    protected function executeOverloadPrepend(string $type): void
-    {
-        $action = 'prepend' . $this->inflectAction($type);
-        $string = 'foo';
-        for ($i = 0; $i < 3; ++$i) {
-            $string .= ' foo';
-            $this->helper->$action('keywords', $string);
-            $values = $this->helper->getContainer()->getArrayCopy();
-            self::assertCount($i + 1, $values);
-            $item = array_shift($values);
-            self::assertIsObject($item);
-            $this->assertObjectHasProperty('type', $item);
-            $this->assertObjectHasProperty('modifiers', $item);
-            $this->assertObjectHasProperty('content', $item);
-            $this->assertObjectHasProperty($item->type, $item);
-            $this->assertEquals('keywords', $item->{$item->type});
-            $this->assertEquals($string, $item->content);
-        }
-    }
-
-    protected function executeOverloadSet(string $type): void
-    {
-        $setAction    = 'set' . $this->inflectAction($type);
-        $appendAction = 'append' . $this->inflectAction($type);
-        $string       = 'foo';
-        for ($i = 0; $i < 3; ++$i) {
-            $this->helper->$appendAction('keywords', $string);
-            $string .= ' foo';
-        }
-        $this->helper->$setAction('keywords', $string);
-
-        $values = $this->helper->getContainer()->getArrayCopy();
-        $this->assertCount(1, $values);
-        $item = array_shift($values);
-        self::assertIsObject($item);
-
-        $this->assertObjectHasProperty('type', $item);
-        $this->assertObjectHasProperty('modifiers', $item);
-        $this->assertObjectHasProperty('content', $item);
-        $this->assertObjectHasProperty($item->type, $item);
-        $this->assertEquals('keywords', $item->{$item->type});
-        $this->assertEquals($string, $item->content);
-    }
-
-    public function testOverloadingAppendNameAppendsMetaTagToStack(): void
-    {
-        $this->executeOverloadAppend('name');
-    }
-
-    public function testOverloadingPrependNamePrependsMetaTagToStack(): void
-    {
-        $this->executeOverloadPrepend('name');
-    }
-
-    public function testOverloadingSetNameOverwritesMetaTagStack(): void
-    {
-        $this->executeOverloadSet('name');
-    }
-
-    public function testOverloadingAppendHttpEquivAppendsMetaTagToStack(): void
-    {
-        $this->executeOverloadAppend('http-equiv');
-    }
-
-    public function testOverloadingPrependHttpEquivPrependsMetaTagToStack(): void
-    {
-        $this->executeOverloadPrepend('http-equiv');
-    }
-
-    public function testOverloadingSetHttpEquivOverwritesMetaTagStack(): void
-    {
-        $this->executeOverloadSet('http-equiv');
-    }
-
-    public function testOverloadingThrowsExceptionWithFewerThanTwoArgs(): void
-    {
-        $this->expectException(Exception\ExceptionInterface::class);
-        /** @psalm-suppress TooFewArguments */
-        $this->helper->setName('foo');
-    }
-
-    public function testOverloadingThrowsExceptionWithInvalidMethodType(): void
-    {
-        $this->expectException(Exception\ExceptionInterface::class);
-        /** @psalm-suppress UndefinedMagicMethod */
-        $this->helper->setFoo('foo');
-    }
-
-    public function testCanBuildMetaTagsWithAttributes(): void
-    {
-        $this->helper->setName('keywords', 'foo bar', ['lang' => 'us_en', 'scheme' => 'foo', 'bogus' => 'unused']);
-        $value = $this->helper->getContainer()->getValue();
-        self::assertIsObject($value);
-        $this->assertObjectHasProperty('modifiers', $value);
-        $modifiers = $value->modifiers;
-        $this->assertArrayHasKey('lang', $modifiers);
-        $this->assertEquals('us_en', $modifiers['lang']);
-        $this->assertArrayHasKey('scheme', $modifiers);
-        $this->assertEquals('foo', $modifiers['scheme']);
-    }
-
-    public function testToStringReturnsValidHtml(): void
-    {
-        $this->helper->setName('keywords', 'foo bar', ['lang' => 'us_en', 'scheme' => 'foo', 'bogus' => 'unused'])
-                     ->prependName('title', 'boo bah')
-                     ->appendHttpEquiv('screen', 'projection');
-        $string = $this->helper->toString();
-
-        $metas = substr_count($string, '<meta ');
-        $this->assertEquals(3, $metas);
-        $metas = substr_count($string, '/>');
-        $this->assertEquals(3, $metas);
-        $metas = substr_count($string, 'name="');
-        $this->assertEquals(2, $metas);
-        $metas = substr_count($string, 'http-equiv="');
-        $this->assertEquals(1, $metas);
-
-        $this->assertStringContainsString('http-equiv="screen" content="projection"', $string);
-        $this->assertStringContainsString(
-            'name="keywords" content="' . $this->escaper->escapeHtmlAttr('foo bar') . '"',
-            $string,
-        );
-        $this->assertStringContainsString('lang="us_en"', $string);
-        $this->assertStringContainsString('scheme="foo"', $string);
-        $this->assertStringNotContainsString('bogus', $string);
-        $this->assertStringNotContainsString('unused', $string);
-        $this->assertStringContainsString(
-            'name="title" content="' . $this->escaper->escapeHtmlAttr('boo bah') . '"',
-            $string,
-        );
-    }
-
-    public function testToStringWhenInvalidKeyProvidedShouldConvertThrownException(): void
-    {
-        $this->helper->__invoke('some-content', 'tag value', 'not allowed key');
-        $error = null;
-        set_error_handler(function (int $code, string $message) use (&$error): bool {
-            self::assertSame(E_USER_WARNING, $code);
-            $error = $message;
-
-            return true;
-        }, E_USER_WARNING);
-        $string = $this->helper->toString();
-        self::assertEquals('', $string);
-        self::assertEquals(
-            'Invalid type "not allowed key" provided for meta',
-            $error,
-        );
-        restore_error_handler();
-    }
-
-    public function testHeadMetaHelperCreatesItemEntry(): void
-    {
-        $this->helper->__invoke('foo', 'keywords');
-        $values = $this->helper->getContainer()->getArrayCopy();
-        $this->assertCount(1, $values);
-        $item = array_shift($values);
-        $this->assertEquals('foo', $item->content);
-        $this->assertEquals('name', $item->type);
-        $this->assertEquals('keywords', $item->name);
-    }
-
-    public function testOverloadingOffsetInsertsAtOffset(): void
-    {
-        $this->helper->offsetSetName(100, 'keywords', 'foo');
-        $values = $this->helper->getContainer()->getArrayCopy();
-        $this->assertCount(1, $values);
-        $this->assertArrayHasKey(100, $values);
-        $item = $values[100];
-        $this->assertEquals('foo', $item->content);
-        $this->assertEquals('name', $item->type);
-        $this->assertEquals('keywords', $item->name);
+        self::assertSame($expect, $this->helper->toString());
     }
 
     public function testIndentationIsHonored(): void
@@ -296,266 +111,190 @@ final class HeadMetaTest extends TestCase
         $this->helper->appendName('seo', 'baz bat');
         $string = $this->helper->toString();
 
-        $scripts = substr_count($string, '    <meta name=');
+        $scripts = substr_count($string, '    <meta content=');
         $this->assertEquals(2, $scripts);
     }
 
-    public function testStringRepresentationReflectsDoctype(): void
+    public function testIndentationCanBeAString(): void
     {
-        $this->setDoctype(Doctype::HTML4_STRICT);
-        $this->helper->__invoke('some content', 'foo');
+        $this->helper->setIndent("\t\t");
+        $this->helper->appendName('keywords', 'foo bar');
+        $this->helper->appendName('seo', 'baz bat');
+        $string = $this->helper->toString();
 
-        $test = $this->helper->toString();
-
-        $this->assertStringNotContainsString('/>', $test);
-        $this->assertStringContainsString($this->escaper->escapeHtmlAttr('some content'), $test);
-        $this->assertStringContainsString('foo', $test);
+        $scripts = substr_count($string, "\t\t" . '<meta content=');
+        $this->assertEquals(2, $scripts);
     }
 
-    public function testSetNameDoesntClobber(): void
+    public function testSelfClosingTagForXmlBasedDoctypes(): void
     {
-        $this->helper->setName('keywords', 'foo');
-        $this->helper->appendHttpEquiv('pragma', 'bar');
-        $this->helper->appendHttpEquiv('Cache-control', 'baz');
-        $this->helper->setName('keywords', 'bat');
+        $this->setDoctype(Doctype::XHTML1_STRICT);
+        $this->helper->appendName('bar', 'foo');
+        $expect = <<<'HTML'
+            <meta content="foo" name="bar" />
+            HTML;
 
-        $this->assertEquals(
-            '<meta http-equiv="pragma" content="bar" />' . PHP_EOL . '<meta http-equiv="Cache-control" content="baz" />'
-            . PHP_EOL . '<meta name="keywords" content="bat" />',
-            $this->helper->toString(),
-        );
+        self::assertSame($expect, $this->helper->toString());
     }
 
-    public function testSetNameDoesntClobberPart2(): void
+    public function testCharsetIsPrependedWhenSet(): void
     {
-        $this->helper->setName('keywords', 'foo');
+        $this->setDoctype(Doctype::HTML5);
         $this->helper->setName('description', 'foo');
-        $this->helper->appendHttpEquiv('pragma', 'baz');
-        $this->helper->appendHttpEquiv('Cache-control', 'baz');
-        $this->helper->setName('keywords', 'bar');
-
-        $expected = sprintf(
-            '<meta name="description" content="foo" />%1$s'
-            . '<meta http-equiv="pragma" content="baz" />%1$s'
-            . '<meta http-equiv="Cache-control" content="baz" />%1$s'
-            . '<meta name="keywords" content="bar" />',
-            PHP_EOL,
-        );
-
-        $this->assertEquals($expected, $this->helper->toString());
-    }
-
-    public function testPlacesMetaTagsInProperOrder(): void
-    {
-        $this->helper->setName('keywords', 'foo');
-        $this->helper->__invoke(
-            'some content',
-            'bar',
-            'name',
-            [],
-            Helper\Placeholder\Container\AbstractContainer::PREPEND,
-        );
-
-        $expected = sprintf(
-            '<meta name="bar" content="%s" />%s'
-            . '<meta name="keywords" content="foo" />',
-            $this->escaper->escapeHtmlAttr('some content'),
-            PHP_EOL,
-        );
-        $this->assertEquals($expected, $this->helper->toString());
-    }
-
-    public function testContainerMaintainsCorrectOrderOfItems(): void
-    {
-        $this->helper->offsetSetName(1, 'keywords', 'foo');
-        $this->helper->offsetSetName(10, 'description', 'foo');
-        $this->helper->offsetSetHttpEquiv(20, 'pragma', 'baz');
-        $this->helper->offsetSetHttpEquiv(5, 'Cache-control', 'baz');
-
-        $test = $this->helper->toString();
-
-        $expected = sprintf(
-            '<meta name="keywords" content="foo" />%1$s'
-            . '<meta http-equiv="Cache-control" content="baz" />%1$s'
-            . '<meta name="description" content="foo" />%1$s'
-            . '<meta http-equiv="pragma" content="baz" />',
-            PHP_EOL,
-        );
-
-        $this->assertEquals($expected, $test);
-    }
-
-    public function testCharsetValidateFail(): void
-    {
-        $this->setDoctype(Doctype::HTML4_STRICT);
-        $this->expectException(Exception\ExceptionInterface::class);
         $this->helper->setCharset('utf-8');
+        $expect = <<<'HTML'
+            <meta charset="utf-8">
+            <meta content="foo" name="description">
+            HTML;
+
+        self::assertSame($expect, $this->helper->toString());
     }
 
-    public function testCharset(): void
+    public function testSetCharsetWillClearExistingCharset(): void
     {
         $this->setDoctype(Doctype::HTML5);
+        $this->helper->append(['charset' => 'foo']);
+        $this->helper->prepend(['charset' => 'bar']);
         $this->helper->setCharset('utf-8');
-        $this->assertEquals(
-            '<meta charset="utf-8">',
-            $this->helper->toString(),
-        );
+        $expect = <<<'HTML'
+            <meta charset="utf-8">
+            HTML;
 
-        $this->setDoctype(Doctype::XHTML5);
-
-        $this->assertEquals(
-            '<meta charset="utf-8">',
-            $this->helper->toString(),
-        );
+        self::assertSame($expect, $this->helper->toString());
     }
 
-    public function testCharsetPosition(): void
+    public function testMultipleCharsetIsPossibleUsingPrependAndAppend(): void
     {
-        $this->setDoctype(Doctype::HTML5);
+        $this->helper->append(['charset' => 'foo']);
+        $this->helper->prepend(['charset' => 'bar']);
+        $expect = <<<'HTML'
+            <meta charset="bar">
+            <meta charset="foo">
+            HTML;
 
-        $this->helper
-            ->setProperty('description', 'foobar')
-            ->setCharset('utf-8');
-
-        $this->assertEquals(
-            '<meta charset="utf-8">' . PHP_EOL
-            . '<meta property="description" content="foobar">',
-            $this->helper->toString(),
-        );
+        self::assertSame($expect, $this->helper->toString());
     }
 
-    public function testCharsetWithXhtmlDoctypeGotException(): void
+    public function testEmptyAttributeArraysAreIgnored(): void
     {
-        $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('XHTML* doctype has no attribute charset; please use appendHttpEquiv()');
+        $this->helper->__invoke(null, null, [])
+            ->append([])
+            ->prepend([]);
 
-        $this->setDoctype(Doctype::XHTML1_RDFA);
-        $this->helper
-             ->setCharset('utf-8');
+        self::assertSame('', $this->helper->toString());
     }
 
-    public function testPropertyIsSupportedWithRdfaDoctype(): void
+    public function testInvokeReturnsSelf(): void
     {
-        $this->setDoctype(Doctype::XHTML1_RDFA);
-        $this->helper->__invoke('foo', 'og:title', 'property');
-
-        $expected = sprintf('<meta property="%s" content="foo" />', $this->escaper->escapeHtmlAttr('og:title'));
-        $this->assertEquals($expected, $this->helper->toString());
+        self::assertSame($this->helper, $this->helper->__invoke());
     }
 
-    public function testPropertyIsNotSupportedByDefaultDoctype(): void
+    public function testInvokeWillAppendNameWithNonNullArguments(): void
     {
-        try {
-            $this->helper->__invoke('foo', 'og:title', 'property');
-            $this->fail('meta property attribute should not be supported on default doctype');
-        } catch (ViewException $e) {
-            $this->assertStringContainsString('Invalid value passed', $e->getMessage());
-        }
+        $this->helper->__invoke('foo', 'bar', ['baz' => 'bat']);
+        $expect = <<<'HTML'
+            <meta baz="bat" content="bar" name="foo">
+            HTML;
+        self::assertSame($expect, $this->helper->toString());
     }
 
-    /**
-     * @depends testPropertyIsSupportedWithRdfaDoctype
-     */
-    public function testOverloadingAppendPropertyAppendsMetaTagToStack(): void
+    public function testInvokeWillAppendAttributesWhenNameAndContentAreNull(): void
     {
-        $this->setDoctype(Doctype::XHTML1_RDFA);
-        $this->executeOverloadAppend('property');
+        $this->helper->__invoke(null, null, ['baz' => 'bat']);
+        $expect = <<<'HTML'
+            <meta baz="bat">
+            HTML;
+        self::assertSame($expect, $this->helper->toString());
     }
 
-    /**
-     * @depends testPropertyIsSupportedWithRdfaDoctype
-     */
-    public function testOverloadingPrependPropertyPrependsMetaTagToStack(): void
+    public function testIdenticalItemsAreIgnoredWhenAppending(): void
     {
-        $this->setDoctype(Doctype::XHTML1_RDFA);
-        $this->executeOverloadPrepend('property');
+        $this->helper->appendName('foo', 'bar');
+        $this->helper->appendName('foo', 'bar');
+        $expect = <<<'HTML'
+            <meta content="bar" name="foo">
+            HTML;
+        self::assertSame($expect, $this->helper->toString());
     }
 
-    /**
-     * @depends testPropertyIsSupportedWithRdfaDoctype
-     */
-    public function testOverloadingSetPropertyOverwritesMetaTagStack(): void
+    public function testIdenticalItemsAreIgnoredWhenPrepending(): void
     {
-        $this->setDoctype(Doctype::XHTML1_RDFA);
-        $this->executeOverloadSet('property');
+        $this->helper->prependName('foo', 'bar');
+        $this->helper->prependName('foo', 'bar');
+        $expect = <<<'HTML'
+            <meta content="bar" name="foo">
+            HTML;
+        self::assertSame($expect, $this->helper->toString());
     }
 
-    public function testItempropIsSupportedWithHtml5Doctype(): void
+    public function testSeparatorCanBeChangedAndWillBeEscaped(): void
     {
-        $this->setDoctype(Doctype::HTML5);
-        $this->helper->__invoke('HeadMeta with Microdata', 'description', 'itemprop');
-
-        $expected = sprintf(
-            '<meta itemprop="description" content="%s">',
-            $this->escaper->escapeHtmlAttr('HeadMeta with Microdata'),
-        );
-        $this->assertEquals($expected, $this->helper->toString());
+        $this->helper->prependName('foo', 'bar')
+            ->prependName('bar', 'baz')
+            ->setSeparator(PHP_EOL . '&');
+        $expect = <<<'HTML'
+            <meta content="baz" name="bar">
+            &amp;<meta content="bar" name="foo">
+            HTML;
+        self::assertSame($expect, $this->helper->toString());
     }
 
-    public function testItempropIsNotSupportedByDefaultDoctype(): void
+    public function testIndentWillBeEscaped(): void
     {
-        try {
-            $this->helper->__invoke('HeadMeta with Microdata', 'description', 'itemprop');
-            $this->fail('meta itemprop attribute should not be supported on default doctype');
-        } catch (ViewException $e) {
-            $this->assertStringContainsString('Invalid value passed', $e->getMessage());
-        }
+        $this->helper->prependName('foo', 'bar')
+            ->prependName('bar', 'baz')
+            ->setIndent('&');
+        $expect = <<<'HTML'
+            &amp;<meta content="baz" name="bar">
+            &amp;<meta content="bar" name="foo">
+            HTML;
+        self::assertSame($expect, $this->helper->toString());
     }
 
-    /**
-     * @depends testItempropIsSupportedWithHtml5Doctype
-     */
-    public function testOverloadingAppendItempropAppendsMetaTagToStack(): void
+    public function testAllMetaMutationMethodsReturnSelf(): void
     {
-        $this->setDoctype(Doctype::HTML5);
-        $this->executeOverloadAppend('itemprop');
+        self::assertSame($this->helper, $this->helper->appendName('foo', 'bar'));
+        self::assertSame($this->helper, $this->helper->prependName('foo', 'bar'));
+        self::assertSame($this->helper, $this->helper->setName('foo', 'bar'));
+        self::assertSame($this->helper, $this->helper->appendProperty('foo', 'bar'));
+        self::assertSame($this->helper, $this->helper->prependProperty('foo', 'bar'));
+        self::assertSame($this->helper, $this->helper->setProperty('foo', 'bar'));
+        self::assertSame($this->helper, $this->helper->appendItemprop('foo', 'bar'));
+        self::assertSame($this->helper, $this->helper->prependItemprop('foo', 'bar'));
+        self::assertSame($this->helper, $this->helper->setItemprop('foo', 'bar'));
+        self::assertSame($this->helper, $this->helper->appendHttpEquiv('foo', 'bar'));
+        self::assertSame($this->helper, $this->helper->prependHttpEquiv('foo', 'bar'));
+        self::assertSame($this->helper, $this->helper->setHttpEquiv('foo', 'bar'));
+        self::assertSame($this->helper, $this->helper->setCharset('foo'));
+        self::assertSame($this->helper, $this->helper->append(['foo' => 'bar']));
+        self::assertSame($this->helper, $this->helper->prepend(['foo' => 'bar']));
     }
 
-    /**
-     * @depends testItempropIsSupportedWithHtml5Doctype
-     */
-    public function testOverloadingPrependItempropPrependsMetaTagToStack(): void
+    public function testResetStateClearsAllMutableProperties(): void
     {
-        $this->setDoctype(Doctype::HTML5);
-        $this->executeOverloadPrepend('itemprop');
-    }
+        $this->helper->setSeparator('-')
+            ->setIndent(2)
+            ->append(['foo' => 'bar'])
+            ->append(['baz' => 'bat']);
 
-    /**
-     * @depends testItempropIsSupportedWithHtml5Doctype
-     */
-    public function testOverloadingSetItempropOverwritesMetaTagStack(): void
-    {
-        $this->setDoctype(Doctype::HTML5);
-        $this->executeOverloadSet('itemprop');
-    }
+        $expect = <<<'HTML'
+              <meta foo="bar">-  <meta baz="bat">
+            HTML;
 
-    public function testConditional(): void
-    {
-        $html = $this->helper->appendHttpEquiv('foo', 'bar', ['conditional' => 'lt IE 7'])->toString();
+        self::assertSame($expect, $this->helper->toString());
 
-        $this->assertMatchesRegularExpression("|^<!--\[if lt IE 7\]>|", $html);
-        $this->assertMatchesRegularExpression("|<!\[endif\]-->$|", $html);
-    }
+        $this->helper->resetState();
 
-    public function testConditionalNoIE(): void
-    {
-        $html = $this->helper->appendHttpEquiv('foo', 'bar', ['conditional' => '!IE'])->toString();
+        self::assertSame('', $this->helper->toString());
 
-        $this->assertStringContainsString('<!--[if !IE]><!--><', $html);
-        $this->assertStringContainsString('<!--<![endif]-->', $html);
-    }
+        $this->helper->append(['foo' => 'bar'])
+            ->append(['baz' => 'bat']);
 
-    public function testConditionalNoIEWidthSpace(): void
-    {
-        $html = $this->helper->appendHttpEquiv('foo', 'bar', ['conditional' => '! IE'])->toString();
+        $expect = <<<'HTML'
+            <meta foo="bar">
+            <meta baz="bat">
+            HTML;
 
-        $this->assertStringContainsString('<!--[if ! IE]><!--><', $html);
-        $this->assertStringContainsString('<!--<![endif]-->', $html);
-    }
-
-    public function testTurnOffAutoEscapeDoesNotEncode(): void
-    {
-        $this->helper->setAutoEscape(false)->appendHttpEquiv('foo', 'bar=baz');
-        $this->assertEquals('<meta http-equiv="foo" content="bar=baz" />', $this->helper->toString());
+        self::assertSame($expect, $this->helper->toString());
     }
 }


### PR DESCRIPTION
- Removes inheritance
- Introduce `final` keyword
- Remove all "Magic", replacing common calls with concrete methods
- Conditionals are no longer supported
- Validation of meta tags has been removed. Instead of querying the doctype and throwing exceptions when `<meta property>` is added to a non-RDFa document, any meta tag is simply allowed, with possibly invalid attributes. The validation rules are much bigger and more numerous than this library can hope to cover.
- Makes hidden dependencies visible as constructor arguments
- `HeadMeta` is no longer iterable or countable or array-like, and you can't fetch a container to capture output buffers
- Adding meta tags at specific offsets is no longer possible