### PR TITLE
Ensure Invokable Variables are not Invoked

### DIFF
--- a/test/Renderer/PhpRendererTest.php
+++ b/test/Renderer/PhpRendererTest.php
@@ -112,7 +112,7 @@ final class PhpRendererTest extends TestCase
 
         self::assertStringContainsString(
             '<p></p>',
-            $renderer->render('variable-as-property')
+            $renderer->render('variable-as-property'),
         );
     }
 
@@ -344,6 +344,32 @@ final class PhpRendererTest extends TestCase
         self::assertStringContainsString(
             '<p>Custom Message</p>',
             $this->renderer->render('undefined-variable-condition', ['message' => 'Custom Message']),
+        );
+    }
+
+    public function testThatInvokableObjectsAreNotInvokedOnAccess(): void
+    {
+        $invokable = new class {
+            public function __invoke(): string
+            {
+                return 'INVOKE';
+            }
+
+            public function __toString(): string
+            {
+                return 'STRING';
+            }
+        };
+
+        $content = $this->renderer->render('invokable-variable', ['item' => $invokable]);
+
+        self::assertStringContainsString(
+            '<cast-to-string>STRING</cast-to-string>',
+            $content,
+        );
+        self::assertStringContainsString(
+            '<invoke>INVOKE</invoke>',
+            $content,
         );
     }
 }

--- a/test/Renderer/templates/invokable-variable.phtml
+++ b/test/Renderer/templates/invokable-variable.phtml
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use function PHPUnit\Framework\assertIsCallable;
+use function PHPUnit\Framework\assertIsObject;
+
+$item = $this->item ?? null;
+
+assertIsObject($item);
+assertIsCallable($item);
+
+?>
+
+<cast-to-string><?= $item ?></cast-to-string>
+<invoke><?= $item() ?></invoke>


### PR DESCRIPTION
Adds a test to ensure invokable variables are not automatically invoked on access, as they were in version 2.x

Closes #18

Supersedes #302
