### PR TITLE
Add un-prefixed `@internal` where necessary

### DIFF
--- a/src/Console/TemplateMapGenerator.php
+++ b/src/Console/TemplateMapGenerator.php
@@ -36,6 +36,8 @@ use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
 
 /**
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  */

--- a/src/Factory/Configuration.php
+++ b/src/Factory/Configuration.php
@@ -14,6 +14,8 @@ use function is_string;
 /**
  * Provides consistent retrieval of configuration and individual values based on historic conventions
  *
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  * @psalm-import-type ViewConfigShape from ConfigProvider

--- a/src/Factory/EscaperFactory.php
+++ b/src/Factory/EscaperFactory.php
@@ -8,6 +8,8 @@ use Laminas\Escaper\Escaper;
 use Psr\Container\ContainerInterface;
 
 /**
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  */

--- a/src/Factory/HelperPluginManagerFactory.php
+++ b/src/Factory/HelperPluginManagerFactory.php
@@ -9,6 +9,8 @@ use Laminas\View\HelperPluginManager;
 use Psr\Container\ContainerInterface;
 
 /**
+ * @internal
+ *
  * @psalm-import-type ViewConfigShape from ConfigProvider
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View

--- a/src/HTML/Tag.php
+++ b/src/HTML/Tag.php
@@ -14,6 +14,8 @@ use const CASE_LOWER;
 /**
  * This class is not part of the public API and has no BC guarantees
  *
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  */

--- a/src/Helper/Escaper/AbstractHelper.php
+++ b/src/Helper/Escaper/AbstractHelper.php
@@ -16,6 +16,8 @@ use function trigger_error;
 use const E_USER_DEPRECATED;
 
 /**
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  */

--- a/src/Helper/Placeholder/Container.php
+++ b/src/Helper/Placeholder/Container.php
@@ -23,6 +23,8 @@ use function ob_start;
  *
  * This class is not part of the public API and has no BC guarantees
  *
+ * @internal
+ *
  * @template TValue
  * @implements IteratorAggregate<int, TValue>
  * @psalm-internal Laminas\View

--- a/src/Helper/Service/DoctypeFactory.php
+++ b/src/Helper/Service/DoctypeFactory.php
@@ -10,6 +10,8 @@ use Laminas\View\Helper\Doctype;
 use Psr\Container\ContainerInterface;
 
 /**
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  * @psalm-import-type ViewConfigShape from ConfigProvider

--- a/src/Helper/Service/EscapeHelperFactory.php
+++ b/src/Helper/Service/EscapeHelperFactory.php
@@ -24,6 +24,8 @@ use function sprintf;
 /**
  * This factory is used to generate helpers that have a single constructor argument on an Escaper instance
  *
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  */

--- a/src/Helper/Service/FetchTranslatorFromContainer.php
+++ b/src/Helper/Service/FetchTranslatorFromContainer.php
@@ -8,6 +8,8 @@ use Laminas\Translator\TranslatorInterface;
 use Psr\Container\ContainerInterface;
 
 /**
+ * @internal
+ *
  * @psalm-internal Laminas
  * @psalm-internal LaminasTest
  */

--- a/src/Helper/Service/GenericFactory.php
+++ b/src/Helper/Service/GenericFactory.php
@@ -25,6 +25,8 @@ use function sprintf;
 /**
  * This factory is used to initialise helpers that have common constructor dependencies
  *
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  */

--- a/src/Helper/Service/LayoutFactory.php
+++ b/src/Helper/Service/LayoutFactory.php
@@ -10,6 +10,8 @@ use Laminas\View\HelperPluginManager;
 use Psr\Container\ContainerInterface;
 
 /**
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  */

--- a/src/Helper/Service/PartialFactory.php
+++ b/src/Helper/Service/PartialFactory.php
@@ -9,6 +9,8 @@ use Laminas\View\Renderer\PhpRenderer;
 use Psr\Container\ContainerInterface;
 
 /**
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  */

--- a/src/Helper/Service/PartialLoopFactory.php
+++ b/src/Helper/Service/PartialLoopFactory.php
@@ -10,6 +10,8 @@ use Laminas\View\HelperPluginManager;
 use Psr\Container\ContainerInterface;
 
 /**
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  */

--- a/src/Renderer/PhpRendererFactory.php
+++ b/src/Renderer/PhpRendererFactory.php
@@ -10,6 +10,8 @@ use Laminas\View\Resolver\ResolverInterface;
 use Psr\Container\ContainerInterface;
 
 /**
+ * @internal
+ *
  * @psalm-internal Laminas
  * @psalm-internal LaminasTest
  */

--- a/src/Renderer/Template.php
+++ b/src/Renderer/Template.php
@@ -26,6 +26,8 @@ use function ob_start;
  * phpcs:disable WebimpressCodingStandard.NamingConventions.ValidVariableName
  * phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
  *
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  * @psalm-no-seal-properties Magic properties are retrieved from this class to fetch view variables

--- a/src/Resolver/Factory/AggregateResolverFactory.php
+++ b/src/Resolver/Factory/AggregateResolverFactory.php
@@ -14,6 +14,8 @@ use Laminas\View\Resolver\TemplatePathStack;
 use Psr\Container\ContainerInterface;
 
 /**
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  */

--- a/src/Resolver/Factory/PrefixPathStackResolverFactory.php
+++ b/src/Resolver/Factory/PrefixPathStackResolverFactory.php
@@ -10,6 +10,8 @@ use Laminas\View\Resolver\PrefixPathStackResolver;
 use Psr\Container\ContainerInterface;
 
 /**
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  * @psalm-import-type ViewConfigShape from ConfigProvider

--- a/src/Resolver/Factory/TemplateMapResolverFactory.php
+++ b/src/Resolver/Factory/TemplateMapResolverFactory.php
@@ -10,6 +10,8 @@ use Laminas\View\Resolver\TemplateMapResolver;
 use Psr\Container\ContainerInterface;
 
 /**
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  * @psalm-import-type ViewConfigShape from ConfigProvider

--- a/src/Resolver/Factory/TemplatePathStackResolverFactory.php
+++ b/src/Resolver/Factory/TemplatePathStackResolverFactory.php
@@ -10,6 +10,8 @@ use Laminas\View\Resolver\TemplatePathStack;
 use Psr\Container\ContainerInterface;
 
 /**
+ * @internal
+ *
  * @psalm-internal Laminas\View
  * @psalm-internal LaminasTest\View
  * @psalm-import-type ViewConfigShape from ConfigProvider


### PR DESCRIPTION
Adding `@internal` will signal intent to a wider variety of tools. Keeping `@psalm-internal` with the allowed namespaces prevents Psalm issues in our code base
