### PR TITLE
Allow Passing Child View Models to the Constructor

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.13.0@70cdf647255a1362b426bb0f522a85817b8c791c">
+<files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
   <file src="src/Helper/Escaper/AbstractHelper.php">
     <MixedAssignment>
       <code><![CDATA[$value[$k]]]></code>
@@ -27,10 +27,5 @@
     <MethodSignatureMismatch>
       <code><![CDATA[$id]]></code>
     </MethodSignatureMismatch>
-  </file>
-  <file src="src/Model/ClearableModelInterface.php">
-    <MissingReturnType>
-      <code><![CDATA[clearChildren]]></code>
-    </MissingReturnType>
   </file>
 </files>

--- a/src/Model/ClearableModelInterface.php
+++ b/src/Model/ClearableModelInterface.php
@@ -12,7 +12,7 @@ namespace Laminas\View\Model;
  */
 interface ClearableModelInterface
 {
-    public function clearChildren();
+    public function clearChildren(): static;
 
     public function clearVariables(): static;
 }

--- a/src/Model/ModelInterface.php
+++ b/src/Model/ModelInterface.php
@@ -10,10 +10,9 @@ use IteratorAggregate;
 /**
  * Interface describing a view model.
  *
- * Extends "Countable"; count() should return the number of children attached
- * to the model.
- *
- * Extends "IteratorAggregate"; should allow iterating over children.
+ * Apart from being a container for view variables, view models also aggregate "child" or nested models.
+ * View models allow iteration over child models and they are also countable, yielding the number of child models
+ * attached.
  *
  * @extends IteratorAggregate<int, ModelInterface>
  */

--- a/src/Model/RetrievableChildrenInterface.php
+++ b/src/Model/RetrievableChildrenInterface.php
@@ -7,7 +7,7 @@ namespace Laminas\View\Model;
 /**
  * Interface describing a Retrievable Child Model
  *
- * Models implementing this interface provide a way to get there children by capture
+ * Models implementing this interface provide a way to get their children by capture
  */
 interface RetrievableChildrenInterface
 {

--- a/src/Model/ViewModel.php
+++ b/src/Model/ViewModel.php
@@ -162,14 +162,15 @@ final class ViewModel implements ModelInterface, ClearableModelInterface, Retrie
 
     public function addChild(ModelInterface $child, string|null $captureTo = null, bool|null $append = null): static
     {
-        $this->children[] = $child;
         if ($captureTo !== null) {
-            $child->setCaptureTo($captureTo);
+            $child = $child->setCaptureTo($captureTo);
         }
 
         if ($append !== null) {
-            $child->setAppend($append);
+            $child = $child->setAppend($append);
         }
+
+        $this->children[] = $child;
 
         return $this;
     }

--- a/src/Model/ViewModel.php
+++ b/src/Model/ViewModel.php
@@ -51,16 +51,21 @@ final class ViewModel implements ModelInterface, ClearableModelInterface, Retrie
     private bool $append = false;
 
     /**
-     * @param iterable<string, mixed> $variables
+     * @param iterable<non-empty-string, mixed> $variables
      */
     public function __construct(
         iterable $variables = [],
         private string $template = '',
     ) {
-        $this->variables = array_map(
-            static fn (mixed $value): mixed => $value,
-            is_array($variables) ? $variables : iterator_to_array($variables)
-        );
+        $this->variables = [];
+        foreach ($variables as $name => $variable) {
+            if (! $variable instanceof ModelInterface) {
+                $this->variables[$name] = $variable;
+                continue;
+            }
+
+            $this->addChild($variable, $name, false);
+        }
     }
 
     /**

--- a/src/Model/ViewModel.php
+++ b/src/Model/ViewModel.php
@@ -52,19 +52,20 @@ final class ViewModel implements ModelInterface, ClearableModelInterface, Retrie
 
     /**
      * @param iterable<non-empty-string, mixed> $variables
+     * @param array<non-empty-string, ModelInterface> $children
      */
     public function __construct(
         iterable $variables = [],
         private string $template = '',
+        array $children = [],
     ) {
-        $this->variables = [];
-        foreach ($variables as $name => $variable) {
-            if (! $variable instanceof ModelInterface) {
-                $this->variables[$name] = $variable;
-                continue;
-            }
+        $this->variables = array_map(
+            static fn (mixed $value): mixed => $value,
+            is_array($variables) ? $variables : iterator_to_array($variables)
+        );
 
-            $this->addChild($variable, $name, false);
+        foreach ($children as $captureTo => $child) {
+            $this->addChild($child, $captureTo);
         }
     }
 

--- a/src/View.php
+++ b/src/View.php
@@ -48,7 +48,7 @@ final class View
 
     /**
      * @param non-empty-string|ModelInterface $modelOrTemplate
-     * @param iterable<string, mixed>|null|ModelInterface $variables
+     * @param iterable<non-empty-string, mixed>|null|ModelInterface $variables
      * @throws RenderingFailedException When any exception occurs during render.
      */
     public function render(

--- a/test/Model/TestAsset/Variable.php
+++ b/test/Model/TestAsset/Variable.php
@@ -8,15 +8,15 @@ use ArrayIterator;
 use IteratorAggregate;
 use Traversable;
 
-/** @implements IteratorAggregate<string, mixed> */
+/** @implements IteratorAggregate<non-empty-string, mixed> */
 final class Variable implements IteratorAggregate
 {
-    /** @param array<string, mixed> $data */
+    /** @param array<non-empty-string, mixed> $data */
     public function __construct(private readonly array $data = [])
     {
     }
 
-    /** @return Traversable<string, mixed> */
+    /** @return Traversable<non-empty-string, mixed> */
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->data);

--- a/test/Model/ViewModelTest.php
+++ b/test/Model/ViewModelTest.php
@@ -394,12 +394,11 @@ final class ViewModelTest extends TestCase
         $child1 = new ViewModel();
         $child2 = new ViewModel();
 
-        $model = new ViewModel([
+        $model = new ViewModel([], '', [
             'apples'  => $child1,
             'oranges' => $child2,
         ]);
 
-        self::assertSame([], $model->getVariables());
         self::assertCount(2, $model);
         self::assertSame([$child1, $child2], iterator_to_array($model, false));
         self::assertSame('apples', $child1->captureTo());

--- a/test/Model/ViewModelTest.php
+++ b/test/Model/ViewModelTest.php
@@ -9,9 +9,11 @@ use Laminas\View\Model\ViewModel;
 use LaminasTest\View\Model\TestAsset\Variable;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 use function count;
+use function iterator_to_array;
 
 final class ViewModelTest extends TestCase
 {
@@ -383,5 +385,23 @@ final class ViewModelTest extends TestCase
     {
         $model = new ViewModel();
         self::assertSame($model, $model->addChild(new ViewModel()));
+    }
+
+    #[Test]
+    public function whenViewModelsArePassedInViaTheConstructorTheyAreAddedAsChildren(): void
+    {
+        $child1 = new ViewModel();
+        $child2 = new ViewModel();
+
+        $model = new ViewModel([
+            'apples'  => $child1,
+            'oranges' => $child2,
+        ]);
+
+        self::assertSame([], $model->getVariables());
+        self::assertCount(2, $model);
+        self::assertSame([$child1, $child2], iterator_to_array($model, false));
+        self::assertSame('apples', $child1->captureTo());
+        self::assertSame('oranges', $child2->captureTo());
     }
 }

--- a/test/Model/ViewModelTest.php
+++ b/test/Model/ViewModelTest.php
@@ -155,8 +155,9 @@ final class ViewModelTest extends TestCase
      */
     public function testCanClearChildren(ViewModel $model): void
     {
-        $model->clearChildren();
+        $result = $model->clearChildren();
         self::assertCount(0, $model);
+        self::assertSame($model, $result);
     }
 
     public function testTemplateIsEmptyByDefault(): void
@@ -295,17 +296,17 @@ final class ViewModelTest extends TestCase
 
     /**
      * @psalm-return list<array{
-     *     0: iterable<string, mixed>,
+     *     0: iterable<non-empty-string, mixed>,
      *     1: null|string,
      *     2: null|string,
      * }>
      */
     public static function variableValue(): array
     {
-        /** @var ArrayObject<string, mixed> $arrayObject */
+        /** @var ArrayObject<non-empty-string, mixed> $arrayObject */
         $arrayObject = new ArrayObject(['foo' => 'bar']);
 
-        /** @var ArrayObject<string, mixed> $emptyObject */
+        /** @var ArrayObject<non-empty-string, mixed> $emptyObject */
         $emptyObject = new ArrayObject([]);
 
         return [
@@ -329,7 +330,7 @@ final class ViewModelTest extends TestCase
         ];
     }
 
-    /** @param iterable<string, mixed> $variables */
+    /** @param iterable<non-empty-string, mixed> $variables */
     #[DataProvider('variableValue')]
     public function testGetVariableSetByConstruct(
         iterable $variables,


### PR DESCRIPTION
Allows setting child view models and variables at the same time via the constructor, for example:

```php
$model = new ViewModel([
    'someValue' => 'Fred',
    'foo' => 42,
],
'some-template',
[
    'sidebar' => new ViewModel(['more' => 'stuff']),
    'header' => new ViewModel(['makeIt' => 'groovy']),
]);
```

This would result in a view model that has 2 variables 'someValue' and 'foo', and, 2 child models that would capture to 'sidebar' and 'header' respectively.

