### PR TITLE
Further duck-typing deprecations + SA issue reduction

### DIFF
--- a/bin/templatemap_generator.php
+++ b/bin/templatemap_generator.php
@@ -98,6 +98,7 @@ if (empty($files)) {
 }
 
 $realPath = realpath($basePath);
+assert($realPath !== false);
 
 $entries = array_map(function (string $file) use ($basePath, $realPath) {
     $file = str_replace('\\', '/', $file);
@@ -115,6 +116,7 @@ $entries = array_map(function (string $file) use ($basePath, $realPath) {
         : $template;
 
     $template = preg_replace('#^\.*/#', '', $template);
+    assert(is_string($template));
 
     return sprintf("    '%s' => __DIR__ . '/%s',", $template, $file);
 }, $files);

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="6.12.0@cf420941d061a57050b6c468ef2c778faf40aee2">
-  <file src="bin/templatemap_generator.php">
-    <PossiblyFalseArgument>
-      <code><![CDATA[$realPath]]></code>
-      <code><![CDATA[$realPath]]></code>
-    </PossiblyFalseArgument>
-    <PossiblyNullArgument>
-      <code><![CDATA[$template]]></code>
-    </PossiblyNullArgument>
-  </file>
   <file src="src/Helper/Escaper/AbstractHelper.php">
     <MixedAssignment>
       <code><![CDATA[$value[$k]]]></code>
@@ -61,104 +52,5 @@
       <code><![CDATA[(string) $capture]]></code>
       <code><![CDATA[(string) $template]]></code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="src/Renderer/Template.php">
-    <UnusedParam>
-      <code><![CDATA[$value]]></code>
-    </UnusedParam>
-  </file>
-  <file src="test/Helper/HtmlListTest.php">
-    <UnusedParam>
-      <code><![CDATA[$key]]></code>
-    </UnusedParam>
-  </file>
-  <file src="test/Helper/PartialLoopTest.php">
-    <MixedAssignment>
-      <code><![CDATA[$value]]></code>
-    </MixedAssignment>
-  </file>
-  <file src="test/Helper/Service/HeadTitleFactoryTest.php">
-    <MixedReturnStatement>
-      <code><![CDATA[iterable]]></code>
-    </MixedReturnStatement>
-  </file>
-  <file src="test/Helper/TestAsset/Aggregate.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[toArray]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="test/Helper/TestAsset/IteratorWithToArrayTestContainer.php">
-    <MixedAssignment>
-      <code><![CDATA[$value]]></code>
-    </MixedAssignment>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[toArray]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="test/Helper/TestAsset/PartialLoopIterator.php">
-    <FalsableReturnStatement>
-      <code><![CDATA[current($this->items)]]></code>
-    </FalsableReturnStatement>
-    <InvalidFalsableReturnType>
-      <code><![CDATA[T|null]]></code>
-    </InvalidFalsableReturnType>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[toArray]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="test/Helper/TestAsset/PartialLoopIteratorWithToArray.php">
-    <FalsableReturnStatement>
-      <code><![CDATA[current($this->items)]]></code>
-    </FalsableReturnStatement>
-    <InvalidFalsableReturnType>
-      <code><![CDATA[T]]></code>
-    </InvalidFalsableReturnType>
-    <InvalidNullableReturnType>
-      <code><![CDATA[int|string]]></code>
-    </InvalidNullableReturnType>
-    <NullableReturnStatement>
-      <code><![CDATA[key($this->items)]]></code>
-    </NullableReturnStatement>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[toArray]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="test/Helper/TestAsset/PartialLoopRecursiveIterator.php">
-    <FalsableReturnStatement>
-      <code><![CDATA[current($this->items)]]></code>
-    </FalsableReturnStatement>
-    <InvalidFalsableReturnType>
-      <code><![CDATA[Iterator]]></code>
-    </InvalidFalsableReturnType>
-    <InvalidNullableReturnType>
-      <code><![CDATA[int|string]]></code>
-    </InvalidNullableReturnType>
-    <NullableReturnStatement>
-      <code><![CDATA[key($this->items)]]></code>
-    </NullableReturnStatement>
-  </file>
-  <file src="test/Helper/TestAsset/PartialLoopToArrayImplementor.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[toArray]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="test/Helper/TestAsset/ToArray.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[toArray]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="test/HelperPluginManagerCompatibilityTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[setInvokableClass]]></code>
-      <code><![CDATA[setService]]></code>
-    </DeprecatedMethod>
-    <InvalidArgument>
-      <code><![CDATA[$this]]></code>
-    </InvalidArgument>
-  </file>
-  <file src="test/Model/TestAsset/Variable.php">
-    <MissingTemplateParam>
-      <code><![CDATA[Iterator]]></code>
-    </MissingTemplateParam>
   </file>
 </files>

--- a/src/Helper/Escaper/AbstractHelper.php
+++ b/src/Helper/Escaper/AbstractHelper.php
@@ -11,6 +11,9 @@ use function is_array;
 use function is_object;
 use function is_string;
 use function method_exists;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 /**
  * @psalm-internal Laminas\View
@@ -72,6 +75,11 @@ abstract class AbstractHelper
             }
 
             if (method_exists($value, 'toArray')) {
+                trigger_error(
+                    'Non-iterable objects implementing a `toArray` method will be rejected in version 4.0 '
+                    . 'of laminas-view ',
+                    E_USER_DEPRECATED,
+                );
                 return $this->__invoke($value->toArray(), $recurse | self::RECURSE_ARRAY);
             }
 

--- a/src/Renderer/Template.php
+++ b/src/Renderer/Template.php
@@ -110,7 +110,7 @@ final class Template implements IteratorAggregate
      *
      * @param non-empty-string $name
      */
-    public function __set(string $name, mixed $value): never
+    public function __set(string $name, mixed $_value): never
     {
         throw RenderingFailedException::becauseMemberVariablesCannotBeMutated($name, $this->__template);
     }

--- a/test/Helper/EscapeCssTest.php
+++ b/test/Helper/EscapeCssTest.php
@@ -7,6 +7,8 @@ namespace LaminasTest\View\Helper;
 use Laminas\Escaper\Escaper;
 use Laminas\View\Helper\EscapeCss;
 use Laminas\View\Helper\Escaper\AbstractHelper;
+use LaminasTest\View\Helper\TestAsset\ToArray;
+use LaminasTest\View\TestHelpers;
 use PHPUnit\Framework\TestCase;
 
 final class EscapeCssTest extends TestCase
@@ -59,7 +61,8 @@ final class EscapeCssTest extends TestCase
         );
     }
 
-    public function testCanRecurseObjectImplementingToArray(): void
+    /** @link ToArray::toArray() */
+    public function testCanRecurseObjectImplementingToArrayWithDeprecation(): void
     {
         $original = [
             'foo' => '<b>bar</b>',
@@ -81,8 +84,16 @@ final class EscapeCssTest extends TestCase
             ],
         ];
 
-        $object = new TestAsset\ToArray($original);
-        self::assertEquals($expected, $this->helper->__invoke($object, AbstractHelper::RECURSE_OBJECT));
+        $object = new ToArray($original);
+
+        /** @var mixed $result */
+        $result = TestHelpers::expectDeprecationWithMessage(
+            'Non-iterable objects implementing a `toArray`',
+            fn (): mixed => $this->helper->__invoke($object, AbstractHelper::RECURSE_OBJECT),
+        );
+
+        self::assertIsArray($result);
+        self::assertEquals($expected, $result);
     }
 
     public function testCanRecurseObjectProperties(): void

--- a/test/Helper/EscapeHtmlAttrTest.php
+++ b/test/Helper/EscapeHtmlAttrTest.php
@@ -7,6 +7,8 @@ namespace LaminasTest\View\Helper;
 use Laminas\Escaper\Escaper;
 use Laminas\View\Helper\EscapeHtmlAttr;
 use Laminas\View\Helper\Escaper\AbstractHelper;
+use LaminasTest\View\Helper\TestAsset\ToArray;
+use LaminasTest\View\TestHelpers;
 use PHPUnit\Framework\TestCase;
 
 final class EscapeHtmlAttrTest extends TestCase
@@ -51,7 +53,8 @@ final class EscapeHtmlAttrTest extends TestCase
         );
     }
 
-    public function testCanRecurseObjectImplementingToArray(): void
+    /** @link ToArray::toArray() */
+    public function testCanRecurseObjectImplementingToArrayWithDeprecation(): void
     {
         $original = [
             'foo' => '<b>bar</b>',
@@ -73,8 +76,16 @@ final class EscapeHtmlAttrTest extends TestCase
             ],
         ];
 
-        $object = new TestAsset\ToArray($original);
-        self::assertEquals($expected, $this->helper->__invoke($object, AbstractHelper::RECURSE_OBJECT));
+        $object = new ToArray($original);
+
+        /** @var mixed $result */
+        $result = TestHelpers::expectDeprecationWithMessage(
+            'Non-iterable objects implementing a `toArray`',
+            fn (): mixed => $this->helper->__invoke($object, AbstractHelper::RECURSE_OBJECT),
+        );
+
+        self::assertIsArray($result);
+        self::assertEquals($expected, $result);
     }
 
     public function testCanRecurseObjectProperties(): void

--- a/test/Helper/EscapeHtmlTest.php
+++ b/test/Helper/EscapeHtmlTest.php
@@ -7,6 +7,8 @@ namespace LaminasTest\View\Helper;
 use Laminas\Escaper\Escaper;
 use Laminas\View\Helper\EscapeHtml;
 use Laminas\View\Helper\Escaper\AbstractHelper;
+use LaminasTest\View\Helper\TestAsset\ToArray;
+use LaminasTest\View\TestHelpers;
 use PHPUnit\Framework\TestCase;
 
 final class EscapeHtmlTest extends TestCase
@@ -54,7 +56,8 @@ final class EscapeHtmlTest extends TestCase
         self::assertSame('&lt;foo&gt;', $this->helper->__invoke($object));
     }
 
-    public function testCanRecurseObjectImplementingToArray(): void
+    /** @link ToArray::toArray() */
+    public function testCanRecurseObjectImplementingToArrayWithDeprecation(): void
     {
         $original = [
             'foo' => '<b>bar</b>',
@@ -66,7 +69,7 @@ final class EscapeHtmlTest extends TestCase
             ],
         ];
 
-        $object = new TestAsset\ToArray($original);
+        $object = new ToArray($original);
 
         $expected = [
             'foo' => '&lt;b&gt;bar&lt;/b&gt;',
@@ -78,7 +81,14 @@ final class EscapeHtmlTest extends TestCase
             ],
         ];
 
-        self::assertEquals($expected, $this->helper->__invoke($object, AbstractHelper::RECURSE_OBJECT));
+        /** @var mixed $result */
+        $result = TestHelpers::expectDeprecationWithMessage(
+            'Non-iterable objects implementing a `toArray`',
+            fn (): mixed => $this->helper->__invoke($object, AbstractHelper::RECURSE_OBJECT),
+        );
+
+        self::assertIsArray($result);
+        self::assertEquals($expected, $result);
     }
 
     public function testCanRecurseObjectProperties(): void

--- a/test/Helper/EscapeJsTest.php
+++ b/test/Helper/EscapeJsTest.php
@@ -7,6 +7,8 @@ namespace LaminasTest\View\Helper;
 use Laminas\Escaper\Escaper;
 use Laminas\View\Helper\EscapeJs;
 use Laminas\View\Helper\Escaper\AbstractHelper;
+use LaminasTest\View\Helper\TestAsset\ToArray;
+use LaminasTest\View\TestHelpers;
 use PHPUnit\Framework\TestCase;
 
 final class EscapeJsTest extends TestCase
@@ -57,7 +59,8 @@ final class EscapeJsTest extends TestCase
         );
     }
 
-    public function testCanRecurseObjectImplementingToArray(): void
+    /** @link ToArray::toArray() */
+    public function testCanRecurseObjectImplementingToArrayWithDeprecation(): void
     {
         $original = [
             'foo' => '<b>bar</b>',
@@ -69,8 +72,6 @@ final class EscapeJsTest extends TestCase
             ],
         ];
 
-        $object = new TestAsset\ToArray($original);
-
         $expected = [
             'foo' => '\x3Cb\x3Ebar\x3C\x2Fb\x3E',
             'baz' => [
@@ -81,7 +82,16 @@ final class EscapeJsTest extends TestCase
             ],
         ];
 
-        self::assertEquals($expected, $this->helper->__invoke($object, AbstractHelper::RECURSE_OBJECT));
+        $object = new ToArray($original);
+
+        /** @var mixed $result */
+        $result = TestHelpers::expectDeprecationWithMessage(
+            'Non-iterable objects implementing a `toArray`',
+            fn (): mixed => $this->helper->__invoke($object, AbstractHelper::RECURSE_OBJECT),
+        );
+
+        self::assertIsArray($result);
+        self::assertEquals($expected, $result);
     }
 
     public function testCanRecurseObjectProperties(): void

--- a/test/Helper/EscapeUrlTest.php
+++ b/test/Helper/EscapeUrlTest.php
@@ -7,6 +7,8 @@ namespace LaminasTest\View\Helper;
 use Laminas\Escaper\Escaper;
 use Laminas\View\Helper\Escaper\AbstractHelper;
 use Laminas\View\Helper\EscapeUrl;
+use LaminasTest\View\Helper\TestAsset\ToArray;
+use LaminasTest\View\TestHelpers;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -53,7 +55,8 @@ final class EscapeUrlTest extends TestCase
         self::assertSame('%3Ci%3E', $this->helper->__invoke($object));
     }
 
-    public function testCanRecurseObjectImplementingToArray(): void
+    /** @link ToArray::toArray() */
+    public function testCanRecurseObjectImplementingToArrayWithDeprecation(): void
     {
         $original = [
             'foo' => '<b>bar</b>',
@@ -64,7 +67,7 @@ final class EscapeUrlTest extends TestCase
                 ],
             ],
         ];
-        $object   = new TestAsset\ToArray($original);
+
         $expected = [
             'foo' => '%3Cb%3Ebar%3C%2Fb%3E',
             'baz' => [
@@ -74,7 +77,17 @@ final class EscapeUrlTest extends TestCase
                 ],
             ],
         ];
-        self::assertEquals($expected, $this->helper->__invoke($object, AbstractHelper::RECURSE_OBJECT));
+
+        $object = new ToArray($original);
+
+        /** @var mixed $result */
+        $result = TestHelpers::expectDeprecationWithMessage(
+            'Non-iterable objects implementing a `toArray`',
+            fn (): mixed => $this->helper->__invoke($object, AbstractHelper::RECURSE_OBJECT),
+        );
+
+        self::assertIsArray($result);
+        self::assertEquals($expected, $result);
     }
 
     public function testCanRecurseObjectProperties(): void

--- a/test/Helper/HtmlListTest.php
+++ b/test/Helper/HtmlListTest.php
@@ -178,12 +178,13 @@ final class HtmlListTest extends TestCase
         $this->assertStringContainsString('<ul>', $list);
         $this->assertStringContainsString('</ul>', $list);
 
-        array_walk_recursive($items, [$this, 'validateItems'], $list);
-    }
-
-    public function validateItems(string $value, int $key, string $userdata): void
-    {
-        $this->assertStringContainsString('<li>' . $value, $userdata);
+        array_walk_recursive(
+            $items,
+            static function (string $value, int $_key, string $userdata): void { // phpcs:ignore
+                self::assertStringContainsString('<li>' . $value, $userdata);
+            },
+            $list,
+        );
     }
 
     public function testEmptyItems(): void

--- a/test/Helper/PartialLoopTest.php
+++ b/test/Helper/PartialLoopTest.php
@@ -75,6 +75,8 @@ final class PartialLoopTest extends TestCase
 
         $result = $this->helper->__invoke('basic-loop.phtml', $rIterator);
         foreach ($rIterator as $item) {
+            self::assertNotFalse($item);
+            /** @var mixed $value */
             foreach ($item as $value) {
                 self::assertIsString($value);
                 self::assertStringContainsString($value, $result, var_export($value, true));

--- a/test/Helper/Service/HeadTitleFactoryTest.php
+++ b/test/Helper/Service/HeadTitleFactoryTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 final class HeadTitleFactoryTest extends TestCase
 {
+    /** @return iterable<string, array{0: array|null, 1: list<string>, 2: string}> */
     public static function configScenarios(): iterable
     {
         yield 'Reasonable valid config' => [

--- a/test/Helper/TestAsset/Aggregate.php
+++ b/test/Helper/TestAsset/Aggregate.php
@@ -12,7 +12,12 @@ final class Aggregate
         'bar' => 'baz',
     ];
 
-    /** @return array<string, string> */
+    /**
+     * @deprecated Remove in 4.0
+     *
+     * @return array<string, string>
+     * @psalm-api Used to test deprecated duck typing
+     */
     public function toArray(): array
     {
         return $this->vars;

--- a/test/Helper/TestAsset/IteratorWithToArrayTestContainer.php
+++ b/test/Helper/TestAsset/IteratorWithToArrayTestContainer.php
@@ -15,6 +15,7 @@ final class IteratorWithToArrayTestContainer
     /** @param array<array-key, mixed> $info */
     public function __construct(array $info)
     {
+        /** @psalm-var mixed $value */
         foreach ($info as $key => $value) {
             $this->$key = $value;
         }
@@ -22,7 +23,12 @@ final class IteratorWithToArrayTestContainer
         $this->info = $info;
     }
 
-    /** @return array<array-key, mixed> */
+    /**
+     * @deprecated To remove in 4.0
+     *
+     * @return array<array-key, mixed>
+     * @psalm-api Used in duck typing
+     */
     public function toArray(): array
     {
         return $this->info;

--- a/test/Helper/TestAsset/PartialLoopIterator.php
+++ b/test/Helper/TestAsset/PartialLoopIterator.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LaminasTest\View\Helper\TestAsset;
 
 use Iterator;
-use ReturnTypeWillChange; // phpcs:ignore
 
 use function current;
 use function key;
@@ -30,41 +29,38 @@ final class PartialLoopIterator implements Iterator
     /**
      * @return T|null
      */
-    #[ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
-        return current($this->items);
+        $item = current($this->items);
+
+        return $item === false ? null : $item;
     }
 
-    /**
-     * @return array-key|null
-     */
-    #[ReturnTypeWillChange]
-    public function key()
+    public function key(): int|string|null
     {
         return key($this->items);
     }
 
-    #[ReturnTypeWillChange]
     public function next(): void
     {
         next($this->items);
     }
 
-    #[ReturnTypeWillChange]
     public function rewind(): void
     {
         reset($this->items);
     }
 
-    #[ReturnTypeWillChange]
     public function valid(): bool
     {
         return current($this->items) !== false;
     }
 
     /**
+     * @deprecated To remove in 4.0
+     *
      * @return array<array-key, T>
+     * @psalm-api Used via duck-typing
      */
     public function toArray(): array
     {

--- a/test/Helper/TestAsset/PartialLoopIteratorWithToArray.php
+++ b/test/Helper/TestAsset/PartialLoopIteratorWithToArray.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LaminasTest\View\Helper\TestAsset;
 
 use Iterator;
-use ReturnTypeWillChange; // phpcs:ignore
 
 use function current;
 use function key;
@@ -27,39 +26,42 @@ final class PartialLoopIteratorWithToArray implements Iterator
         $this->items = $array;
     }
 
-    /** @return array<array-key, T> */
+    /**
+     * @deprecated This should be removed in 4.0
+     *
+     * @return array<array-key, T>
+     * @psalm-api Used in duck typing tests
+     */
     public function toArray(): array
     {
         return $this->items;
     }
 
     /**
-     * @return T
+     * @return T|null
      */
-    #[ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
-        return current($this->items);
+        $item = current($this->items);
+
+        return $item === false ? null : $item;
     }
 
-    public function key(): int|string
+    public function key(): int|string|null
     {
         return key($this->items);
     }
 
-    #[ReturnTypeWillChange]
     public function next(): void
     {
         next($this->items);
     }
 
-    #[ReturnTypeWillChange]
     public function rewind(): void
     {
         reset($this->items);
     }
 
-    #[ReturnTypeWillChange]
     public function valid(): bool
     {
         return current($this->items) !== false;

--- a/test/Helper/TestAsset/PartialLoopRecursiveIterator.php
+++ b/test/Helper/TestAsset/PartialLoopRecursiveIterator.php
@@ -27,12 +27,12 @@ final class PartialLoopRecursiveIterator implements Iterator
         $this->items[] = $iterator;
     }
 
-    public function current(): Iterator
+    public function current(): Iterator|false
     {
         return current($this->items);
     }
 
-    public function key(): int|string
+    public function key(): int|string|null
     {
         return key($this->items);
     }

--- a/test/Helper/TestAsset/PartialLoopToArrayImplementor.php
+++ b/test/Helper/TestAsset/PartialLoopToArrayImplementor.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Helper\TestAsset;
 
+use LaminasTest\View\Helper\PartialLoopTest;
+
 final class PartialLoopToArrayImplementor
 {
     private array $data;
@@ -13,6 +15,13 @@ final class PartialLoopToArrayImplementor
         $this->data = $data;
     }
 
+    /**
+     * @deprecated This should be removed in 4.0
+     *
+     * @link PartialLoopTest::testShouldAllowIteratingOverObjectsImplementingToArrayWithDeprecation
+     *
+     * @psalm-api This method is used via duck-typing in tests
+     */
     public function toArray(): array
     {
         return $this->data;

--- a/test/Helper/TestAsset/ToArray.php
+++ b/test/Helper/TestAsset/ToArray.php
@@ -11,7 +11,12 @@ final class ToArray
     {
     }
 
-    /** @return array<array-key, mixed> */
+    /**
+     * @deprecated This should be removed in 4.0
+     *
+     * @return array<array-key, mixed>
+     * @psalm-api Used to check duck-typing in Abstract escape helper operates as expected
+     */
     public function toArray(): array
     {
         return $this->array;

--- a/test/HelperPluginManagerCompatibilityTest.php
+++ b/test/HelperPluginManagerCompatibilityTest.php
@@ -67,13 +67,21 @@ final class HelperPluginManagerCompatibilityTest extends TestCase
     public function testRegisteringInvalidElementRaisesException(): void
     {
         $this->expectException($this->getServiceNotFoundException());
-        self::getPluginManager()->setService('test', $this);
+        self::getPluginManager()->configure([
+            'services' => [
+                'test' => $this,
+            ],
+        ]);
     }
 
     public function testLoadingInvalidElementRaisesException(): void
     {
         $manager = self::getPluginManager();
-        $manager->setInvokableClass('test', stdClass::class);
+        $manager->configure([
+            'invokables' => [
+                'test' => stdClass::class,
+            ],
+        ]);
         $this->expectException($this->getServiceNotFoundException());
         $manager->get('test');
     }

--- a/test/Model/TestAsset/Variable.php
+++ b/test/Model/TestAsset/Variable.php
@@ -4,39 +4,21 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Model\TestAsset;
 
-use Iterator;
-use ReturnTypeWillChange; // phpcs:ignore
+use ArrayIterator;
+use IteratorAggregate;
+use Traversable;
 
-final class Variable implements Iterator
+/** @implements IteratorAggregate<string, mixed> */
+final class Variable implements IteratorAggregate
 {
-    #[ReturnTypeWillChange]
-    /**
-     * @return void
-     */
-    public function current()
+    /** @param array<string, mixed> $data */
+    public function __construct(private readonly array $data = [])
     {
     }
 
-    #[ReturnTypeWillChange]
-    /**
-     * @return void
-     */
-    public function key()
+    /** @return Traversable<string, mixed> */
+    public function getIterator(): Traversable
     {
-    }
-
-    #[ReturnTypeWillChange]
-    public function next()
-    {
-    }
-
-    #[ReturnTypeWillChange]
-    public function rewind()
-    {
-    }
-
-    public function valid(): bool
-    {
-        return false;
+        return new ArrayIterator($this->data);
     }
 }

--- a/test/Model/ViewModelTest.php
+++ b/test/Model/ViewModelTest.php
@@ -46,9 +46,8 @@ final class ViewModelTest extends TestCase
 
     public function testAllowsPassingNonArrayAccessObjectsAsArrayInConstructor(): void
     {
-        $vars  = ['foo' => new Variable()];
-        $model = new ViewModel($vars);
-        self::assertSame($vars, $model->getVariables());
+        $model = new ViewModel(new Variable(['foo' => 'bar']));
+        self::assertSame(['foo' => 'bar'], $model->getVariables());
     }
 
     public function testCanSetVariablesSingly(): void


### PR DESCRIPTION
Deprecates duck-typing on `toArray` inside the Escape helpers and fixes a bunch of minor Psalm issues.

Most remaining (~18) issues revolve around view models which still need refactoring and cleaning up.

Also testing out the Sarif reporting introduced in #343 