### PR TITLE
Allow for View Model Mutations Prior to Rendering

### DIFF
--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Laminas\View\Renderer;
 
 use Laminas\View\Exception\RenderingFailedException;
-use Laminas\View\Helper\ViewModel;
+use Laminas\View\Helper\ViewModel as ViewModelHelper;
 use Laminas\View\HelperPluginManagerInterface;
 use Laminas\View\Model\ModelInterface;
+use Laminas\View\Model\ViewModel;
 use Laminas\View\Resolver\ResolverInterface;
 
-use function is_array;
-use function iterator_to_array;
+use function assert;
 
 final class PhpRenderer implements RendererInterface
 {
@@ -42,9 +42,6 @@ final class PhpRenderer implements RendererInterface
         string|ModelInterface $templateNameOrModel,
         iterable|null $variables = null,
     ): string {
-        /**
-         * Make sure that a template file path can be resolved:
-         */
         $templateName = $templateNameOrModel instanceof ModelInterface
             ? $templateNameOrModel->getTemplate()
             : $templateNameOrModel;
@@ -53,38 +50,37 @@ final class PhpRenderer implements RendererInterface
             throw RenderingFailedException::becauseATemplateWasNotSpecified();
         }
 
-        $filename = $this->templateResolver->resolve($templateName);
-        if ($filename === false) {
-            throw RenderingFailedException::becauseTheTemplateCannotBeResolvedToAFile($templateName);
-        }
+        $viewModel = $templateNameOrModel instanceof ModelInterface
+            ? $templateNameOrModel
+            : new ViewModel($variables ?? [], $templateName);
 
-        /**
-         * Normalise view variables to array<string, mixed>
-         */
-
-        // Given a model instance, its variables take precedence over the $values argument
-        $variables = $templateNameOrModel instanceof ModelInterface
-            ? $templateNameOrModel->getVariables()
-            : $variables ?? [];
-
-        $variables = is_array($variables) ? $variables : iterator_to_array($variables);
-
-        if ($templateNameOrModel instanceof ModelInterface) {
-            $helper = $this->pluginManager->get(ViewModel::class);
-            $helper->setCurrent($templateNameOrModel);
-        }
-
-        $content = (new Template(
-            $filename,
-            $variables,
-            $this->pluginManager,
-            $this->strictVariables,
-        ))();
+        $content = $this->renderModel($viewModel);
 
         if ($this->filter !== null) {
             return ($this->filter)($content);
         }
 
         return $content;
+    }
+
+    private function renderModel(ModelInterface $model): string
+    {
+        $template = $model->getTemplate();
+        assert($template !== '');
+
+        $filename = $this->templateResolver->resolve($template);
+        if ($filename === false) {
+            throw RenderingFailedException::becauseTheTemplateCannotBeResolvedToAFile($template);
+        }
+
+        $helper = $this->pluginManager->get(ViewModelHelper::class);
+        $helper->setCurrent($model);
+
+        return (new Template(
+            $filename,
+            $model->getVariables(),
+            $this->pluginManager,
+            $this->strictVariables,
+        ))();
     }
 }

--- a/src/View.php
+++ b/src/View.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\View;
 
+use Closure;
 use Laminas\View\Exception\RenderingFailedException;
 use Laminas\View\Helper\ViewModel as ViewModelHelper;
 use Laminas\View\Model\ModelInterface;
@@ -16,6 +17,9 @@ final class View
 {
     private readonly ViewModelHelper $viewModelHelper;
 
+    /** @var list<(Closure(ModelInterface): ModelInterface)> */
+    private array $preRenderHandlers;
+
     /**
      * @param non-empty-string $defaultLayoutTemplate
      * @param non-empty-string $defaultCaptureTo
@@ -26,7 +30,8 @@ final class View
         private readonly string $defaultLayoutTemplate,
         private readonly string $defaultCaptureTo,
     ) {
-        $this->viewModelHelper = $this->pluginManager->get(ViewModelHelper::class);
+        $this->viewModelHelper   = $this->pluginManager->get(ViewModelHelper::class);
+        $this->preRenderHandlers = [];
     }
 
     /**
@@ -101,6 +106,21 @@ final class View
 
         $this->viewModelHelper->setCurrent($model);
 
-        return $this->renderer->render($model);
+        return $this->renderer->render($this->beforeRender($model));
+    }
+
+    /** @param Closure(ModelInterface): ModelInterface $handler */
+    public function registerPreRenderHandler(Closure $handler): void
+    {
+        $this->preRenderHandlers[] = $handler;
+    }
+
+    private function beforeRender(ModelInterface $model): ModelInterface
+    {
+        foreach ($this->preRenderHandlers as $handler) {
+            $model = $handler($model);
+        }
+
+        return $model;
     }
 }

--- a/test/Helper/RenderChildModelTest.php
+++ b/test/Helper/RenderChildModelTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Helper;
 
-use Laminas\View\Exception;
 use Laminas\View\Helper\RenderChildModel;
 use Laminas\View\Helper\ViewModel as ViewModelHelper;
 use Laminas\View\HelperPluginManager;
@@ -16,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 final class RenderChildModelTest extends TestCase
 {
     private PhpRenderer $renderer;
-    private ViewModelHelper $viewModelHelper;
     private RenderChildModel $helper;
     private ViewModel $parent;
 
@@ -37,14 +35,14 @@ final class RenderChildModelTest extends TestCase
 
         $plugins = $container->get(HelperPluginManager::class);
 
-        $this->viewModelHelper = $plugins->get(ViewModelHelper::class);
+        $viewModelHelper = $plugins->get(ViewModelHelper::class);
 
         $this->helper = $plugins->get(RenderChildModel::class);
 
         $this->parent = new ViewModel();
         $this->parent->setTemplate('layout');
-        $this->viewModelHelper->setRoot($this->parent);
-        $this->viewModelHelper->setCurrent($this->parent);
+        $viewModelHelper->setRoot($this->parent);
+        $viewModelHelper->setCurrent($this->parent);
     }
 
     public function testRendersEmptyStringWhenUnableToResolveChildModel(): void
@@ -124,13 +122,5 @@ final class RenderChildModelTest extends TestCase
             $result,
             $result
         );
-    }
-
-    public function testAttemptingToRenderWithNoCurrentModelRaisesException(): void
-    {
-        $this->expectException(Exception\RuntimeException::class);
-        $this->expectExceptionMessage('no view model');
-        $this->viewModelHelper->resetState();
-        $this->renderer->render('layout');
     }
 }

--- a/test/ViewTest.php
+++ b/test/ViewTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\View;
 
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\View\ConfigProvider;
+use Laminas\View\Model\ModelInterface;
 use Laminas\View\Model\ViewModel;
 use Laminas\View\View;
 use PHPUnit\Framework\TestCase;
@@ -270,5 +271,35 @@ final class ViewTest extends TestCase
 
         self::assertStringContainsString('<p>Message 1</p>', $content);
         self::assertStringContainsString('<default-layout>', $content);
+    }
+
+    public function testThatArbitraryMutationsCanBeAppliedToTheViewModelPriorToRendering(): void
+    {
+        $view = self::createView();
+
+        $view->registerPreRenderHandler(static fn (ModelInterface $model): ModelInterface
+            => $model->setVariable('message', 'Tricked You!'));
+
+        $content = $view->render('single-variable', ['message' => 'Message 1']);
+
+        self::assertStringContainsString('<p>Tricked You!</p>', $content);
+        self::assertStringNotContainsString('Message 1', $content);
+    }
+
+    public function testThatViewModelMutationsAreAppliedInTheOrderOfRegistration(): void
+    {
+        $view = self::createView();
+
+        $view->registerPreRenderHandler(static fn (ModelInterface $model): ModelInterface =>
+            $model->setVariable('message', 'Kermit'));
+
+        $view->registerPreRenderHandler(static fn (ModelInterface $model): ModelInterface =>
+            $model->setVariable('message', 'Miss Piggy'));
+
+        $content = $view->render('single-variable', ['message' => 'Fozzy Bear']);
+
+        self::assertStringContainsString('<p>Miss Piggy</p>', $content);
+        self::assertStringNotContainsString('Fozzy Bear', $content);
+        self::assertStringNotContainsString('Kermit', $content);
     }
 }


### PR DESCRIPTION
This affordance is primarily for Mezzio so that it becomes feasible to apply default parameters/variables to view models nested with arbitrary depth, without having to duplicate most of the code in `Laminas\View\View`.

From the context of Mezzio Laminas View Renderer, it would do something like:

```php
$this->renderer->registerPreRenderHandler(function (ModelInterface $model): ModelInterface {
    return $this->mergeViewModel($model->getTemplate(), $model);
});
```

This branch is cut from #372 so that will need merging first…