### PR TITLE
Deprecate the `HtmlPage` view helper

### DIFF
--- a/docs/book/v2/helpers/html-object.md
+++ b/docs/book/v2/helpers/html-object.md
@@ -14,6 +14,9 @@ documentation will only contain examples of two of these helpers.
 
 ## HtmlPage helper
 
+WARNING: **Deprecated**
+The `HtmlPage` view helper has been deprecated and will be removed in version 3.0.
+
 Embedding an external HTML page in your page using the helper only requires the resource URI.
 
 ```php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2675,6 +2675,12 @@
       <code><![CDATA[$key]]></code>
     </UnusedParam>
   </file>
+  <file src="test/Helper/HtmlPageTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[HtmlPage]]></code>
+      <code><![CDATA[new HtmlPage()]]></code>
+    </DeprecatedClass>
+  </file>
   <file src="test/Helper/HtmlTagTest.php">
     <MixedArgument>
       <code><![CDATA[$escape($value)]]></code>

--- a/src/Helper/HtmlPage.php
+++ b/src/Helper/HtmlPage.php
@@ -6,7 +6,12 @@ namespace Laminas\View\Helper;
 
 use function array_merge;
 
-/** @final */
+/**
+ * @deprecated Since 2.40.0 - This helper is deprecated for removal in 3.0 - It's main purpose as a helper to avoid
+ *             remembering the correct `classid` attribute value is long obsolete. IE is dead.
+ *
+ * @final
+ */
 class HtmlPage extends AbstractHtmlElement
 {
     /**


### PR DESCRIPTION
I wonder if anyone has used this view helper within the last 10 years or so?