### PR TITLE
Refactor `Cycle` View Helper

### DIFF
--- a/docs/book/v3/helpers/cycle.md
+++ b/docs/book/v3/helpers/cycle.md
@@ -4,7 +4,7 @@ The `Cycle` helper is used to alternate a set of values.
 
 ## Basic Usage
 
-To add elements to cycle, specify them in constructor:
+To add elements to cycle, specify them during invocation:
 
 ```php
 <table>
@@ -83,7 +83,7 @@ You can also provide a `$name` argument to `assign()`:
 <?php $this->cycle()->assign([1, 2, 3], 'number'); ?>
 ```
 
-Or use the `setName()` method priort to invoking either of `next()` or `prev()`.
+Or use the `setName()` method prior to invoking either of `next()` or `prev()`.
 
 As a combined example:
 
@@ -101,3 +101,6 @@ $this->cycle()->assign([1, 2, 3], 'numbers');
     <?php endforeach ?>
 </table>
 ```
+
+NOTE:
+The data given to the cycle helper to cycle between must be "stringable", i.e. a string, a number, or an object implementing `Stringable`.

--- a/docs/book/v3/migration/v2-to-v3.md
+++ b/docs/book/v3/migration/v2-to-v3.md
@@ -40,6 +40,20 @@ Both of these methods have been removed.
 Now, the only way to configure the resource map is via constructor injection.
 The method of configuring the resource map remains unchanged.
 
+#### `Cycle`
+
+The `Cycle` helper no longer inherits from `AbstractHelper` meaning that the `getView` and `setView` methods no longer exist.
+
+This helper no longer implements `Iterator` which is unlikely to cause any issues because it was never intended to be iterated over, rather the methods it exposed have similarities to those in `Iterator`.
+
+The following additional methods have been removed:
+
+- `getName`
+- `valid`
+
+Along with adding native parameter and return types, the return type of `rewind` has changed from `self` to `void`.
+The helper is now also `final`.
+
 #### `Doctype`
 
 The `Doctype` view helper no longer extends from `AbstractHelper` therefore the `getView` and `setView` methods no longer exist on the class.

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9,34 +9,6 @@
       <code><![CDATA[$template]]></code>
     </PossiblyNullArgument>
   </file>
-  <file src="src/Helper/Cycle.php">
-    <ImplementedReturnTypeMismatch>
-      <code><![CDATA[Cycle]]></code>
-      <code><![CDATA[Cycle]]></code>
-    </ImplementedReturnTypeMismatch>
-    <MissingTemplateParam>
-      <code><![CDATA[Iterator]]></code>
-    </MissingTemplateParam>
-    <MixedArgument>
-      <code><![CDATA[$this->data[$this->name]]]></code>
-      <code><![CDATA[$this->data[$this->name]]]></code>
-    </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$this->data[$this->name][$this->key()]]]></code>
-      <code><![CDATA[$this->data[$this->name][$this->key()]]]></code>
-    </MixedArrayAccess>
-    <MixedOperand>
-      <code><![CDATA[$this->pointers[$this->name]]]></code>
-      <code><![CDATA[$this->pointers[$this->name]]]></code>
-    </MixedOperand>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->data[$this->name]]]></code>
-      <code><![CDATA[$this->pointers[$this->name]]]></code>
-    </MixedReturnStatement>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[getName]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="src/Helper/Escaper/AbstractHelper.php">
     <MixedAssignment>
       <code><![CDATA[$value[$k]]]></code>
@@ -360,11 +332,6 @@
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$params[$param]]]></code>
     </PossiblyUndefinedArrayOffset>
-  </file>
-  <file src="test/Helper/CycleTest.php">
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(string) $this->helper->toString()]]></code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="test/Helper/HtmlListTest.php">
     <UnusedParam>

--- a/src/Helper/Cycle.php
+++ b/src/Helper/Cycle.php
@@ -4,78 +4,82 @@ declare(strict_types=1);
 
 namespace Laminas\View\Helper;
 
-use Iterator;
-use ReturnTypeWillChange; // phpcs:ignore
+use Stringable;
 
 use function count;
 
 /**
- * Helper for alternating between set of values
- *
- * @final
+ * Helper for alternating between a set of values
  */
-class Cycle extends AbstractHelper implements Iterator
+final class Cycle implements Stringable, StatefulHelperInterface
 {
     /**
      * Default name
-     *
-     * @var string
      */
-    public const DEFAULT_NAME = 'default';
+    private const DEFAULT_NAME = 'default';
 
     /**
      * Array of values
      *
-     * @var array
+     * @var array<string, list<scalar|Stringable>>
      */
-    protected $data = [self::DEFAULT_NAME => []];
+    private array $data = [
+        self::DEFAULT_NAME => [],
+    ];
 
     /**
      * Actual name of cycle
-     *
-     * @var string
      */
-    protected $name = self::DEFAULT_NAME;
+    private string $name = self::DEFAULT_NAME;
 
     /**
      * Pointers
      *
-     * @var array
+     * @var array<string, int>
      */
-    protected $pointers = [self::DEFAULT_NAME => -1];
+    private array $pointers = [
+        self::DEFAULT_NAME => -1,
+    ];
+
+    public function resetState(): void
+    {
+        $this->name     = self::DEFAULT_NAME;
+        $this->pointers = [
+            self::DEFAULT_NAME => -1,
+        ];
+        $this->data     = [
+            self::DEFAULT_NAME => [],
+        ];
+    }
 
     /**
      * Add elements to alternate
      *
-     * @param  string $name
-     * @return Cycle
+     * @param list<scalar|Stringable> $data
      */
-    public function __invoke(array $data = [], $name = self::DEFAULT_NAME)
+    public function __invoke(array $data = [], string $name = self::DEFAULT_NAME): self
     {
-        if (! empty($data)) {
+        if ($data !== []) {
             $this->data[$name] = $data;
         }
 
         $this->setName($name);
+
         return $this;
     }
 
     /**
      * Cast to string
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->toString();
     }
 
     /**
      * Turn helper into string
-     *
-     * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return (string) $this->data[$this->name][$this->key()];
     }
@@ -83,24 +87,21 @@ class Cycle extends AbstractHelper implements Iterator
     /**
      * Add elements to alternate
      *
-     * @param  string $name
-     * @return Cycle
+     * @param list<scalar|Stringable> $data
      */
-    public function assign(array $data, $name = self::DEFAULT_NAME)
+    public function assign(array $data, string $name = self::DEFAULT_NAME): self
     {
         $this->setName($name);
         $this->data[$name] = $data;
         $this->rewind();
+
         return $this;
     }
 
     /**
      * Sets actual name of cycle
-     *
-     * @param  string $name
-     * @return Cycle
      */
-    public function setName($name = self::DEFAULT_NAME)
+    public function setName(string $name): self
     {
         $this->name = $name;
 
@@ -116,32 +117,16 @@ class Cycle extends AbstractHelper implements Iterator
     }
 
     /**
-     * Gets actual name of cycle
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    /**
      * Return all elements
      *
-     * @return array
+     * @return list<scalar|Stringable>
      */
-    public function getAll()
+    public function getAll(): array
     {
         return $this->data[$this->name];
     }
 
-    /**
-     * Move to next value
-     *
-     * @return Cycle
-     */
-    #[ReturnTypeWillChange]
-    public function next()
+    public function next(): self
     {
         $count = count($this->data[$this->name]);
 
@@ -156,10 +141,8 @@ class Cycle extends AbstractHelper implements Iterator
 
     /**
      * Move to previous value
-     *
-     * @return Cycle
      */
-    public function prev()
+    public function prev(): self
     {
         $count = count($this->data[$this->name]);
 
@@ -174,11 +157,8 @@ class Cycle extends AbstractHelper implements Iterator
 
     /**
      * Return iteration number
-     *
-     * @return int
      */
-    #[ReturnTypeWillChange]
-    public function key()
+    public function key(): int
     {
         if ($this->pointers[$this->name] < 0) {
             return 0;
@@ -189,34 +169,16 @@ class Cycle extends AbstractHelper implements Iterator
 
     /**
      * Rewind pointer
-     *
-     * @return Cycle
      */
-    #[ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         $this->pointers[$this->name] = -1;
-        return $this;
     }
 
     /**
-     * Check if element is valid
-     *
-     * @return bool
+     * Return current element
      */
-    #[ReturnTypeWillChange]
-    public function valid()
-    {
-        return isset($this->data[$this->name][$this->key()]);
-    }
-
-    /**
-     * Return  current element
-     *
-     * @return mixed
-     */
-    #[ReturnTypeWillChange]
-    public function current()
+    public function current(): int|float|bool|string|Stringable
     {
         return $this->data[$this->name][$this->key()];
     }

--- a/test/Helper/CycleTest.php
+++ b/test/Helper/CycleTest.php
@@ -4,93 +4,90 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Helper;
 
-use Laminas\View\Helper;
+use Laminas\View\Helper\Cycle;
 use PHPUnit\Framework\TestCase;
 
 final class CycleTest extends TestCase
 {
-    /** @var Helper\Cycle */
-    public $helper;
+    private Cycle $helper;
 
-    /**
-     * Sets up the fixture, for example, open a network connection.
-     * This method is called before a test is executed.
-     */
     protected function setUp(): void
     {
-        $this->helper = new Helper\Cycle();
+        $this->helper = new Cycle();
     }
 
     public function testCycleMethodReturnsObjectInstance(): void
     {
-        $cycle = $this->helper->__invoke();
-        $this->assertInstanceOf(Helper\Cycle::class, $cycle);
+        self::assertSame(
+            $this->helper,
+            $this->helper->__invoke(),
+        );
     }
 
     public function testAssignAndGetValues(): void
     {
         $this->helper->assign(['a', 1, 'asd']);
-        $this->assertEquals(['a', 1, 'asd'], $this->helper->getAll());
+        self::assertEquals(['a', 1, 'asd'], $this->helper->getAll());
     }
 
     public function testCycleMethod(): void
     {
         $this->helper->__invoke(['a', 1, 'asd']);
-        $this->assertEquals(['a', 1, 'asd'], $this->helper->getAll());
+        self::assertEquals(['a', 1, 'asd'], $this->helper->getAll());
     }
 
     public function testToString(): void
     {
         $this->helper->__invoke(['a', 1, 'asd']);
-        $this->assertEquals('a', (string) $this->helper->toString());
+        self::assertEquals('a', $this->helper->toString());
     }
 
     public function testNextValue(): void
     {
         $this->helper->assign(['a', 1, 3]);
-        $this->assertEquals('a', (string) $this->helper->next());
-        $this->assertEquals(1, (string) $this->helper->next());
-        $this->assertEquals(3, (string) $this->helper->next());
-        $this->assertEquals('a', (string) $this->helper->next());
-        $this->assertEquals(1, (string) $this->helper->next());
+        self::assertEquals('a', (string) $this->helper->next());
+        self::assertEquals(1, (string) $this->helper->next());
+        self::assertEquals(3, (string) $this->helper->next());
+        self::assertEquals('a', (string) $this->helper->next());
+        self::assertEquals(1, (string) $this->helper->next());
     }
 
     public function testPrevValue(): void
     {
         $this->helper->assign([4, 1, 3]);
-        $this->assertEquals(3, (string) $this->helper->prev());
-        $this->assertEquals(1, (string) $this->helper->prev());
-        $this->assertEquals(4, (string) $this->helper->prev());
-        $this->assertEquals(3, (string) $this->helper->prev());
-        $this->assertEquals(1, (string) $this->helper->prev());
+        self::assertEquals(3, (string) $this->helper->prev());
+        self::assertEquals(1, (string) $this->helper->prev());
+        self::assertEquals(4, (string) $this->helper->prev());
+        self::assertEquals(3, (string) $this->helper->prev());
+        self::assertEquals(1, (string) $this->helper->prev());
     }
 
     public function testRewind(): void
     {
         $this->helper->assign([5, 8, 3]);
-        $this->assertEquals(5, (string) $this->helper->next());
-        $this->assertEquals(8, (string) $this->helper->next());
+        self::assertEquals(5, (string) $this->helper->next());
+        self::assertEquals(8, (string) $this->helper->next());
         $this->helper->rewind();
-        $this->assertEquals(5, (string) $this->helper->next());
-        $this->assertEquals(8, (string) $this->helper->next());
+        self::assertEquals(5, (string) $this->helper->next());
+        self::assertEquals(8, (string) $this->helper->next());
     }
 
     public function testMixedMethods(): void
     {
         $this->helper->assign([5, 8, 3]);
-        $this->assertEquals(5, (string) $this->helper->next());
-        $this->assertEquals(5, (string) $this->helper->current());
-        $this->assertEquals(8, (string) $this->helper->next());
-        $this->assertEquals(5, (string) $this->helper->prev());
+        self::assertEquals(5, (string) $this->helper->next());
+        self::assertEquals(5, (string) $this->helper->current());
+        self::assertEquals(8, (string) $this->helper->next());
+        self::assertEquals(5, (string) $this->helper->prev());
     }
 
     public function testTwoCycles(): void
     {
         $this->helper->assign([5, 8, 3]);
-        $this->assertEquals(5, (string) $this->helper->next());
-        $this->assertEquals(2, (string) $this->helper->__invoke([2, 38, 1], 'cycle2')->next());
-        $this->assertEquals(8, (string) $this->helper->__invoke()->next());
-        $this->assertEquals(38, (string) $this->helper->setName('cycle2')->next());
+        self::assertEquals(5, (string) $this->helper->next());
+        self::assertEquals(2, (string) $this->helper->__invoke([2, 38, 1], 'cycle2')->next());
+        self::assertEquals(8, (string) $this->helper->__invoke()->next());
+        self::assertEquals(38, (string) $this->helper->setName('cycle2')->next());
     }
 
     public function testTwoCyclesInLoop(): void
@@ -98,8 +95,8 @@ final class CycleTest extends TestCase
         $expected  = [5, 4, 2, 3];
         $expected2 = [7, 34, 8, 6];
         for ($i = 0; $i < 4; $i++) {
-            $this->assertEquals($expected[$i], (string) $this->helper->__invoke($expected)->next());
-            $this->assertEquals($expected2[$i], (string) $this->helper->__invoke($expected2, 'cycle2')->next());
+            self::assertEquals($expected[$i], (string) $this->helper->__invoke($expected)->next());
+            self::assertEquals($expected2[$i], (string) $this->helper->__invoke($expected2, 'cycle2')->next());
         }
     }
 }


### PR DESCRIPTION
Stops implementing `Iterator` - not only was it unnecessary, but the `next` and `prev` methods _must_ return `self` in order to fulfill the `Stringable` behaviour contract which conflicts with the return types on `Iterator`.

Drops useless methods `getName` and `valid`

Marks as final and adds types.
