### PR TITLE
Update HeadLink Attributes

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2881,6 +2881,7 @@
       <code><![CDATA[headLink]]></code>
       <code><![CDATA[headLink]]></code>
       <code><![CDATA[headLink]]></code>
+      <code><![CDATA[headLink]]></code>
       <code><![CDATA[offsetSet]]></code>
       <code><![CDATA[plugin]]></code>
     </DeprecatedMethod>

--- a/src/Helper/HeadLink.php
+++ b/src/Helper/HeadLink.php
@@ -47,21 +47,28 @@ class HeadLink extends AbstractStandalone
      * @var string[]
      */
     protected $itemKeys = [
+        'as',
+        'blocking',
         'charset',
+        'crossorigin',
+        'disabled',
+        'extras',
+        'fetchpriority',
         'href',
         'hreflang',
         'id',
+        'imagesizes',
+        'imagesrcset',
+        'integrity',
+        'itemprop',
+        'lang',
         'media',
+        'referrerpolicy',
         'rel',
         'rev',
         'sizes',
-        'type',
         'title',
-        'extras',
-        'itemprop',
-        'crossorigin',
-        'integrity',
-        'as',
+        'type',
     ];
 
     /**

--- a/test/Helper/HeadLinkTest.php
+++ b/test/Helper/HeadLinkTest.php
@@ -467,4 +467,15 @@ final class HeadLinkTest extends TestCase
         $this->helper->headLink(['as' => 'style', 'href' => '/foo/bar.css', 'rel' => 'preload']);
         $this->assertStringContainsString('as="style"', $this->helper->toString());
     }
+
+    public function testFetchPriorityAttributeIsSupported(): void
+    {
+        $this->helper->headLink([
+            'as'            => 'style',
+            'href'          => '/foo/bar.css',
+            'rel'           => 'preload',
+            'fetchpriority' => 'high',
+        ]);
+        $this->assertStringContainsString('fetchpriority="high"', $this->helper->toString());
+    }
 }


### PR DESCRIPTION
Updates the list of acceptable attributes for HeadLink based on https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link and sorts them alphabetically
