### PR TITLE
Remove Initializers from the `HelperPluginManager`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -357,32 +357,9 @@
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/HelperPluginManager.php">
-    <DeprecatedProperty>
-      <code><![CDATA[$this->initializers]]></code>
-      <code><![CDATA[$this->initializers]]></code>
-      <code><![CDATA[$this->initializers]]></code>
-      <code><![CDATA[$this->initializers]]></code>
-    </DeprecatedProperty>
-    <DocblockTypeContradiction>
-      <code><![CDATA[! $events]]></code>
-      <code><![CDATA[! $events]]></code>
-    </DocblockTypeContradiction>
     <MethodSignatureMismatch>
       <code><![CDATA[HelperPluginManager]]></code>
     </MethodSignatureMismatch>
-    <MixedArgument>
-      <code><![CDATA[$container->get('EventManager')]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$container]]></code>
-    </MixedAssignment>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[injectEventManager]]></code>
-      <code><![CDATA[injectRenderer]]></code>
-    </PossiblyUnusedMethod>
-    <UndefinedInterfaceMethod>
-      <code><![CDATA[getServiceLocator]]></code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="src/HtmlAttributesSet.php">
     <MixedArgumentTypeCoercion>
@@ -544,7 +521,6 @@
   <file src="src/Renderer/PhpRenderer.php">
     <DocblockTypeContradiction>
       <code><![CDATA[! is_array($variables) && ! $variables instanceof ArrayAccess]]></code>
-      <code><![CDATA[gettype($helpers)]]></code>
     </DocblockTypeContradiction>
     <FalsableReturnStatement>
       <code><![CDATA[$this->__content]]></code>
@@ -565,9 +541,6 @@
       <code><![CDATA[$variablesAsArray[$key]]]></code>
       <code><![CDATA[$vars[$name]]]></code>
     </MixedAssignment>
-    <MixedMethodCall>
-      <code><![CDATA[new $helpers(new ServiceManager())]]></code>
-    </MixedMethodCall>
     <MixedReturnStatement>
       <code><![CDATA[$this->__filterChain->filter($this->__content)]]></code>
       <code><![CDATA[$this->__filterChain->filter($this->__content)]]></code>
@@ -598,9 +571,6 @@
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(bool) $renderTrees]]></code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[is_object($helpers)]]></code>
-    </RedundantConditionGivenDocblockType>
     <UnresolvableInclude>
       <code><![CDATA[include $this->__file]]></code>
     </UnresolvableInclude>

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\View;
 
-use Laminas\EventManager\EventManagerAwareInterface;
-use Laminas\EventManager\SharedEventManagerInterface;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
@@ -145,16 +143,10 @@ final class HelperPluginManager extends AbstractPluginManager
         ],
     ];
 
-    /** @var Renderer\RendererInterface|null */
-    protected $renderer;
-
     /**
      * Constructor
      *
      * Merges provided configuration with default configuration.
-     *
-     * Adds initializers to inject the attached renderer and event manager, if
-     * any, to the currently requested helper.
      *
      * @inheritDoc
      */
@@ -164,103 +156,7 @@ final class HelperPluginManager extends AbstractPluginManager
     ) {
         $config = array_replace_recursive(self::CONFIG, $config);
 
-        $this->initializers[] = [$this, 'injectRenderer'];
-        $this->initializers[] = [$this, 'injectEventManager'];
-
         parent::__construct($creationContext, $config);
-    }
-
-    /**
-     * Set renderer
-     *
-     * @return HelperPluginManager
-     */
-    public function setRenderer(Renderer\RendererInterface $renderer)
-    {
-        $this->renderer = $renderer;
-
-        return $this;
-    }
-
-    /**
-     * Retrieve renderer instance
-     *
-     * @return null|Renderer\RendererInterface
-     */
-    public function getRenderer()
-    {
-        return $this->renderer;
-    }
-
-    /**
-     * Inject a helper instance with the registered renderer
-     *
-     * @param ContainerInterface|HelperInterface $first helper instance
-     *     under laminas-servicemanager v2, ContainerInterface under v3.
-     * @param ContainerInterface|HelperInterface $second
-     *     ContainerInterface under laminas-servicemanager v3, helper instance
-     *     under v2. Ignored regardless.
-     * @return void
-     */
-    public function injectRenderer($first, $second)
-    {
-        $helper = $first instanceof ContainerInterface
-            ? $second
-            : $first;
-
-        if (! $helper instanceof Helper\HelperInterface) {
-            return;
-        }
-
-        $renderer = $this->getRenderer();
-        if (null === $renderer) {
-            return;
-        }
-        $helper->setView($renderer);
-    }
-
-    /**
-     * Inject a helper instance with the registered event manager
-     *
-     * @param ContainerInterface|HelperInterface $first helper instance
-     *     under laminas-servicemanager v2, ContainerInterface under v3.
-     * @param ContainerInterface|HelperInterface $second
-     *     ContainerInterface under laminas-servicemanager v3, helper instance
-     *     under v2. Ignored regardless.
-     * @return void
-     */
-    public function injectEventManager($first, $second)
-    {
-        if ($first instanceof ContainerInterface) {
-            // v3 usage
-            $container = $first;
-            $helper    = $second;
-        } else {
-            // v2 usage; grab the parent container
-            $container = $second->getServiceLocator();
-            $helper    = $first;
-        }
-
-        if (! $container instanceof ContainerInterface) {
-            // Under laminas-navigation v2.5, the navigation PluginManager is
-            // always lazy-loaded, which means it never has a parent
-            // container.
-            return;
-        }
-
-        if (! $helper instanceof EventManagerAwareInterface) {
-            return;
-        }
-
-        if (! $container->has('EventManager')) {
-            // If the container doesn't have an EM service, do nothing.
-            return;
-        }
-
-        $events = $helper->getEventManager();
-        if (! $events || ! $events->getSharedManager() instanceof SharedEventManagerInterface) {
-            $helper->setEventManager($container->get('EventManager'));
-        }
     }
 
     /**

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -23,13 +23,10 @@ use function array_key_exists;
 use function array_pop;
 use function assert;
 use function call_user_func_array;
-use function class_exists;
 use function extract;
 use function get_debug_type;
-use function gettype;
 use function is_array;
 use function is_callable;
-use function is_object;
 use function is_string;
 use function method_exists;
 use function ob_end_clean;
@@ -121,10 +118,8 @@ class PhpRenderer implements Renderer, TreeRendererInterface
 
     /**
      * Helper plugin manager
-     *
-     * @var HelperPluginManager|null
      */
-    private $__helpers;
+    private HelperPluginManager|null $__helpers = null;
 
     /**
      * @var FilterChain|null
@@ -326,31 +321,8 @@ class PhpRenderer implements Renderer, TreeRendererInterface
         unset($vars[$name]);
     }
 
-    /**
-     * Set helper plugin manager instance
-     *
-     * @param  string|HelperPluginManager $helpers
-     * @return PhpRenderer
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setHelperPluginManager($helpers)
+    public function setHelperPluginManager(HelperPluginManager $helpers): self
     {
-        if (is_string($helpers)) {
-            if (! class_exists($helpers)) {
-                throw new Exception\InvalidArgumentException(sprintf(
-                    'Invalid helper helpers class provided (%s)',
-                    $helpers
-                ));
-            }
-            $helpers = new $helpers(new ServiceManager());
-        }
-        if (! $helpers instanceof HelperPluginManager) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'Helper helpers must extend Laminas\View\HelperPluginManager; got type "%s" instead',
-                is_object($helpers) ? $helpers::class : gettype($helpers)
-            ));
-        }
-        $helpers->setRenderer($this);
         $this->__helpers = $helpers;
 
         return $this;
@@ -358,19 +330,14 @@ class PhpRenderer implements Renderer, TreeRendererInterface
 
     /**
      * Get helper plugin manager instance
-     *
-     * @return HelperPluginManager
      */
-    public function getHelperPluginManager()
+    public function getHelperPluginManager(): HelperPluginManager
     {
-        $pluginManager = $this->__helpers;
-
-        if (! $pluginManager instanceof HelperPluginManager) {
-            $pluginManager = new HelperPluginManager(new ServiceManager());
-            $this->setHelperPluginManager($pluginManager);
+        if (! $this->__helpers instanceof HelperPluginManager) {
+            $this->__helpers = new HelperPluginManager(new ServiceManager());
         }
 
-        return $pluginManager;
+        return $this->__helpers;
     }
 
     /**
@@ -380,7 +347,7 @@ class PhpRenderer implements Renderer, TreeRendererInterface
      * @param  string|class-string<T> $name Name of plugin to return
      * @return ($name is class-string ? T : HelperInterface|callable)
      */
-    public function plugin($name)
+    public function plugin(string $name): mixed
     {
         return $this->getHelperPluginManager()->get($name);
     }

--- a/test/HelperPluginManagerTest.php
+++ b/test/HelperPluginManagerTest.php
@@ -13,7 +13,6 @@ use Laminas\View\Helper\HelperInterface;
 use Laminas\View\Helper\Identity;
 use Laminas\View\Helper\Partial;
 use Laminas\View\HelperPluginManager;
-use Laminas\View\Renderer\PhpRenderer;
 use PHPUnit\Framework\TestCase;
 
 final class HelperPluginManagerTest extends TestCase
@@ -23,26 +22,6 @@ final class HelperPluginManagerTest extends TestCase
     protected function setUp(): void
     {
         $this->helpers = new HelperPluginManager(new ServiceManager());
-    }
-
-    public function testViewIsNullByDefault(): void
-    {
-        $this->assertNull($this->helpers->getRenderer());
-    }
-
-    public function testAllowsInjectingRenderer(): void
-    {
-        $renderer = new PhpRenderer();
-        $this->helpers->setRenderer($renderer);
-        $this->assertSame($renderer, $this->helpers->getRenderer());
-    }
-
-    public function testInjectsRendererToHelperWhenRendererIsPresent(): void
-    {
-        $renderer = new PhpRenderer();
-        $this->helpers->setRenderer($renderer);
-        $helper = $this->helpers->get(HeadStyle::class);
-        $this->assertSame($renderer, $helper->getView());
     }
 
     public function testNoRendererInjectedInHelperWhenRendererIsNotPresent(): void

--- a/test/PhpRendererTest.php
+++ b/test/PhpRendererTest.php
@@ -9,7 +9,6 @@ use Laminas\Filter\FilterChain;
 use Laminas\Filter\FilterPluginManager;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Exception\DomainException;
-use Laminas\View\Exception\ExceptionInterface;
 use Laminas\View\Exception\RuntimeException;
 use Laminas\View\Exception\UnexpectedValueException;
 use Laminas\View\Helper\Doctype;
@@ -27,7 +26,6 @@ use LaminasTest\View\TestAsset\Uninvokable;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
-use stdClass;
 use Throwable;
 
 use function assert;
@@ -113,48 +111,6 @@ final class PhpRendererTest extends TestCase
     {
         $helper = $this->renderer->plugin('doctype');
         $this->assertInstanceOf(Doctype::class, $helper);
-    }
-
-    public function testPassingStringOfUndefinedClassToSetHelperPluginManagerRaisesException(): void
-    {
-        $this->expectException(ExceptionInterface::class);
-        $this->expectExceptionMessage('Invalid');
-        $this->renderer->setHelperPluginManager('__foo__');
-    }
-
-    public function testPassingValidStringClassToSetHelperPluginManagerCreatesIt(): void
-    {
-        $this->renderer->setHelperPluginManager(HelperPluginManager::class);
-        $this->assertInstanceOf(HelperPluginManager::class, $this->renderer->getHelperPluginManager());
-    }
-
-    /**
-     * @psalm-return array<array-key, array{0: mixed}>
-     */
-    public static function invalidPluginManagers(): array
-    {
-        return [
-            [true],
-            [1],
-            [1.0],
-            [['foo']],
-            [new stdClass()],
-        ];
-    }
-
-    #[DataProvider('invalidPluginManagers')]
-    public function testPassingInvalidArgumentToSetHelperPluginManagerRaisesException(mixed $plugins): void
-    {
-        $this->expectException(ExceptionInterface::class);
-        $this->expectExceptionMessage('must extend');
-        /** @psalm-suppress MixedArgument */
-        $this->renderer->setHelperPluginManager($plugins);
-    }
-
-    public function testInjectsSelfIntoHelperPluginManager(): void
-    {
-        $plugins = $this->renderer->getHelperPluginManager();
-        $this->assertSame($this->renderer, $plugins->getRenderer());
     }
 
     public function testFilterChainIsNullByDefault(): void


### PR DESCRIPTION
Helpers should use dependency injection via the constructor rather than relying on magic setter injection at runtime.

Also, the `ServiceManager::$initializers` property is deprecated