### PR TITLE
Remove `ViewModel` "Options"

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -41,7 +41,6 @@
   <file src="src/Model/ClearableModelInterface.php">
     <MissingReturnType>
       <code><![CDATA[clearChildren]]></code>
-      <code><![CDATA[clearOptions]]></code>
       <code><![CDATA[clearVariables]]></code>
     </MissingReturnType>
   </file>
@@ -57,14 +56,11 @@
       <code><![CDATA[ModelInterface]]></code>
       <code><![CDATA[ModelInterface]]></code>
       <code><![CDATA[ModelInterface]]></code>
-      <code><![CDATA[ModelInterface]]></code>
-      <code><![CDATA[ModelInterface]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Model/ViewModel.php">
     <DocblockTypeContradiction>
       <code><![CDATA[gettype($variables)]]></code>
-      <code><![CDATA[is_array($options)]]></code>
     </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[array|ArrayAccess|Traversable]]></code>
@@ -78,15 +74,10 @@
     <PossiblyInvalidArrayAccess>
       <code><![CDATA[$variables[$name]]]></code>
     </PossiblyInvalidArrayAccess>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[getOption]]></code>
-    </PossiblyUnusedMethod>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(bool) $append]]></code>
       <code><![CDATA[(bool) $terminate]]></code>
       <code><![CDATA[(string) $capture]]></code>
-      <code><![CDATA[(string) $name]]></code>
-      <code><![CDATA[(string) $name]]></code>
       <code><![CDATA[(string) $name]]></code>
       <code><![CDATA[(string) $name]]></code>
       <code><![CDATA[(string) $template]]></code>
@@ -115,7 +106,6 @@
     <MixedAssignment>
       <code><![CDATA[$includeReturn]]></code>
       <code><![CDATA[$this->__template]]></code>
-      <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$variablesAsArray[$key]]]></code>
       <code><![CDATA[$vars[$name]]]></code>
@@ -287,10 +277,8 @@
     <InvalidArgument>
       <code><![CDATA[$vars]]></code>
       <code><![CDATA[new stdClass()]]></code>
-      <code><![CDATA[new stdClass()]]></code>
     </InvalidArgument>
     <MixedArgumentTypeCoercion>
-      <code><![CDATA[$options]]></code>
       <code><![CDATA[$vars]]></code>
     </MixedArgumentTypeCoercion>
     <PossiblyInvalidArgument>

--- a/src/Model/ClearableModelInterface.php
+++ b/src/Model/ClearableModelInterface.php
@@ -14,7 +14,5 @@ interface ClearableModelInterface
 {
     public function clearChildren();
 
-    public function clearOptions();
-
     public function clearVariables();
 }

--- a/src/Model/ModelInterface.php
+++ b/src/Model/ModelInterface.php
@@ -7,7 +7,6 @@ namespace Laminas\View\Model;
 use ArrayAccess;
 use Countable;
 use IteratorAggregate;
-use Traversable;
 
 /**
  * Interface describing a view model.
@@ -21,30 +20,6 @@ use Traversable;
  */
 interface ModelInterface extends Countable, IteratorAggregate
 {
-    /**
-     * Set renderer option/hint
-     *
-     * @param  string $name
-     * @param  mixed $value
-     * @return ModelInterface
-     */
-    public function setOption($name, $value);
-
-    /**
-     * Set renderer options/hints en masse
-     *
-     * @param  array<string, mixed>|Traversable<string, mixed> $options
-     * @return ModelInterface
-     */
-    public function setOptions($options);
-
-    /**
-     * Get renderer options/hints
-     *
-     * @return array<string, mixed>|Traversable<string, mixed>
-     */
-    public function getOptions();
-
     /**
      * Get a single view variable
      *

--- a/src/Model/ViewModel.php
+++ b/src/Model/ViewModel.php
@@ -9,17 +9,18 @@ use ArrayIterator;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\View\Exception;
 use Laminas\View\Variables as ViewVariables;
-use ReturnTypeWillChange; // phpcs:ignore
+use ReturnTypeWillChange;
 use Traversable;
 
 use function array_key_exists;
 use function array_merge;
 use function count;
-use function get_debug_type;
 use function gettype;
 use function is_array;
 use function is_object;
 use function sprintf;
+
+// phpcs:ignore
 
 /** @final */
 class ViewModel implements ModelInterface, ClearableModelInterface, RetrievableChildrenInterface
@@ -37,13 +38,6 @@ class ViewModel implements ModelInterface, ClearableModelInterface, RetrievableC
      * @var list<ModelInterface>
      */
     protected $children = [];
-
-    /**
-     * Renderer options
-     *
-     * @var array<string, mixed>
-     */
-    protected $options = [];
 
     /**
      * Template to use when rendering this model
@@ -78,9 +72,8 @@ class ViewModel implements ModelInterface, ClearableModelInterface, RetrievableC
      * Constructor
      *
      * @param  null|array<string, mixed>|Traversable<string, mixed>|ArrayAccess<string, mixed> $variables
-     * @param  null|array<string, mixed>|Traversable<string, mixed> $options
      */
-    public function __construct($variables = null, $options = null)
+    public function __construct($variables = null)
     {
         if (null === $variables) {
             $variables = new ViewVariables();
@@ -88,10 +81,6 @@ class ViewModel implements ModelInterface, ClearableModelInterface, RetrievableC
 
         // Initializing the variables container
         $this->setVariables($variables, true);
-
-        if (null !== $options) {
-            $this->setOptions($options);
-        }
     }
 
     /**
@@ -162,80 +151,6 @@ class ViewModel implements ModelInterface, ClearableModelInterface, RetrievableC
         if (is_object($this->variables)) {
             $this->variables = clone $this->variables;
         }
-    }
-
-    /**
-     * Set a single option
-     *
-     * @param  string $name
-     * @param  mixed $value
-     * @return ViewModel
-     */
-    public function setOption($name, $value)
-    {
-        $this->options[(string) $name] = $value;
-        return $this;
-    }
-
-    /**
-     * Get a single option
-     *
-     * @param  string       $name           The option to get.
-     * @param  mixed|null   $default        (optional) A default value if the option is not yet set.
-     * @return mixed
-     */
-    public function getOption($name, $default = null)
-    {
-        $name = (string) $name;
-        return array_key_exists($name, $this->options) ? $this->options[$name] : $default;
-    }
-
-    /**
-     * Set renderer options/hints en masse
-     *
-     * @param array<string, mixed>|Traversable<string, mixed> $options
-     * @throws Exception\InvalidArgumentException
-     * @return ViewModel
-     */
-    public function setOptions($options)
-    {
-        // Assumption is that lowest common denominator for renderer configuration
-        // is an array
-        if ($options instanceof Traversable) {
-            $options = ArrayUtils::iteratorToArray($options);
-        }
-
-        if (! is_array($options)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s: expects an array, or Traversable argument; received "%s"',
-                __METHOD__,
-                get_debug_type($options),
-            ));
-        }
-
-        $this->options = $options;
-        return $this;
-    }
-
-    /**
-     * Get renderer options/hints
-     *
-     * @return array<string, mixed>
-     */
-    public function getOptions()
-    {
-        return $this->options;
-    }
-
-    /**
-     * Clear any existing renderer options/hints
-     *
-     * @return $this
-     */
-    public function clearOptions()
-    {
-        $this->options = [];
-        return $this;
     }
 
     /**

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -28,7 +28,6 @@ use function get_debug_type;
 use function is_array;
 use function is_callable;
 use function is_string;
-use function method_exists;
 use function ob_end_clean;
 use function ob_get_clean;
 use function ob_start;
@@ -354,15 +353,6 @@ class PhpRenderer implements Renderer, TreeRendererInterface
                     __METHOD__
                 ));
             }
-            $options = $model->getOptions();
-            foreach ($options as $setting => $value) {
-                $method = 'set' . $setting;
-                if (method_exists($this, $method)) {
-                    $this->$method($value);
-                }
-                unset($method, $setting, $value);
-            }
-            unset($options);
 
             // Give view model awareness via ViewModel helper
             $helper = $this->plugin(ViewModel::class);

--- a/test/Model/ViewModelTest.php
+++ b/test/Model/ViewModelTest.php
@@ -16,7 +16,6 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function count;
-use function iterator_to_array;
 
 final class ViewModelTest extends TestCase
 {
@@ -36,30 +35,19 @@ final class ViewModelTest extends TestCase
     {
         $model = new ViewModel();
         $this->assertInstanceOf(ViewVariables::class, $model->getVariables());
-        $this->assertEquals([], $model->getOptions());
     }
 
-    public function testAllowsEmptyOptionsArgumentToConstructor(): void
+    public function testAllowsPassingVariablesToConstructor(): void
     {
         $model = new ViewModel(['foo' => 'bar']);
         $this->assertEquals(['foo' => 'bar'], $model->getVariables());
-        $this->assertEquals([], $model->getOptions());
     }
 
-    public function testAllowsPassingBothVariablesAndOptionsArgumentsToConstructor(): void
+    public function testAllowsPassingTraversableArgumentsToConstructor(): void
     {
-        $model = new ViewModel(['foo' => 'bar'], ['template' => 'foo/bar']);
-        $this->assertEquals(['foo' => 'bar'], $model->getVariables());
-        $this->assertEquals(['template' => 'foo/bar'], $model->getOptions());
-    }
-
-    public function testAllowsPassingTraversableArgumentsToVariablesAndOptionsInConstructor(): void
-    {
-        $vars    = new ArrayObject();
-        $options = new ArrayObject();
-        $model   = new ViewModel($vars, $options);
+        $vars  = new ArrayObject();
+        $model = new ViewModel($vars);
         $this->assertSame($vars, $model->getVariables());
-        $this->assertSame(iterator_to_array($options), $model->getOptions());
     }
 
     public function testAllowsPassingNonArrayAccessObjectsAsArrayInConstructor(): void
@@ -108,59 +96,12 @@ final class ViewModelTest extends TestCase
         $this->assertEquals(0, count($vars));
     }
 
-    public function testCanSetOptionsSingly(): void
-    {
-        $model = new ViewModel([], ['foo' => 'bar']);
-        $model->setOption('bar', 'baz');
-        $this->assertEquals(['foo' => 'bar', 'bar' => 'baz'], $model->getOptions());
-    }
-
-    public function testCanOverwriteOptionsSingly(): void
-    {
-        $model = new ViewModel([], ['foo' => 'bar']);
-        $model->setOption('foo', 'baz');
-        $this->assertEquals(['foo' => 'baz'], $model->getOptions());
-    }
-
-    public function testSetOptionsOverwritesAllPreviouslyStored(): ViewModel
-    {
-        $model = new ViewModel([], ['foo' => 'bar', 'bar' => 'baz']);
-        $model->setOptions(['bar' => 'BAZBAT']);
-        $this->assertEquals(['bar' => 'BAZBAT'], $model->getOptions());
-        return $model;
-    }
-
-    public function testOptionsAreInternallyConvertedToAnArrayFromTraversables(): void
-    {
-        $options = new ArrayObject(['foo' => 'bar']);
-        $model   = new ViewModel();
-        $model->setOptions($options);
-        $this->assertEquals($options->getArrayCopy(), $model->getOptions());
-    }
-
-    /**
-     * @depends testSetOptionsOverwritesAllPreviouslyStored
-     */
-    public function testCanClearOptions(ViewModel $model): void
-    {
-        $model->clearOptions();
-        $this->assertEquals([], $model->getOptions());
-    }
-
     public function testPassingAnInvalidArgumentToSetVariablesRaisesAnException(): void
     {
         $model = new ViewModel();
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('expects an array');
         $model->setVariables(new stdClass());
-    }
-
-    public function testPassingAnInvalidArgumentToSetOptionsRaisesAnException(): void
-    {
-        $model = new ViewModel();
-        $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('expects an array');
-        $model->setOptions(new stdClass());
     }
 
     public function testCaptureToDefaultsToContent(): void


### PR DESCRIPTION
The view model does not need options as part of its contract. The only feasible option might be 'template', but this should be a property of the view model rather than an option.

Users can create their own view models based on `ModelInterface` if options are necessary for some reason.
