### PR TITLE
Swap `FilterChain` for a `callable`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~3.1.0",
-        "laminas/laminas-filter": "^3.0",
         "laminas/laminas-http": "^2.22",
         "phpunit/phpunit": "^10.5.46",
         "psalm/plugin-phpunit": "^0.19.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c91193f30829e844500cb02dd6bb5a8c",
+    "content-hash": "73855de49d8f1aa6db3ec26e6b7016bc",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -2014,86 +2014,6 @@
                 }
             ],
             "time": "2025-05-13T08:37:04+00:00"
-        },
-        {
-            "name": "laminas/laminas-filter",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "e1d1c9cac048be355893117fd13514f8cc8ff6b3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/e1d1c9cac048be355893117fd13514f8cc8ff6b3",
-                "reference": "e1d1c9cac048be355893117fd13514f8cc8ff6b3",
-                "shasum": ""
-            },
-            "require": {
-                "ext-fileinfo": "*",
-                "ext-filter": "*",
-                "ext-iconv": "*",
-                "ext-mbstring": "*",
-                "laminas/laminas-servicemanager": "^4.1.0",
-                "laminas/laminas-stdlib": "^3.19.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-                "psr/container": "^1 || ^2",
-                "psr/http-factory": "^1.1",
-                "psr/http-message": "^2.0"
-            },
-            "require-dev": {
-                "ext-bz2": "*",
-                "ext-zip": "*",
-                "ext-zlib": "*",
-                "laminas/laminas-coding-standard": "^3.0.1",
-                "laminas/laminas-diactoros": "^3.6",
-                "pear/archive_tar": "^1.5.0",
-                "pear/pear": "^1.10.16",
-                "phpunit/phpunit": "^10.5.46",
-                "psalm/plugin-phpunit": "^0.19.5",
-                "vimeo/psalm": "^6.10.3"
-            },
-            "suggest": {
-                "laminas/laminas-i18n": "Laminas\\I18n component for filters depending on i18n functionality",
-                "psr/http-factory-implementation": "psr/http-factory-implementation, for creating file upload instances when consuming PSR-7 in file upload filters"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Filter",
-                    "config-provider": "Laminas\\Filter\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Filter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Programmatically filter and normalize data and files",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "filter",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-filter/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-filter/issues",
-                "rss": "https://github.com/laminas/laminas-filter/releases.atom",
-                "source": "https://github.com/laminas/laminas-filter"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2025-05-06T10:11:59+00:00"
         },
         {
             "name": "laminas/laminas-http",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.10.3@90b5b9f5e7c8e441b191d3c82c58214753d7c7c1">
+<files psalm-version="6.11.0@4ed53b7ccebc09ef60ec4c9e464bf8a01bfd35b0">
   <file src="bin/templatemap_generator.php">
     <PossiblyFalseArgument>
       <code><![CDATA[$realPath]]></code>
@@ -145,11 +145,13 @@
     </DocblockTypeContradiction>
     <FalsableReturnStatement>
       <code><![CDATA[$this->__content]]></code>
-      <code><![CDATA[$this->__filterChain->filter($this->__content)]]></code>
     </FalsableReturnStatement>
     <ImplementedParamTypeMismatch>
       <code><![CDATA[$values]]></code>
     </ImplementedParamTypeMismatch>
+    <InvalidFalsableReturnType>
+      <code><![CDATA[string]]></code>
+    </InvalidFalsableReturnType>
     <MixedArgument>
       <code><![CDATA[$this->__template]]></code>
       <code><![CDATA[array_pop($this->__varsCache)]]></code>
@@ -163,14 +165,15 @@
       <code><![CDATA[$vars[$name]]]></code>
     </MixedAssignment>
     <MixedReturnStatement>
-      <code><![CDATA[$this->__filterChain->filter($this->__content)]]></code>
-      <code><![CDATA[$this->__filterChain->filter($this->__content)]]></code>
       <code><![CDATA[$this->__vars[$key]]]></code>
       <code><![CDATA[$this->getHelperPluginManager()->get($name)]]></code>
     </MixedReturnStatement>
     <PossibleRawObjectIteration>
       <code><![CDATA[$variables]]></code>
     </PossibleRawObjectIteration>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$this->__content]]></code>
+    </PossiblyFalseArgument>
     <PossiblyFalsePropertyAssignmentValue>
       <code><![CDATA[ob_get_clean()]]></code>
     </PossiblyFalsePropertyAssignmentValue>

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Laminas\View\Renderer;
 
 use ArrayAccess;
-use Laminas\Filter\FilterChain;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Exception;
 use Laminas\View\Helper\Doctype;
@@ -81,7 +80,7 @@ class PhpRenderer implements Renderer, TreeRendererInterface
     /**
      * @var string Rendered content
      */
-    private $__content = '';
+    private string $__content = '';
 
     /**
      * @var bool Whether to render trees of view models
@@ -121,9 +120,9 @@ class PhpRenderer implements Renderer, TreeRendererInterface
     private HelperPluginManager|null $__helpers = null;
 
     /**
-     * @var FilterChain|null
+     * @var (callable(string): string)|null
      */
-    private $__filterChain;
+    private $__filter;
 
     /**
      * @var Variables|null
@@ -377,22 +376,15 @@ class PhpRenderer implements Renderer, TreeRendererInterface
     }
 
     /**
-     * Set filter chain
+     * Set a post-rendering filter to apply to the rendered output
      *
-     * @return PhpRenderer
+     * @param callable(string): string $filter
      */
-    public function setFilterChain(FilterChain $filters)
+    public function setFilter(callable $filter): self
     {
-        $this->__filterChain = $filters;
-        return $this;
-    }
+        $this->__filter = $filter;
 
-    /**
-     * Retrieve filter chain for post-filtering script content, if one has been configured
-     */
-    public function getFilterChain(): FilterChain|null
-    {
-        return $this->__filterChain;
+        return $this;
     }
 
     /**
@@ -495,8 +487,8 @@ class PhpRenderer implements Renderer, TreeRendererInterface
 
         $this->setVars(array_pop($this->__varsCache));
 
-        if ($this->__filterChain instanceof FilterChain) {
-            return $this->__filterChain->filter($this->__content); // filter output
+        if ($this->__filter !== null) {
+            return ($this->__filter)($this->__content);
         }
 
         return $this->__content;

--- a/test/PhpRendererTest.php
+++ b/test/PhpRendererTest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace LaminasTest\View;
 
 use ArrayObject;
-use Laminas\Filter\FilterChain;
-use Laminas\Filter\FilterPluginManager;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Exception\DomainException;
 use Laminas\View\Exception\RuntimeException;
@@ -19,22 +17,20 @@ use Laminas\View\Renderer\PhpRenderer;
 use Laminas\View\Resolver\TemplateMapResolver;
 use Laminas\View\Resolver\TemplatePathStack;
 use Laminas\View\Variables;
-use LaminasTest\View\TestAsset\InMemoryContainer;
 use LaminasTest\View\TestAsset\Invokable;
 use LaminasTest\View\TestAsset\SharedInstance;
 use LaminasTest\View\TestAsset\Uninvokable;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use ReflectionObject;
 use Throwable;
 
 use function assert;
 use function realpath;
 use function restore_error_handler;
 use function set_error_handler;
-use function str_replace;
 
 use const E_WARNING;
+use const PHP_EOL;
 
 final class PhpRendererTest extends TestCase
 {
@@ -113,16 +109,16 @@ final class PhpRendererTest extends TestCase
         $this->assertInstanceOf(Doctype::class, $helper);
     }
 
-    public function testFilterChainIsNullByDefault(): void
+    public function testFilterCanBeAddedToMutateOutput(): void
     {
-        $this->assertNull($this->renderer->getFilterChain());
-    }
+        $this->resolver()->addPath(__DIR__ . '/_templates');
+        $output = $this->renderer->render('empty.phtml');
+        self::assertSame('Empty view' . PHP_EOL, $output);
 
-    public function testMaySetExplicitFilterChainInstance(): void
-    {
-        $filterChain = new FilterChain(new FilterPluginManager(new InMemoryContainer()));
-        $this->renderer->setFilterChain($filterChain);
-        $this->assertSame($filterChain, $this->renderer->getFilterChain());
+        $filter = static fn (string $content): string => $content . 'foo';
+        $this->renderer->setFilter($filter);
+        $output = $this->renderer->render('empty.phtml');
+        self::assertSame('Empty view' . PHP_EOL . 'foo', $output);
     }
 
     public function testRenderingAllowsVariableSubstitutions(): void
@@ -136,16 +132,12 @@ final class PhpRendererTest extends TestCase
 
     public function testRenderingFiltersContentWithFilterChain(): void
     {
-        $filterChain = new FilterChain(new FilterPluginManager(new InMemoryContainer()));
-        $filterChain->attach(static fn(string $content): string => str_replace('INJECT', 'bar', $content));
-
-        $this->renderer->setFilterChain($filterChain);
-
-        $expected = 'foo bar baz';
-        $this->renderer->vars()->assign(['bar' => 'INJECT']);
+        $filter   = static fn (string $content): string => $content . 'Miss Piggy';
+        $this->renderer->setFilter($filter);
+        $expected = 'Empty view' . PHP_EOL . 'Miss Piggy';
         $this->resolver()->addPath(__DIR__ . '/_templates');
-        $test = $this->renderer->render('test.phtml');
-        $this->assertStringContainsString($expected, $test);
+        $renderResult = $this->renderer->render('empty.phtml');
+        $this->assertSame($expected, $renderResult);
     }
 
     public function testCanAccessHelpersInTemplates(): void
@@ -414,18 +406,11 @@ final class PhpRendererTest extends TestCase
         $this->assertEquals(3, $this->renderer->sharedinstance());
     }
 
-    public function testDoesNotCallFilterChainIfNoFilterChainWasSet(): void
+    public function testContentIsNotMutatedWhenNoFilterHasBeenSet(): void
     {
         $this->resolver()->addPath(__DIR__ . '/_templates');
-
         $result = $this->renderer->render('empty.phtml');
-
-        $this->assertStringContainsString('Empty view', $result);
-        $rendererReflection = new ReflectionObject($this->renderer);
-        $method             = $rendererReflection->getProperty('__filterChain');
-        $filterChain        = $method->getValue($this->renderer);
-
-        $this->assertEmpty($filterChain);
+        self::assertSame('Empty view' . PHP_EOL, $result);
     }
 
     public function testRendererDoesntUsePreviousRenderedOutputWhenInvokedWithEmptyString(): void

--- a/tools/crc/config.json
+++ b/tools/crc/config.json
@@ -1,5 +1,3 @@
 {
-    "symbol-whitelist" : [
-        "Laminas\\Filter\\FilterChain"
-    ]
+    "symbol-whitelist" : []
 }


### PR DESCRIPTION
Renames `setFilterChain` to `setFilter` in `PhpRenderer`, changing argument type to a well-defined callable shape.

`FilterChain` is callable, therefore it could still stand in here without the coupling to `Laminas\Filter`

Removes the `getFilter` method because "getters".

There are no changes to docs here yet - mainly because PhpRenderer needs a refactor and the filter will likely become a constructor dependency amongst other things