### PR TITLE
HelperPluginManager: drop template requirement as the class can be used to retrieve all sort of HelperInterface

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -756,7 +756,6 @@
       <code><![CDATA[($strict is true ? NavigationHelper : NavigationHelper|false)]]></code>
       <code><![CDATA[Navigation]]></code>
       <code><![CDATA[NavigationHelper]]></code>
-      <code><![CDATA[Navigation\PluginManager]]></code>
     </DeprecatedInterface>
     <DeprecatedMethod>
       <code><![CDATA[setRenderer]]></code>
@@ -1206,7 +1205,6 @@
       <code><![CDATA[Menu::class]]></code>
       <code><![CDATA[Menu::class]]></code>
       <code><![CDATA[Menu::class]]></code>
-      <code><![CDATA[PluginManager]]></code>
       <code><![CDATA[Sitemap::class]]></code>
       <code><![CDATA[Sitemap::class]]></code>
       <code><![CDATA[Sitemap::class]]></code>
@@ -1817,7 +1815,6 @@
       <code><![CDATA[validatePlugin]]></code>
     </PossiblyUnusedMethod>
     <PropertyTypeCoercion>
-      <code><![CDATA[$this->initializers]]></code>
       <code><![CDATA[$this->initializers]]></code>
     </PropertyTypeCoercion>
     <UndefinedInterfaceMethod>

--- a/src/Helper/Navigation/PluginManager.php
+++ b/src/Helper/Navigation/PluginManager.php
@@ -18,9 +18,7 @@ use Laminas\View\HelperPluginManager;
  *
  * @deprecated This class has been moved to the `Laminas\Navigation` component and will be removed in 3.0
  *
- * @template InstanceType of HelperInterface|AbstractHelper
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
- * @extends HelperPluginManager<InstanceType>
  */
 class PluginManager extends HelperPluginManager
 {

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -30,7 +30,6 @@ use function sprintf;
  * Helper\HelperInterface. Additionally, it registers a number of default
  * helpers.
  *
- * @template InstanceType of HelperInterface|callable
  * @extends AbstractPluginManager<HelperInterface|callable>
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  * @final


### PR DESCRIPTION
Hello, I'm following the new good deprecation warnings, but this one is wrong IMHO:

```
Method My\View\Helper\Foobar::__construct() has parameter $helperPluginManager with
    generic class Laminas\View\HelperPluginManager but does not specify its types: InstanceType
```

As far as I understand the `@template InstanceType of [...]` annotation on both `PluginManager` and `HelperPluginManager` make no sense because it's their very nature to retrieve all sort of _helpers_ as long as they are a `HelperInterface` type, and this is already enforced by `@extends AbstractPluginManager<HelperInterface|callable>`