### PR TITLE
Refactor the `HtmlObject` view helper

### DIFF
--- a/docs/book/v3/migration/v2-to-v3.md
+++ b/docs/book/v3/migration/v2-to-v3.md
@@ -149,6 +149,14 @@ This helper no longer inherits from a base class, therefore the following method
 - `setView`
 - `getClosingBracket`
 
+#### `HtmlObject`
+
+This helper no longer inherits from a base class, therefore the following methods have been removed
+
+- `getView`
+- `setView`
+- `getClosingBracket`
+
 #### `Layout`
 
 The inheritance hierarchy has been removed from this helper and the following methods have been removed:

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13,7 +13,6 @@
     <MissingConstructor>
       <code><![CDATA[$closingBracket]]></code>
       <code><![CDATA[$closingBracket]]></code>
-      <code><![CDATA[$closingBracket]]></code>
     </MissingConstructor>
     <MixedArgument>
       <code><![CDATA[$val]]></code>
@@ -28,6 +27,9 @@
       <code><![CDATA[plugin]]></code>
       <code><![CDATA[plugin]]></code>
     </PossiblyNullReference>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[getClosingBracket]]></code>
+    </PossiblyUnusedMethod>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(array) $attribs]]></code>
     </RedundantCastGivenDocblockType>
@@ -166,17 +168,6 @@
     <PossiblyUnusedReturnValue>
       <code><![CDATA[HelperInterface]]></code>
     </PossiblyUnusedReturnValue>
-  </file>
-  <file src="src/Helper/HtmlObject.php">
-    <MixedArgument>
-      <code><![CDATA[$options]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$options]]></code>
-    </MixedAssignment>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$content]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Helper/HtmlTag.php">
     <MixedArgument>
@@ -724,11 +715,6 @@
     <UnusedParam>
       <code><![CDATA[$key]]></code>
     </UnusedParam>
-  </file>
-  <file src="test/Helper/HtmlObjectTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[setService]]></code>
-    </DeprecatedMethod>
   </file>
   <file src="test/Helper/HtmlTagTest.php">
     <DeprecatedMethod>

--- a/src/Helper/HtmlObject.php
+++ b/src/Helper/HtmlObject.php
@@ -4,69 +4,63 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper;
 
-use Laminas\View\Exception\InvalidArgumentException;
+use Laminas\Escaper\EscaperInterface;
+use Laminas\View\HtmlAttributesSet;
 
+use function array_keys;
+use function array_map;
 use function array_merge;
+use function array_values;
 use function implode;
-use function is_array;
-use function is_string;
+use function sprintf;
 
 use const PHP_EOL;
 
-/** @final */
-class HtmlObject extends AbstractHtmlElement
+final class HtmlObject
 {
+    public function __construct(
+        private readonly EscaperInterface $escaper,
+        private readonly Doctype $doctype,
+    ) {
+    }
+
     /**
      * Output an object set
      *
-     * @param  string $data    The data file
-     * @param  string $type    Data file type
-     * @param  array  $attribs Attribs for the object tag
-     * @param  array  $params  Params for in the object tag
-     * @param  string|list<string>|null $content Alternative content for object
-     * @throws InvalidArgumentException
-     * @return string
+     * @param string $data The data attribute - the URL of the resource
+     * @param string $type The mime type of the target resource
+     * @param array<string, scalar> $attributes HTML tag attributes
+     * @param array<string, scalar> $params Parameters for the resource
+     * @param string|null $content Fallback content. This content is not escaped and is assumed to be markup.
      */
     public function __invoke(
-        $data = null,
-        $type = null,
-        array $attribs = [],
+        string $data,
+        string $type,
+        array $attributes = [],
         array $params = [],
-        $content = null
-    ) {
-        if ($data === null || $type === null) {
-            throw new InvalidArgumentException(
-                'HTMLObject: missing argument. $data and $type are required in '
-                . 'htmlObject($data, $type, array $attribs = array(), array $params = array(), $content = null)'
-            );
-        }
+        string|null $content = null,
+    ): string {
+        $attributes = array_merge(['data' => $data, 'type' => $type], $attributes);
+        $parameters = implode(PHP_EOL, array_map(
+            function (string $name, int|float|bool|string $value): string {
+                return sprintf(
+                    '    <param name="%s" value="%s"%s>',
+                    $this->escaper->escapeHtmlAttr($name),
+                    $this->escaper->escapeHtmlAttr((string) $value),
+                    $this->doctype->isXhtml() ? ' /' : '',
+                );
+            },
+            array_keys($params),
+            array_values($params),
+        ));
 
-        // Merge data and type
-        $attribs = array_merge(['data' => $data, 'type' => $type], $attribs);
+        $attributes = (string) new HtmlAttributesSet($this->escaper, $attributes);
 
-        // Params
-        $paramHtml      = [];
-        $closingBracket = $this->getClosingBracket();
-
-        foreach ($params as $param => $options) {
-            if (is_string($options)) {
-                $options = ['value' => $options];
-            }
-
-            $options = array_merge(['name' => $param], $options);
-
-            $paramHtml[] = '<param' . $this->htmlAttribs($options) . $closingBracket;
-        }
-
-        // Content
-        if (is_array($content)) {
-            $content = implode(PHP_EOL, $content);
-        }
-
-        // Object header
-        return '<object' . $this->htmlAttribs($attribs) . '>' . PHP_EOL
-                 . implode(PHP_EOL, $paramHtml) . PHP_EOL
-                 . ($content ? $content . PHP_EOL : '')
-                 . '</object>';
+        return <<<HTML
+            <object{$attributes}>
+            {$parameters}
+                {$content}
+            </object>
+            HTML;
     }
 }

--- a/src/Helper/Service/HtmlObjectFactory.php
+++ b/src/Helper/Service/HtmlObjectFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View\Helper\Service;
+
+use Laminas\Escaper\EscaperInterface;
+use Laminas\View\Helper\Doctype;
+use Laminas\View\Helper\HtmlObject;
+use Laminas\View\HelperPluginManager;
+use Psr\Container\ContainerInterface;
+
+/** @internal */
+final class HtmlObjectFactory
+{
+    public function __invoke(ContainerInterface $container): HtmlObject
+    {
+        $helpers = $container->get(HelperPluginManager::class);
+
+        return new HtmlObject(
+            $container->get(EscaperInterface::class),
+            $helpers->get(Doctype::class),
+        );
+    }
+}

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -46,7 +46,7 @@ final class HelperPluginManager extends AbstractPluginManager
             Helper\HeadTitle::class           => Helper\Service\HeadTitleFactory::class,
             Helper\HtmlAttributes::class      => EscapeHelperFactory::class,
             Helper\HtmlList::class            => EscapeHelperFactory::class,
-            Helper\HtmlObject::class          => InvokableFactory::class,
+            Helper\HtmlObject::class          => Helper\Service\HtmlObjectFactory::class,
             Helper\HtmlTag::class             => InvokableFactory::class,
             Helper\Identity::class            => Helper\Service\IdentityFactory::class,
             Helper\InlineScript::class        => InvokableFactory::class,

--- a/test/Helper/HtmlObjectTest.php
+++ b/test/Helper/HtmlObjectTest.php
@@ -4,43 +4,31 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Helper;
 
+use Laminas\Escaper\Escaper;
 use Laminas\View\Helper\Doctype;
 use Laminas\View\Helper\HtmlObject;
-use Laminas\View\Renderer\PhpRenderer;
-use Laminas\View\Renderer\RendererInterface;
 use PHPUnit\Framework\TestCase;
 
 /** @psalm-import-type DoctypeID from Doctype */
 final class HtmlObjectTest extends TestCase
 {
     private HtmlObject $helper;
-    private PhpRenderer $view;
 
-    /**
-     * Sets up the fixture, for example, open a network connection.
-     * This method is called before a test is executed.
-     *
-     * @access protected
-     */
     protected function setUp(): void
     {
-        $this->view   = new PhpRenderer();
-        $this->helper = new HtmlObject();
-        $this->helper->setView($this->view);
+        $this->helper = new HtmlObject(
+            new Escaper(),
+            new Doctype(),
+        );
     }
 
     /** @param DoctypeID $doctype */
     private function setDoctype(string $doctype): void
     {
-        $helpers = $this->view->getHelperPluginManager();
-        $helpers->setAllowOverride(true);
-        $doctype = new Doctype($doctype);
-        $helpers->setService(Doctype::class, $doctype);
-    }
-
-    public function testViewObjectIsSet(): void
-    {
-        $this->assertInstanceof(RendererInterface::class, $this->helper->getView());
+        $this->helper = new HtmlObject(
+            new Escaper(),
+            new Doctype($doctype),
+        );
     }
 
     public function testMakeHtmlObjectWithoutAttribsWithoutParams(): void
@@ -54,14 +42,14 @@ final class HtmlObjectTest extends TestCase
     public function testMakeHtmlObjectWithAttribsWithoutParams(): void
     {
         $attribs = [
-            'attribkey1' => 'attribvalue1',
-            'attribkey2' => 'attribvalue2',
+            'key1' => 'value1',
+            'key2' => 'value2',
         ];
 
         $htmlObject = $this->helper->__invoke('datastring', 'typestring', $attribs);
 
         $this->assertStringContainsString(
-            '<object data="datastring" type="typestring" attribkey1="attribvalue1" attribkey2="attribvalue2">',
+            '<object data="datastring" type="typestring" key1="value1" key2="value2">',
             $htmlObject,
         );
         $this->assertStringContainsString('</object>', $htmlObject);
@@ -72,8 +60,8 @@ final class HtmlObjectTest extends TestCase
         $this->setDoctype(Doctype::HTML4_STRICT);
 
         $params = [
-            'paramname1' => 'paramvalue1',
-            'paramname2' => 'paramvalue2',
+            'name1' => 'value1',
+            'name2' => 'value2',
         ];
 
         $htmlObject = $this->helper->__invoke('datastring', 'typestring', [], $params);
@@ -116,5 +104,11 @@ final class HtmlObjectTest extends TestCase
         $this->assertStringContainsString('<object data="datastring" type="typestring">', $htmlObject);
         $this->assertStringContainsString('testcontent', $htmlObject);
         $this->assertStringContainsString('</object>', $htmlObject);
+    }
+
+    public function testFallbackContentIsNotEscaped(): void
+    {
+        $html = $this->helper->__invoke('foo', 'bar', [], [], '<p>Baz</p>');
+        self::assertStringContainsString('<p>Baz</p>', $html);
     }
 }


### PR DESCRIPTION
I'd be surprised if anyone uses this helper, however, its so simple it at least serves as an example for helpers that generate basic repeatable markup whilst using proper DI