### PR TITLE
Reinstate 'Termination' of View Models

### DIFF
--- a/src/View.php
+++ b/src/View.php
@@ -65,7 +65,7 @@ final class View
             $model = $modelOrTemplate;
         }
 
-        if ($enableLayout) {
+        if ($enableLayout && $model->terminate() !== true) {
             $layoutModel = new ViewModel([]);
             $layoutModel->setTemplate($this->defaultLayoutTemplate);
             $model->setCaptureTo($this->defaultCaptureTo);

--- a/test/ViewTest.php
+++ b/test/ViewTest.php
@@ -113,6 +113,20 @@ final class ViewTest extends TestCase
         self::assertStringContainsString('<p>Hey There!</p>', $content);
     }
 
+    public function testLayoutIsDisabledWhenTheModelIsMarkedAsTerminal(): void
+    {
+        $view  = self::createView();
+        $model = new ViewModel(['message' => 'Hey There!']);
+        $model->setTemplate('single-variable');
+        $model->setTerminal(true);
+
+        $content = $view->render($model);
+
+        self::assertStringStartsNotWith('<default-layout>', $content);
+        self::assertStringEndsNotWith('</default-layout>', trim($content));
+        self::assertStringContainsString('<p>Hey There!</p>', $content);
+    }
+
     public function testLayoutCanBeChangedInsideTemplatesViaTheLayoutViewHelper(): void
     {
         $view    = self::createView();


### PR DESCRIPTION
`ViewModel::setTerminal(true)` should disable automatic layout rendering as it does in view v2 when used as part of MVC

This behaviour disappeared during refactoring so needed re-implementing