### PR TITLE
Re-introduce `Laminas\View\View`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,9 +46,9 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~3.1.0",
-        "phpunit/phpunit": "^10.5.47",
+        "phpunit/phpunit": "^10.5.48",
         "psalm/plugin-phpunit": "^0.19.5",
-        "vimeo/psalm": "^6.12.0"
+        "vimeo/psalm": "^6.13.0"
     },
     "conflict": {
         "amphp/dns": "<2.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82bfd01e398d53015c105e8a1fdbdb03",
+    "content-hash": "4e741f915f495e3872d35d41b0846440",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1626,16 +1626,16 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.1.0",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "18a95476797ed480b3f2598984bc6f7e1eecc9a8"
+                "reference": "6e0fa428497bf560152ee73ffbb8af5c6a56b0dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/18a95476797ed480b3f2598984bc6f7e1eecc9a8",
-                "reference": "18a95476797ed480b3f2598984bc6f7e1eecc9a8",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/6e0fa428497bf560152ee73ffbb8af5c6a56b0dd",
+                "reference": "6e0fa428497bf560152ee73ffbb8af5c6a56b0dd",
                 "shasum": ""
             },
             "require": {
@@ -1647,7 +1647,7 @@
                 "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "yoast/phpunit-polyfills": "^1.0"
             },
@@ -1718,7 +1718,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-05-28T16:05:48+00:00"
+            "time": "2025-06-27T17:24:01+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -2209,16 +2209,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.1",
+            "version": "1.13.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
+                "reference": "faed855a7b5f4d4637717c2b3863e277116beb36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
-                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/faed855a7b5f4d4637717c2b3863e277116beb36",
+                "reference": "faed855a7b5f4d4637717c2b3863e277116beb36",
                 "shasum": ""
             },
             "require": {
@@ -2257,7 +2257,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.3"
             },
             "funding": [
                 {
@@ -2265,7 +2265,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T12:36:36+00:00"
+            "time": "2025-07-05T12:25:42+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -2613,16 +2613,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68"
+                "reference": "b9e61a61e39e02dd90944e9115241c7f7e76bfd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
-                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/b9e61a61e39e02dd90944e9115241c7f7e76bfd8",
+                "reference": "b9e61a61e39e02dd90944e9115241c7f7e76bfd8",
                 "shasum": ""
             },
             "require": {
@@ -2654,9 +2654,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.1.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.2.0"
             },
-            "time": "2025-02-19T13:28:12+00:00"
+            "time": "2025-07-13T07:04:09+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2981,16 +2981,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.47",
+            "version": "10.5.48",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3637b3e50d32ab3a0d1a33b3b6177169ec3d95a3"
+                "reference": "6e0a2bc39f6fae7617989d690d76c48e6d2eb541"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3637b3e50d32ab3a0d1a33b3b6177169ec3d95a3",
-                "reference": "3637b3e50d32ab3a0d1a33b3b6177169ec3d95a3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6e0a2bc39f6fae7617989d690d76c48e6d2eb541",
+                "reference": "6e0a2bc39f6fae7617989d690d76c48e6d2eb541",
                 "shasum": ""
             },
             "require": {
@@ -3000,7 +3000,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.13.1",
+                "myclabs/deep-copy": "^1.13.3",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
@@ -3062,7 +3062,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.47"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.48"
             },
             "funding": [
                 {
@@ -3086,7 +3086,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-20T11:29:11+00:00"
+            "time": "2025-07-11T04:07:17+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4511,16 +4511,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.22",
+            "version": "v6.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3"
+                "reference": "9056771b8eca08d026cd3280deeec3cfd99c4d93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3",
-                "reference": "7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9056771b8eca08d026cd3280deeec3cfd99c4d93",
+                "reference": "9056771b8eca08d026cd3280deeec3cfd99c4d93",
                 "shasum": ""
             },
             "require": {
@@ -4585,7 +4585,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.22"
+                "source": "https://github.com/symfony/console/tree/v6.4.23"
             },
             "funding": [
                 {
@@ -4601,7 +4601,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-07T07:05:04+00:00"
+            "time": "2025-06-27T19:37:22+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5352,16 +5352,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.12.0",
+            "version": "6.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "cf420941d061a57050b6c468ef2c778faf40aee2"
+                "reference": "70cdf647255a1362b426bb0f522a85817b8c791c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/cf420941d061a57050b6c468ef2c778faf40aee2",
-                "reference": "cf420941d061a57050b6c468ef2c778faf40aee2",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/70cdf647255a1362b426bb0f522a85817b8c791c",
+                "reference": "70cdf647255a1362b426bb0f522a85817b8c791c",
                 "shasum": ""
             },
             "require": {
@@ -5466,7 +5466,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-05-28T12:52:06+00:00"
+            "time": "2025-07-14T09:59:17+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -34,23 +34,6 @@
     </MissingReturnType>
   </file>
   <file src="src/Model/ModelInterface.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[isAppend]]></code>
-    </PossiblyUnusedMethod>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[ModelInterface]]></code>
-      <code><![CDATA[ModelInterface]]></code>
-      <code><![CDATA[ModelInterface]]></code>
-      <code><![CDATA[ModelInterface]]></code>
-      <code><![CDATA[ModelInterface]]></code>
-    </PossiblyUnusedReturnValue>
-  </file>
-  <file src="src/Model/ViewModel.php">
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $append]]></code>
-      <code><![CDATA[(bool) $terminate]]></code>
-      <code><![CDATA[(string) $capture]]></code>
-      <code><![CDATA[(string) $template]]></code>
-    </RedundantCastGivenDocblockType>
+    <PossiblyUnusedReturnValue/>
   </file>
 </files>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -8,7 +8,6 @@ use Laminas\Escaper\Escaper;
 use Laminas\Escaper\EscaperInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\Helper\Doctype;
-use Laminas\View\Helper\Service\EscaperFactory;
 
 /**
  * @psalm-import-type DoctypeID from Doctype
@@ -24,7 +23,9 @@ use Laminas\View\Helper\Service\EscaperFactory;
  *     },
  *     view_manager?: array{
  *         base_path?: non-empty-string|null,
- *         strict_variables: bool,
+ *         strict_variables?: bool,
+ *         default_layout?: non-empty-string,
+ *         default_capture_to?: non-empty-string,
  *         doctype?: DoctypeID,
  *         encoding?: non-empty-string,
  *         template_map?: array<string, string>,
@@ -33,7 +34,10 @@ use Laminas\View\Helper\Service\EscaperFactory;
  *         default_template_suffix?: non-empty-string,
  *     },
  *     templates?: array{
+ *         strict_variables?: bool,
+ *         default_capture_to?: non-empty-string,
  *         extension?: non-empty-string,
+ *         default_layout?: non-empty-string,
  *         map?: array<string, string>,
  *     },
  * }
@@ -109,6 +113,11 @@ final class ConfigProvider
             ],
             'templates'          => [
                 /**
+                 * Strict variables controls whether an exception is thrown when a view template attempts to use a
+                 * variable that has not been defined.
+                 */
+                'strict_variables' => true,
+                /**
                  * Templates configured here will be provided to the TemplateMapResolver
                  * This is conventional for a Mezzio app
                  */
@@ -128,13 +137,14 @@ final class ConfigProvider
     {
         return [
             'factories' => [
-                HelperPluginManager::class              => HelperPluginManagerFactory::class,
-                Escaper::class                          => EscaperFactory::class,
                 Renderer\PhpRenderer::class             => Renderer\PhpRendererFactory::class,
                 Resolver\AggregateResolver::class       => Resolver\Factory\AggregateResolverFactory::class,
                 Resolver\PrefixPathStackResolver::class => Resolver\Factory\PrefixPathStackResolverFactory::class,
                 Resolver\TemplateMapResolver::class     => Resolver\Factory\TemplateMapResolverFactory::class,
                 Resolver\TemplatePathStack::class       => Resolver\Factory\TemplatePathStackResolverFactory::class,
+                Escaper::class                          => Factory\EscaperFactory::class,
+                HelperPluginManager::class              => Factory\HelperPluginManagerFactory::class,
+                View::class                             => Factory\ViewFactory::class,
             ],
             'aliases'   => [
                 EscaperInterface::class             => Escaper::class,

--- a/src/Factory/Configuration.php
+++ b/src/Factory/Configuration.php
@@ -2,12 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Laminas\View\Helper\Service;
+namespace Laminas\View\Factory;
 
 use Laminas\View\ConfigProvider;
 use Psr\Container\ContainerInterface;
 
 use function is_array;
+use function is_bool;
 use function is_string;
 
 /**
@@ -19,8 +20,11 @@ use function is_string;
  */
 final class Configuration
 {
-    private const DEFAULT_ENCODING        = 'utf-8';
-    private const DEFAULT_TEMPLATE_SUFFIX = 'phtml';
+    private const DEFAULT_ENCODING         = 'utf-8';
+    private const DEFAULT_TEMPLATE_SUFFIX  = 'phtml';
+    private const STRICT_VARIABLES_DEFAULT = true;
+    private const DEFAULT_LAYOUT_TEMPLATE  = 'layout::default';
+    private const DEFAULT_CAPTURE_TO       = 'content';
 
     /** @return array<array-key, mixed> */
     public static function get(ContainerInterface $container): array
@@ -60,7 +64,7 @@ final class Configuration
      * @return non-empty-string
      */
     public static function defaultTemplateSuffix(
-        ContainerInterface $container
+        ContainerInterface $container,
     ): string {
         /** @var ViewConfigShape $config */
         $config = self::get($container);
@@ -68,5 +72,54 @@ final class Configuration
         $suffix = $config['templates']['extension'] ?? $suffix;
 
         return is_string($suffix) ? $suffix : self::DEFAULT_TEMPLATE_SUFFIX;
+    }
+
+    /**
+     * Return the strict_variables configuration option
+     */
+    public static function strictVariables(
+        ContainerInterface $container,
+    ): bool {
+        /** @var ViewConfigShape $config */
+        $config = self::get($container);
+
+        $strict = $config['view_manager']['strict_variables'] ?? null;
+        $strict = $config['templates']['strict_variables'] ?? $strict;
+
+        return is_bool($strict) ? $strict : self::STRICT_VARIABLES_DEFAULT;
+    }
+
+    /**
+     * Retrieve the name of the default layout template
+     *
+     * @return non-empty-string
+     */
+    public static function defaultLayout(
+        ContainerInterface $container,
+    ): string {
+        /** @var ViewConfigShape $config */
+        $config = self::get($container);
+
+        $template = $config['view_manager']['default_layout'] ?? null;
+        $template = $config['templates']['default_layout'] ?? $template;
+
+        return is_string($template) ? $template : self::DEFAULT_LAYOUT_TEMPLATE;
+    }
+
+    /**
+     * Retrieve the default variable name that "child" templates will be captured or rendered to
+     *
+     * @return non-empty-string
+     */
+    public static function defaultCaptureTo(
+        ContainerInterface $container,
+    ): string {
+        /** @var ViewConfigShape $config */
+        $config = self::get($container);
+
+        $captureTo = $config['view_manager']['default_capture_to'] ?? null;
+        $captureTo = $config['templates']['default_capture_to'] ?? $captureTo;
+
+        return is_string($captureTo) ? $captureTo : self::DEFAULT_CAPTURE_TO;
     }
 }

--- a/src/Factory/EscaperFactory.php
+++ b/src/Factory/EscaperFactory.php
@@ -2,11 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Laminas\View\Helper\Service;
+namespace Laminas\View\Factory;
 
 use Laminas\Escaper\Escaper;
 use Psr\Container\ContainerInterface;
 
+/**
+ * @psalm-internal Laminas\View
+ * @psalm-internal LaminasTest\View
+ */
 final class EscaperFactory
 {
     public function __invoke(ContainerInterface $container): Escaper

--- a/src/Factory/HelperPluginManagerFactory.php
+++ b/src/Factory/HelperPluginManagerFactory.php
@@ -2,9 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Laminas\View;
+namespace Laminas\View\Factory;
 
-use Laminas\View\Helper\Service\Configuration;
+use Laminas\View\ConfigProvider;
+use Laminas\View\HelperPluginManager;
 use Psr\Container\ContainerInterface;
 
 /**

--- a/src/Factory/ViewFactory.php
+++ b/src/Factory/ViewFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View\Factory;
+
+use Laminas\View\HelperPluginManagerInterface;
+use Laminas\View\Renderer\RendererInterface;
+use Laminas\View\View;
+use Psr\Container\ContainerInterface;
+
+final class ViewFactory
+{
+    public function __invoke(ContainerInterface $container): View
+    {
+        return new View(
+            $container->get(RendererInterface::class),
+            $container->get(HelperPluginManagerInterface::class),
+            Configuration::defaultLayout($container),
+            Configuration::defaultCaptureTo($container),
+        );
+    }
+}

--- a/src/Helper/Layout.php
+++ b/src/Helper/Layout.php
@@ -24,7 +24,7 @@ final class Layout
      * If no arguments are given, grabs the "root" or "layout" view model.
      * Otherwise, attempts to set the template for that view model.
      *
-     * @param null|string $template Providing a template name will set that template as the current layout template
+     * @param null|non-empty-string $template Provide a template name to set that template as the current layout
      * @return ($template is null ? ModelInterface : self)
      */
     public function __invoke(string|null $template = null): ModelInterface|self

--- a/src/Helper/Service/BasePathFactory.php
+++ b/src/Helper/Service/BasePathFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\View\Helper\Service;
 
 use Laminas\View\ConfigProvider;
+use Laminas\View\Factory\Configuration;
 use Laminas\View\Helper\BasePath;
 use Psr\Container\ContainerInterface;
 

--- a/src/Helper/Service/DoctypeFactory.php
+++ b/src/Helper/Service/DoctypeFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\View\Helper\Service;
 
 use Laminas\View\ConfigProvider;
+use Laminas\View\Factory\Configuration;
 use Laminas\View\Helper\Doctype;
 use Psr\Container\ContainerInterface;
 

--- a/src/Model/ModelInterface.php
+++ b/src/Model/ModelInterface.php
@@ -46,85 +46,69 @@ interface ModelInterface extends Countable, IteratorAggregate
     /**
      * Set the template to be used by this model
      *
-     * @param  string $template
-     * @return ModelInterface
+     * @param non-empty-string $template
      */
-    public function setTemplate($template);
+    public function setTemplate(string $template): static;
 
     /**
      * Get the template to be used by this model
      *
-     * @return string
+     * Implementations should return an empty string when the template has not been set
      */
-    public function getTemplate();
+    public function getTemplate(): string;
 
     /**
      * Add a child model
      *
-     * @param  null|string $captureTo Optional; if specified, the "capture to" value to set on the child
-     * @param  null|bool $append Optional; if specified, append to child  with the same capture
-     * @return ModelInterface
+     * @param null|non-empty-string $captureTo Optional; if specified, the "capture to" value to set on the child.
+     *                                         When null, the default 'capture to' value is used.
+     * @param bool|null $append Optional; when true, the child model will be marked as an appending model.
      */
-    public function addChild(ModelInterface $child, $captureTo = null, $append = false);
+    public function addChild(ModelInterface $child, string|null $captureTo = null, bool|null $append = null): static;
 
     /**
      * Return all children.
      *
-     * Return specifies an array, but may be any iterable object.
-     *
      * @return list<ModelInterface>
      */
-    public function getChildren();
+    public function getChildren(): array;
 
     /**
      * Does the model have any children?
-     *
-     * @return bool
      */
-    public function hasChildren();
+    public function hasChildren(): bool;
 
     /**
      * Set the name of the variable to capture this model to, if it is a child model
      *
-     * @param  string $capture
-     * @return ModelInterface
+     * @param non-empty-string $capture
      */
-    public function setCaptureTo($capture);
+    public function setCaptureTo(string $capture): static;
 
     /**
      * Get the name of the variable to which to capture this model
      *
-     * @return string
+     * @return non-empty-string
      */
-    public function captureTo();
+    public function captureTo(): string;
 
     /**
-     * Set flag indicating whether or not this is considered a terminal or standalone model
-     *
-     * @param  bool $terminate
-     * @return ModelInterface
+     * Set flag indicating whether this is considered a terminal or standalone model
      */
-    public function setTerminal($terminate);
+    public function setTerminal(bool $terminate): static;
 
     /**
      * Is this considered a terminal or standalone model?
-     *
-     * @return bool
      */
-    public function terminate();
+    public function terminate(): bool;
 
     /**
-     * Set flag indicating whether or not append to child  with the same capture
-     *
-     * @param  bool $append
-     * @return ModelInterface
+     * Set flag indicating whether to append to child with the same capture
      */
-    public function setAppend($append);
+    public function setAppend(bool $append): static;
 
     /**
      * Is this append to child  with the same capture?
-     *
-     * @return bool
      */
-    public function isAppend();
+    public function isAppend(): bool;
 }

--- a/src/Model/RetrievableChildrenInterface.php
+++ b/src/Model/RetrievableChildrenInterface.php
@@ -14,9 +14,8 @@ interface RetrievableChildrenInterface
     /**
      * Returns an array of View models with captureTo value $capture
      *
-     * @param string $capture
      * @param bool $recursive search recursive through children, default true
      * @return list<ModelInterface>
      */
-    public function getChildrenByCaptureTo($capture, $recursive = true);
+    public function getChildrenByCaptureTo(string $capture, bool $recursive = true): array;
 }

--- a/src/Model/ViewModel.php
+++ b/src/Model/ViewModel.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Laminas\View\Model;
 
 use ArrayIterator;
-use Laminas\View\Exception\UndefinedVariableException;
-use ReturnTypeWillChange;
 use Traversable;
 
 use function array_key_exists;
@@ -24,30 +22,21 @@ final class ViewModel implements ModelInterface, ClearableModelInterface, Retrie
     /**
      * What variable a parent model should capture this model to
      *
-     * @var string
+     * @var non-empty-string
      */
-    protected $captureTo = 'content';
+    private string $captureTo = 'content';
 
     /**
      * Child models
      *
      * @var list<ModelInterface>
      */
-    protected $children = [];
-
-    /**
-     * Template to use when rendering this model
-     *
-     * @var string
-     */
-    protected $template = '';
+    private array $children = [];
 
     /**
      * Is this a standalone, or terminal, model?
-     *
-     * @var bool
      */
-    protected $terminate = false;
+    private bool $terminate = false;
 
     /**
      * View variables
@@ -57,18 +46,16 @@ final class ViewModel implements ModelInterface, ClearableModelInterface, Retrie
     private array $variables;
 
     /**
-     * Is this append to child  with the same capture?
-     *
-     * @var bool
+     * Is this append to child with the same capture?
      */
-    protected $append = false;
+    private bool $append = false;
 
     /**
      * @param iterable<string, mixed> $variables
      */
     public function __construct(
         iterable $variables = [],
-        private readonly bool $strictVariables = true,
+        private string $template = '',
     ) {
         $this->variables = array_map(
             static fn (mixed $value): mixed => $value,
@@ -86,15 +73,9 @@ final class ViewModel implements ModelInterface, ClearableModelInterface, Retrie
 
     /**
      * Property overloading: get variable value
-     *
-     * @throws UndefinedVariableException
      */
     public function __get(string $name): mixed
     {
-        if (! isset($this->variables[$name]) && $this->strictVariables) {
-            throw UndefinedVariableException::forVariableName($name);
-        }
-
         return $this->variables[$name] ?? null;
     }
 
@@ -168,89 +149,48 @@ final class ViewModel implements ModelInterface, ClearableModelInterface, Retrie
         return $this;
     }
 
-    /**
-     * Set the template to be used by this model
-     *
-     * @param  string $template
-     * @return ViewModel
-     */
-    public function setTemplate($template)
+    public function setTemplate(string $template): static
     {
-        $this->template = (string) $template;
+        $this->template = $template;
         return $this;
     }
 
-    /**
-     * Get the template to be used by this model
-     *
-     * @return string
-     */
-    public function getTemplate()
+    public function getTemplate(): string
     {
         return $this->template;
     }
 
-    /**
-     * Add a child model
-     *
-     * @param  null|string $captureTo Optional; if specified, the "capture to" value to set on the child
-     * @param  null|bool $append Optional; if specified, append to child  with the same capture
-     * @return ViewModel
-     */
-    public function addChild(ModelInterface $child, $captureTo = null, $append = null)
+    public function addChild(ModelInterface $child, string|null $captureTo = null, bool|null $append = null): static
     {
         $this->children[] = $child;
-        if (null !== $captureTo) {
+        if ($captureTo !== null) {
             $child->setCaptureTo($captureTo);
         }
-        if (null !== $append) {
+
+        if ($append !== null) {
             $child->setAppend($append);
         }
 
         return $this;
     }
 
-    /**
-     * Return all children.
-     *
-     * Return specifies an array, but may be any iterable object.
-     *
-     * @return list<ModelInterface>
-     */
-    public function getChildren()
+    public function getChildren(): array
     {
         return $this->children;
     }
 
-    /**
-     * Does the model have any children?
-     *
-     * @return bool
-     */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
-        return (bool) $this->children;
+        return $this->children !== [];
     }
 
-    /**
-     * Clears out all child models
-     *
-     * @return ViewModel
-     */
-    public function clearChildren()
+    public function clearChildren(): static
     {
         $this->children = [];
         return $this;
     }
 
-    /**
-     * Returns an array of Viewmodels with captureTo value $capture
-     *
-     * @param string $capture
-     * @param bool $recursive search recursive through children, default true
-     * @return list<ModelInterface>
-     */
-    public function getChildrenByCaptureTo($capture, $recursive = true)
+    public function getChildrenByCaptureTo(string $capture, bool $recursive = true): array
     {
         $children = [];
 
@@ -267,79 +207,40 @@ final class ViewModel implements ModelInterface, ClearableModelInterface, Retrie
         return $children;
     }
 
-    /**
-     * Set the name of the variable to capture this model to, if it is a child model
-     *
-     * @param  string $capture
-     * @return ViewModel
-     */
-    public function setCaptureTo($capture)
+    public function setCaptureTo(string $capture): static
     {
-        $this->captureTo = (string) $capture;
+        $this->captureTo = $capture;
         return $this;
     }
 
-    /**
-     * Get the name of the variable to which to capture this model
-     *
-     * @return string
-     */
-    public function captureTo()
+    public function captureTo(): string
     {
         return $this->captureTo;
     }
 
-    /**
-     * Set flag indicating whether or not this is considered a terminal or standalone model
-     *
-     * @param  bool $terminate
-     * @return ViewModel
-     */
-    public function setTerminal($terminate)
+    public function setTerminal(bool $terminate): static
     {
-        $this->terminate = (bool) $terminate;
+        $this->terminate = $terminate;
         return $this;
     }
 
-    /**
-     * Is this considered a terminal or standalone model?
-     *
-     * @return bool
-     */
-    public function terminate()
+    public function terminate(): bool
     {
         return $this->terminate;
     }
 
-    /**
-     * Set flag indicating whether or not append to child  with the same capture
-     *
-     * @param  bool $append
-     * @return ViewModel
-     */
-    public function setAppend($append)
+    public function setAppend(bool $append): static
     {
-        $this->append = (bool) $append;
+        $this->append = $append;
         return $this;
     }
 
-    /**
-     * Is this append to child  with the same capture?
-     *
-     * @return bool
-     */
-    public function isAppend()
+    public function isAppend(): bool
     {
         return $this->append;
     }
 
-    /**
-     * Return count of children
-     *
-     * @return int
-     */
-    #[ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->children);
     }
@@ -349,8 +250,7 @@ final class ViewModel implements ModelInterface, ClearableModelInterface, Retrie
      *
      * @return Traversable<int, ModelInterface>
      */
-    #[ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->children);
     }

--- a/src/Renderer/PhpRendererFactory.php
+++ b/src/Renderer/PhpRendererFactory.php
@@ -4,41 +4,23 @@ declare(strict_types=1);
 
 namespace Laminas\View\Renderer;
 
+use Laminas\View\Factory\Configuration;
 use Laminas\View\HelperPluginManagerInterface;
 use Laminas\View\Resolver\ResolverInterface;
 use Psr\Container\ContainerInterface;
 
-use function assert;
-use function is_array;
-use function is_bool;
-
+/**
+ * @psalm-internal Laminas
+ * @psalm-internal LaminasTest
+ */
 final class PhpRendererFactory
 {
     public function __invoke(ContainerInterface $container): PhpRenderer
     {
-        $config = $this->config($container);
-        $strict = $config['strict_variables'] ?? true;
-        assert(is_bool($strict));
-
         return new PhpRenderer(
             $container->get(HelperPluginManagerInterface::class),
             $container->get(ResolverInterface::class),
-            $strict,
+            Configuration::strictVariables($container),
         );
-    }
-
-    /** @return array<array-key, mixed> */
-    private function config(ContainerInterface $container): array
-    {
-        /** @var mixed $config */
-        $config = $container->has('config')
-            ? $container->get('config')
-            : [];
-
-        $config = is_array($config) ? $config : [];
-        /** @psalm-var mixed $set */
-        $set = $config['view_manager'] ?? [];
-
-        return is_array($set) ? $set : [];
     }
 }

--- a/src/Resolver/Factory/PrefixPathStackResolverFactory.php
+++ b/src/Resolver/Factory/PrefixPathStackResolverFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laminas\View\Resolver\Factory;
 
 use Laminas\View\ConfigProvider;
-use Laminas\View\Helper\Service\Configuration;
+use Laminas\View\Factory\Configuration;
 use Laminas\View\Resolver\PrefixPathStackResolver;
 use Psr\Container\ContainerInterface;
 

--- a/src/Resolver/Factory/TemplateMapResolverFactory.php
+++ b/src/Resolver/Factory/TemplateMapResolverFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laminas\View\Resolver\Factory;
 
 use Laminas\View\ConfigProvider;
-use Laminas\View\Helper\Service\Configuration;
+use Laminas\View\Factory\Configuration;
 use Laminas\View\Resolver\TemplateMapResolver;
 use Psr\Container\ContainerInterface;
 

--- a/src/Resolver/Factory/TemplatePathStackResolverFactory.php
+++ b/src/Resolver/Factory/TemplatePathStackResolverFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laminas\View\Resolver\Factory;
 
 use Laminas\View\ConfigProvider;
-use Laminas\View\Helper\Service\Configuration;
+use Laminas\View\Factory\Configuration;
 use Laminas\View\Resolver\TemplatePathStack;
 use Psr\Container\ContainerInterface;
 

--- a/src/View.php
+++ b/src/View.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View;
+
+use Laminas\View\Exception\RenderingFailedException;
+use Laminas\View\Helper\ViewModel as ViewModelHelper;
+use Laminas\View\Model\ModelInterface;
+use Laminas\View\Model\ViewModel;
+use Laminas\View\Renderer\RendererInterface;
+
+use function is_string;
+
+final class View
+{
+    private readonly ViewModelHelper $viewModelHelper;
+
+    /**
+     * @param non-empty-string $defaultLayoutTemplate
+     * @param non-empty-string $defaultCaptureTo
+     */
+    public function __construct(
+        private readonly RendererInterface $renderer,
+        private readonly HelperPluginManagerInterface $pluginManager,
+        private readonly string $defaultLayoutTemplate,
+        private readonly string $defaultCaptureTo,
+    ) {
+        $this->viewModelHelper = $this->pluginManager->get(ViewModelHelper::class);
+    }
+
+    /**
+     * Render a configured top-level layout view model
+     *
+     * It is expected that the given model will have a non-empty template configured and all necessary variables and
+     * child models set.
+     *
+     * @throws RenderingFailedException When any exception occurs during render.
+     */
+    public function renderLayout(ModelInterface $layout): string
+    {
+        $this->viewModelHelper->setRoot($layout);
+        $content = $this->renderRecursively($layout);
+        $this->pluginManager->resetState();
+
+        return $content;
+    }
+
+    /**
+     * @param non-empty-string|ModelInterface $modelOrTemplate
+     * @param iterable<string, mixed>|null|ModelInterface $variables
+     * @throws RenderingFailedException When any exception occurs during render.
+     */
+    public function render(
+        string|ModelInterface $modelOrTemplate,
+        iterable|ModelInterface|null $variables = null,
+        bool $enableLayout = true,
+    ): string {
+        if (is_string($modelOrTemplate)) {
+            $model = $variables instanceof ModelInterface
+                ? $variables
+                : new ViewModel($variables ?? []);
+            $model->setTemplate($modelOrTemplate);
+        } else {
+            $model = $modelOrTemplate;
+        }
+
+        if ($enableLayout) {
+            $layoutModel = new ViewModel([]);
+            $layoutModel->setTemplate($this->defaultLayoutTemplate);
+            $model->setCaptureTo($this->defaultCaptureTo);
+            $layoutModel->addChild($model);
+
+            return $this->renderLayout($layoutModel);
+        }
+
+        $content = $this->renderRecursively($model);
+        $this->pluginManager->resetState();
+
+        return $content;
+    }
+
+    /** @throws RenderingFailedException When any exception occurs during render. */
+    private function renderRecursively(ModelInterface $model): string
+    {
+        foreach ($model->getChildren() as $child) {
+            $this->viewModelHelper->setCurrent($child);
+            $content = $this->renderRecursively($child);
+            if ($child->isAppend()) {
+                /** @psalm-var mixed $existingContent */
+                $existingContent = $model->getVariable($child->captureTo(), '');
+                $existingContent = is_string($existingContent)
+                    ? $existingContent
+                    : '';
+
+                $content = $existingContent . $content;
+            }
+
+            $model->setVariable($child->captureTo(), $content);
+        }
+
+        $this->viewModelHelper->setCurrent($model);
+
+        return $this->renderer->render($model);
+    }
+}

--- a/test/Factory/ConfigurationTest.php
+++ b/test/Factory/ConfigurationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Factory;
+namespace LaminasTest\View\Factory;
 
 use Laminas\View\Factory\Configuration;
 use LaminasTest\View\TestAsset\InMemoryContainer;

--- a/test/Factory/ConfigurationTest.php
+++ b/test/Factory/ConfigurationTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace LaminasTest\View\Helper\Service;
+namespace Factory;
 
-use Laminas\View\Helper\Service\Configuration;
+use Laminas\View\Factory\Configuration;
 use LaminasTest\View\TestAsset\InMemoryContainer;
 use PHPUnit\Framework\TestCase;
 

--- a/test/Factory/HelperPluginManagerFactoryTest.php
+++ b/test/Factory/HelperPluginManagerFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Factory;
+namespace LaminasTest\View\Factory;
 
 use Laminas\View\Factory\HelperPluginManagerFactory;
 use LaminasTest\View\TestAsset\InMemoryContainer;

--- a/test/Factory/HelperPluginManagerFactoryTest.php
+++ b/test/Factory/HelperPluginManagerFactoryTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace LaminasTest\View;
+namespace Factory;
 
-use Laminas\View\HelperPluginManagerFactory;
+use Laminas\View\Factory\HelperPluginManagerFactory;
 use LaminasTest\View\TestAsset\InMemoryContainer;
 use PHPUnit\Framework\TestCase;
 

--- a/test/Model/ViewModelTest.php
+++ b/test/Model/ViewModelTest.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace LaminasTest\View\Model;
 
 use ArrayObject;
-use Laminas\View\Exception\UndefinedVariableException;
-use Laminas\View\Model\ClearableModelInterface;
-use Laminas\View\Model\ModelInterface;
 use Laminas\View\Model\ViewModel;
 use Laminas\View\Variables as ViewVariables;
 use LaminasTest\View\Model\TestAsset\Variable;
@@ -19,18 +16,6 @@ use function count;
 
 final class ViewModelTest extends TestCase
 {
-    public function testImplementsModelInterface(): void
-    {
-        $model = new ViewModel();
-        self::assertInstanceOf(ModelInterface::class, $model);
-    }
-
-    public function testImplementsClearableModelInterface(): void
-    {
-        $model = new ViewModel();
-        self::assertInstanceOf(ClearableModelInterface::class, $model);
-    }
-
     public function testAllowsPassingVariablesToConstructor(): void
     {
         $model = new ViewModel(['foo' => 'bar']);
@@ -170,7 +155,7 @@ final class ViewModelTest extends TestCase
     public function testCanClearChildren(ViewModel $model): void
     {
         $model->clearChildren();
-        self::assertEquals(0, count($model));
+        self::assertCount(0, $model);
     }
 
     public function testTemplateIsEmptyByDefault(): void
@@ -359,17 +344,39 @@ final class ViewModelTest extends TestCase
         self::assertSame($expected, $model->getVariable('foo', $default));
     }
 
-    public function testStrictVariableCauseExceptionsDuringRetrievalOfUnknownVariable(): void
-    {
-        $view = new ViewModel();
-        $this->expectException(UndefinedVariableException::class);
-        $this->expectExceptionMessage('The variable "foo" has not been defined');
-        $view->foo;
-    }
-
     public function testNullIsReturnedForUnknownVariablesWhenStrictVariablesIsOff(): void
     {
-        $view = new ViewModel([], false);
+        $view = new ViewModel();
         self::assertNull($view->foo);
+    }
+
+    public function testSetTerminalHasFluentInterface(): void
+    {
+        $model = new ViewModel();
+        self::assertSame($model, $model->setTerminal(true));
+    }
+
+    public function testSetAppendHasFluentInterface(): void
+    {
+        $model = new ViewModel();
+        self::assertSame($model, $model->setAppend(true));
+    }
+
+    public function testSetCaptureToHasFluentInterface(): void
+    {
+        $model = new ViewModel();
+        self::assertSame($model, $model->setCaptureTo('foot'));
+    }
+
+    public function testSetTemplateHasFluentInterface(): void
+    {
+        $model = new ViewModel();
+        self::assertSame($model, $model->setTemplate('kermit'));
+    }
+
+    public function testAddChildHasFluentInterface(): void
+    {
+        $model = new ViewModel();
+        self::assertSame($model, $model->addChild(new ViewModel()));
     }
 }

--- a/test/ViewTest.php
+++ b/test/ViewTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\View;
+
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\View\ConfigProvider;
+use Laminas\View\Model\ViewModel;
+use Laminas\View\View;
+use PHPUnit\Framework\TestCase;
+
+use function array_merge_recursive;
+use function preg_replace;
+use function trim;
+
+/** @psalm-import-type ViewConfigShape from ConfigProvider */
+final class ViewTest extends TestCase
+{
+    /** @param ViewConfigShape|array<never, never> $config */
+    private static function createView(array $config = []): View
+    {
+        /** Default template directory for the majority of tests */
+        $defaults                           = [
+            'view_manager' => [
+                'template_path_stack' => [
+                    __DIR__ . '/templates/view',
+                ],
+                'template_map'        => [
+                    'layout::default' => __DIR__ . '/templates/view/default-layout.phtml',
+                    'layout::other'   => __DIR__ . '/templates/view/other-layout.phtml',
+                ],
+            ],
+        ];
+        $config                             = array_merge_recursive(
+            (new ConfigProvider())->__invoke(),
+            $defaults,
+            $config,
+        );
+        $config['dependencies']['services'] = ['config' => $config];
+        $serviceManager                     = new ServiceManager($config['dependencies']);
+
+        return $serviceManager->get(View::class);
+    }
+
+    public function testRenderWithDefaultLayoutAndStringTemplate(): void
+    {
+        $view    = self::createView();
+        $content = $view->render('single-variable', ['message' => 'Hey There!']);
+
+        self::assertStringStartsWith('<default-layout>', $content);
+        self::assertStringEndsWith('</default-layout>', trim($content));
+        self::assertStringContainsString('<p>Hey There!</p>', $content);
+    }
+
+    public function testRenderWithSimplePreparedViewModelAndDefaultLayout(): void
+    {
+        $view  = self::createView();
+        $model = new ViewModel(['message' => 'Hey There!']);
+        $model->setTemplate('single-variable');
+
+        $content = $view->render($model);
+
+        self::assertStringStartsWith('<default-layout>', $content);
+        self::assertStringEndsWith('</default-layout>', trim($content));
+        self::assertStringContainsString('<p>Hey There!</p>', $content);
+    }
+
+    public function testVariablesArgumentIsIgnoredWhenAModelIsGiven(): void
+    {
+        $view  = self::createView();
+        $model = new ViewModel(['message' => 'Hey There!']);
+        $model->setTemplate('single-variable');
+
+        $content = $view->render($model, ['message' => 'Something else']);
+
+        self::assertStringStartsWith('<default-layout>', $content);
+        self::assertStringEndsWith('</default-layout>', trim($content));
+        self::assertStringContainsString('<p>Hey There!</p>', $content);
+    }
+
+    public function testStringTemplateWithModelAsVariablesWillOverrideTemplateInModel(): void
+    {
+        $view  = self::createView();
+        $model = new ViewModel(['message' => 'Hey There!']);
+        $model->setTemplate('does-not-exist');
+
+        $content = $view->render('single-variable', $model);
+
+        self::assertStringContainsString('<p>Hey There!</p>', $content);
+    }
+
+    public function testLayoutCanBeDisabledWithStringTemplateArgument(): void
+    {
+        $view    = self::createView();
+        $content = $view->render('single-variable', ['message' => 'Hey There!'], false);
+
+        self::assertStringStartsNotWith('<default-layout>', $content);
+        self::assertStringEndsNotWith('</default-layout>', trim($content));
+        self::assertStringContainsString('<p>Hey There!</p>', $content);
+    }
+
+    public function testLayoutCanBeDisabledWithViewModelArgument(): void
+    {
+        $view  = self::createView();
+        $model = new ViewModel(['message' => 'Hey There!']);
+        $model->setTemplate('single-variable');
+
+        $content = $view->render($model, null, false);
+
+        self::assertStringStartsNotWith('<default-layout>', $content);
+        self::assertStringEndsNotWith('</default-layout>', trim($content));
+        self::assertStringContainsString('<p>Hey There!</p>', $content);
+    }
+
+    public function testLayoutCanBeChangedInsideTemplatesViaTheLayoutViewHelper(): void
+    {
+        $view    = self::createView();
+        $content = $view->render('switch-layout', ['message' => 'Hey There!']);
+
+        self::assertStringStartsWith('<other-layout>', $content);
+        self::assertStringEndsWith('</other-layout>', trim($content));
+        self::assertStringContainsString('<p>Hey There!</p>', $content);
+    }
+
+    public function testLayoutSwitchingInsideTemplatesDoesNotAffectSubsequentRendersUsingTheDefaultLayout(): void
+    {
+        $view          = self::createView();
+        $otherLayout   = $view->render('switch-layout', ['message' => 'Render 1']);
+        $defaultLayout = $view->render('single-variable', ['message' => 'Render 2']);
+
+        self::assertStringStartsWith('<other-layout>', $otherLayout);
+        self::assertStringStartsWith('<default-layout>', $defaultLayout);
+
+        self::assertStringContainsString('<p>Render 1</p>', $otherLayout);
+        self::assertStringContainsString('<p>Render 2</p>', $defaultLayout);
+    }
+
+    public function testBasicNestingOfViewModels(): void
+    {
+        $level2 = (new ViewModel())->setTemplate('basic-nesting-level-2');
+        $level1 = (new ViewModel())->setTemplate('basic-nesting-level-1');
+        $level1->addChild($level2);
+
+        $view    = self::createView();
+        $content = $view->render($level1);
+
+        self::assertStringStartsWith('<default-layout>', $content);
+        self::assertStringContainsString('<level-one>', $content);
+        self::assertStringContainsString('<level-two>', $content);
+    }
+
+    public function testNestedAppendingViewModelsWillBeAggregated(): void
+    {
+        $level1 = (new ViewModel())->setTemplate('basic-nesting-level-1');
+
+        $a = (new ViewModel(['message' => 'Message-A']))
+            ->setTemplate('single-variable')
+            ->setAppend(true);
+        $b = (new ViewModel(['message' => 'Message-B']))
+            ->setTemplate('single-variable')
+            ->setAppend(true);
+
+        $level1->addChild($a);
+        $level1->addChild($b);
+
+        $view    = self::createView();
+        $content = $view->render($level1);
+
+        $expect  = '<default-layout><level-one><p>Message-A</p><p>Message-B</p></level-one></default-layout>';
+        $content = preg_replace('/\s+/', '', $content);
+
+        self::assertSame($expect, $content);
+    }
+
+    public function testMutatingAppendDuringAddChild(): void
+    {
+        $level1 = (new ViewModel())->setTemplate('basic-nesting-level-1');
+
+        $a = (new ViewModel(['message' => 'Message-A']))
+            ->setTemplate('single-variable')
+            ->setAppend(true);
+        $b = (new ViewModel(['message' => 'Message-B']))
+            ->setTemplate('single-variable')
+            ->setAppend(true);
+
+        $level1->addChild($a, null, false);
+        $level1->addChild($b, null, false);
+
+        $view    = self::createView();
+        $content = $view->render($level1);
+
+        $expect  = '<default-layout><level-one><p>Message-B</p></level-one></default-layout>';
+        $content = preg_replace('/\s+/', '', $content);
+
+        self::assertSame($expect, $content);
+    }
+
+    public function testNestedModelsClobberExistingValuesForCaptureToVariableName(): void
+    {
+        $level1 = (new ViewModel([
+            'content' => 'This should be over-written',
+        ]))->setTemplate('basic-nesting-level-1');
+        $a      = (new ViewModel(['message' => 'Message 1']))->setTemplate('single-variable');
+        $level1->addChild($a);
+
+        $view    = self::createView();
+        $content = $view->render($level1);
+
+        self::assertStringContainsString('<p>Message 1</p>', $content);
+        self::assertStringNotContainsString('This should be over-written', $content);
+    }
+
+    public function testExistingStringVariablesWillNotBeClobberedWhenTheChildIsAppending(): void
+    {
+        $level1 = (new ViewModel([
+            'content' => 'This should be retained',
+        ]))->setTemplate('basic-nesting-level-1');
+        $a      = (new ViewModel(['message' => 'Message 1']))->setTemplate('single-variable');
+        $level1->addChild($a, null, true);
+
+        $view    = self::createView();
+        $content = $view->render($level1);
+
+        self::assertStringContainsString('<p>Message 1</p>', $content);
+        self::assertStringContainsString('This should be retained', $content);
+    }
+
+    public function testExistingNonStringVariablesWillBeClobberedWhenTheChildIsAppending(): void
+    {
+        $level1 = (new ViewModel([
+            'content' => ['This array will be clobbered'],
+        ]))->setTemplate('basic-nesting-level-1');
+        $a      = (new ViewModel(['message' => 'Message 1']))->setTemplate('single-variable');
+        $level1->addChild($a, null, true);
+
+        $view    = self::createView();
+        $content = $view->render($level1);
+
+        $expect  = '<default-layout><level-one><p>Message1</p></level-one></default-layout>';
+        $content = preg_replace('/\s+/', '', $content);
+
+        self::assertSame($expect, $content);
+    }
+
+    public function testThatTheViewModelHelperIsMutatedWithTheCurrentModel(): void
+    {
+        /**
+         * This test performs assertions inside the template
+         *
+         * @see ./templates/view/view-model-helper-assertion.phtml
+         */
+
+        $view    = self::createView();
+        $content = $view->render('view-model-helper-assertion', ['message' => 'Message 1']);
+
+        self::assertStringContainsString('<p>Message 1</p>', $content);
+        self::assertStringContainsString('<default-layout>', $content);
+    }
+}

--- a/test/templates/view/basic-nesting-level-1.phtml
+++ b/test/templates/view/basic-nesting-level-1.phtml
@@ -1,0 +1,3 @@
+<level-one>
+    <?= $this->content ?>
+</level-one>

--- a/test/templates/view/basic-nesting-level-2.phtml
+++ b/test/templates/view/basic-nesting-level-2.phtml
@@ -1,0 +1,1 @@
+<level-two></level-two>

--- a/test/templates/view/default-layout.phtml
+++ b/test/templates/view/default-layout.phtml
@@ -1,0 +1,3 @@
+<default-layout>
+    <?= $this->content ?>
+</default-layout>

--- a/test/templates/view/other-layout.phtml
+++ b/test/templates/view/other-layout.phtml
@@ -1,0 +1,3 @@
+<other-layout>
+    <?= $this->content ?>
+</other-layout>

--- a/test/templates/view/single-variable.phtml
+++ b/test/templates/view/single-variable.phtml
@@ -1,0 +1,1 @@
+<p><?= $this->message ?></p>

--- a/test/templates/view/switch-layout.phtml
+++ b/test/templates/view/switch-layout.phtml
@@ -1,0 +1,6 @@
+<?php
+
+$this->layout('layout::other');
+
+?>
+<p><?= $this->message ?></p>

--- a/test/templates/view/view-model-helper-assertion.phtml
+++ b/test/templates/view/view-model-helper-assertion.phtml
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Laminas\View\Helper\ViewModel;
+use Laminas\View\Model\ModelInterface;
+
+use function PHPUnit\Framework\assertInstanceOf;
+use function PHPUnit\Framework\assertNotSame;
+use function PHPUnit\Framework\assertSame;
+
+$helper = $this->viewModel();
+
+assertInstanceOf(ViewModel::class, $helper);
+
+$current = $helper->getCurrent();
+assertInstanceOf(ModelInterface::class, $current);
+
+$layoutModel = $helper->getRoot();
+assertInstanceOf(ModelInterface::class, $layoutModel);
+
+assertNotSame($current, $layoutModel);
+
+$variable = $current->getVariable('message');
+
+assertSame('Message 1', $variable);
+
+?>
+
+<p><?= $this->message ?></p>

--- a/tools/crc/composer.lock
+++ b/tools/crc/composer.lock
@@ -198,16 +198,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.22",
+            "version": "v6.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3"
+                "reference": "9056771b8eca08d026cd3280deeec3cfd99c4d93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3",
-                "reference": "7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9056771b8eca08d026cd3280deeec3cfd99c4d93",
+                "reference": "9056771b8eca08d026cd3280deeec3cfd99c4d93",
                 "shasum": ""
             },
             "require": {
@@ -272,7 +272,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.22"
+                "source": "https://github.com/symfony/console/tree/v6.4.23"
             },
             "funding": [
                 {
@@ -288,7 +288,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-07T07:05:04+00:00"
+            "time": "2025-06-27T19:37:22+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",

--- a/tools/infection/composer.json
+++ b/tools/infection/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "psalm/plugin-phpunit": "^0.19.5",
         "roave/infection-static-analysis-plugin": "^1.38",
-        "vimeo/psalm": "^6.12.0"
+        "vimeo/psalm": "^6.13.0"
     },
     "autoload": {
         "psr-4": {

--- a/tools/infection/composer.lock
+++ b/tools/infection/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0b4b0130f20722727137cf863c6f78a",
+    "content-hash": "261ed06166ceabefe3c31af02399296d",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -2958,16 +2958,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68"
+                "reference": "b9e61a61e39e02dd90944e9115241c7f7e76bfd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
-                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/b9e61a61e39e02dd90944e9115241c7f7e76bfd8",
+                "reference": "b9e61a61e39e02dd90944e9115241c7f7e76bfd8",
                 "shasum": ""
             },
             "require": {
@@ -2999,9 +2999,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.1.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.2.0"
             },
-            "time": "2025-02-19T13:28:12+00:00"
+            "time": "2025-07-13T07:04:09+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3413,16 +3413,16 @@
         },
         {
             "name": "sanmai/pipeline",
-            "version": "6.17",
+            "version": "6.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sanmai/pipeline.git",
-                "reference": "491b172349d77c9e2f2f2aa1791c9de95bfd1abe"
+                "reference": "6d729c0b0c662010d84cdea9b99f90a65ae4cf5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sanmai/pipeline/zipball/491b172349d77c9e2f2f2aa1791c9de95bfd1abe",
-                "reference": "491b172349d77c9e2f2f2aa1791c9de95bfd1abe",
+                "url": "https://api.github.com/repos/sanmai/pipeline/zipball/6d729c0b0c662010d84cdea9b99f90a65ae4cf5e",
+                "reference": "6d729c0b0c662010d84cdea9b99f90a65ae4cf5e",
                 "shasum": ""
             },
             "require": {
@@ -3431,12 +3431,13 @@
             "require-dev": {
                 "ergebnis/composer-normalize": "^2.8",
                 "friendsofphp/php-cs-fixer": "^3.17",
-                "infection/infection": ">=0.10.5",
+                "infection/infection": ">=0.30.3",
                 "league/pipeline": "^0.3 || ^1.0",
-                "phan/phan": ">=1.1",
                 "php-coveralls/php-coveralls": "^2.4.1",
-                "phpstan/phpstan": ">=0.10 <2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2",
                 "phpunit/phpunit": ">=9.4 <12",
+                "sanmai/phpstan-rules": "^0.3.0",
                 "vimeo/psalm": ">=2"
             },
             "type": "library",
@@ -3466,7 +3467,7 @@
             "description": "General-purpose collections pipeline",
             "support": {
                 "issues": "https://github.com/sanmai/pipeline/issues",
-                "source": "https://github.com/sanmai/pipeline/tree/6.17"
+                "source": "https://github.com/sanmai/pipeline/tree/6.21"
             },
             "funding": [
                 {
@@ -3474,7 +3475,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-06-16T07:09:33+00:00"
+            "time": "2025-07-16T04:06:56+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -3613,16 +3614,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.0",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "66c1440edf6f339fd82ed6c7caa76cb006211b44"
+                "reference": "9e27aecde8f506ba0fd1d9989620c04a87697101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/66c1440edf6f339fd82ed6c7caa76cb006211b44",
-                "reference": "66c1440edf6f339fd82ed6c7caa76cb006211b44",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9e27aecde8f506ba0fd1d9989620c04a87697101",
+                "reference": "9e27aecde8f506ba0fd1d9989620c04a87697101",
                 "shasum": ""
             },
             "require": {
@@ -3687,7 +3688,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.0"
+                "source": "https://github.com/symfony/console/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -3703,7 +3704,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-24T10:34:04+00:00"
+            "time": "2025-06-27T19:55:54+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4669,16 +4670,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.12.0",
+            "version": "6.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "cf420941d061a57050b6c468ef2c778faf40aee2"
+                "reference": "70cdf647255a1362b426bb0f522a85817b8c791c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/cf420941d061a57050b6c468ef2c778faf40aee2",
-                "reference": "cf420941d061a57050b6c468ef2c778faf40aee2",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/70cdf647255a1362b426bb0f522a85817b8c791c",
+                "reference": "70cdf647255a1362b426bb0f522a85817b8c791c",
                 "shasum": ""
             },
             "require": {
@@ -4783,7 +4784,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-05-28T12:52:06+00:00"
+            "time": "2025-07-14T09:59:17+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
The 'View Manager' is configured with a default layout template so that it is convenient for users to call `render` and automatically render a template as a 'child model' of a layout.

Also…

- Adds native types to Model interface and implementation
- Re-organises some factories and internal configuration details

TODO

- Docs will need a complete re-work in view of recent MVC decisions
- `ModelInterface` needs further refactoring - for example, making it an iterable of child models is unnecessary. If it should be iterable, better to iterate over variables, i.e. `ModelInterface<string, mixed>`. Additional simplification will be useful so that it is trivial to write implementations instead of extending from `ViewModel`.