### PR TITLE
Deprecate `AbstractHtmlElement` Base Class

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -206,6 +206,9 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Helper/Gravatar.php">
+    <DeprecatedClass>
+      <code><![CDATA[AbstractHtmlElement]]></code>
+    </DeprecatedClass>
     <DocblockTypeContradiction>
       <code><![CDATA[$flag === null]]></code>
     </DocblockTypeContradiction>
@@ -480,6 +483,9 @@
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Helper/HtmlFlash.php">
+    <DeprecatedClass>
+      <code><![CDATA[AbstractHtmlElement]]></code>
+    </DeprecatedClass>
     <MixedAssignment>
       <code><![CDATA[$htmlObject]]></code>
     </MixedAssignment>
@@ -496,7 +502,15 @@
       <code><![CDATA[plugin]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="src/Helper/HtmlList.php">
+    <DeprecatedClass>
+      <code><![CDATA[AbstractHtmlElement]]></code>
+    </DeprecatedClass>
+  </file>
   <file src="src/Helper/HtmlObject.php">
+    <DeprecatedClass>
+      <code><![CDATA[AbstractHtmlElement]]></code>
+    </DeprecatedClass>
     <MixedArgument>
       <code><![CDATA[$options]]></code>
     </MixedArgument>
@@ -508,6 +522,9 @@
     </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Helper/HtmlPage.php">
+    <DeprecatedClass>
+      <code><![CDATA[AbstractHtmlElement]]></code>
+    </DeprecatedClass>
     <MixedAssignment>
       <code><![CDATA[$htmlObject]]></code>
     </MixedAssignment>
@@ -525,6 +542,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/HtmlQuicktime.php">
+    <DeprecatedClass>
+      <code><![CDATA[AbstractHtmlElement]]></code>
+    </DeprecatedClass>
     <MixedAssignment>
       <code><![CDATA[$htmlObject]]></code>
     </MixedAssignment>
@@ -542,6 +562,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Helper/HtmlTag.php">
+    <DeprecatedClass>
+      <code><![CDATA[AbstractHtmlElement]]></code>
+    </DeprecatedClass>
     <MixedArgument>
       <code><![CDATA[$value]]></code>
     </MixedArgument>
@@ -639,6 +662,8 @@
   <file src="src/Helper/Navigation/AbstractHelper.php">
     <DeprecatedClass>
       <code><![CDATA[AclListener::class]]></code>
+      <code><![CDATA[View\Helper\AbstractHtmlElement]]></code>
+      <code><![CDATA[parent::htmlAttribs($attribs)]]></code>
     </DeprecatedClass>
     <DeprecatedInterface>
       <code><![CDATA[AbstractHelper]]></code>
@@ -2142,6 +2167,11 @@
       <code><![CDATA[$params[$param]]]></code>
     </PossiblyUndefinedArrayOffset>
   </file>
+  <file src="test/Helper/AbstractHtmlElementTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[AbstractHtmlElement::class]]></code>
+    </DeprecatedClass>
+  </file>
   <file src="test/Helper/CycleTest.php">
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(string) $this->helper->toString()]]></code>
@@ -3396,6 +3426,9 @@
     </InvalidArgument>
   </file>
   <file src="test/Helper/TestAsset/ConcreteElementHelper.php">
+    <DeprecatedClass>
+      <code><![CDATA[AbstractHtmlElement]]></code>
+    </DeprecatedClass>
     <PossiblyUnusedMethod>
       <code><![CDATA[normalizeElementId]]></code>
     </PossiblyUnusedMethod>

--- a/src/Helper/AbstractHtmlElement.php
+++ b/src/Helper/AbstractHtmlElement.php
@@ -13,6 +13,10 @@ use function trim;
 
 use const PHP_EOL;
 
+/**
+ * @deprecated Since 2.40.0. This abstract base class is unnecessary once helpers are refactored to use dependency
+ *             injection.
+ */
 abstract class AbstractHtmlElement extends AbstractHelper
 {
     /**


### PR DESCRIPTION
All helpers will/have been refactored to remove this class from their inheritance hierarchy. It will no longer be necessary in 3.0.

It also has dubious utility for users and authors of custom helpers
