### PR TITLE
Prevent ambiguous arguments to `PhpRenderer::render`

### DIFF
--- a/src/Exception/RenderingFailedException.php
+++ b/src/Exception/RenderingFailedException.php
@@ -105,7 +105,7 @@ final class RenderingFailedException extends RuntimeException
     public static function becauseOfAmbiguousArgumentsToPhpRenderer(): self
     {
         return new self(
-            'Passing both view model view variables to render is ambiguous. '
+            'Passing both view model and view variables to render is ambiguous. '
             . 'Either provide just the model, or, a template name and the variables with '
             . 'which to create the model.'
         );

--- a/src/Exception/RenderingFailedException.php
+++ b/src/Exception/RenderingFailedException.php
@@ -101,4 +101,13 @@ final class RenderingFailedException extends RuntimeException
             $templatePath,
         ), 0, $previous);
     }
+
+    public static function becauseOfAmbiguousArgumentsToPhpRenderer(): self
+    {
+        return new self(
+            'Passing both view model view variables to render is ambiguous. '
+            . 'Either provide just the model, or, a template name and the variables with '
+            . 'which to create the model.'
+        );
+    }
 }

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -12,6 +12,8 @@ use Laminas\View\Model\ViewModel;
 use Laminas\View\Resolver\ResolverInterface;
 
 use function assert;
+use function is_object;
+use function iterator_to_array;
 
 final class PhpRenderer implements RendererInterface
 {
@@ -48,6 +50,13 @@ final class PhpRenderer implements RendererInterface
 
         if ($templateName === '') {
             throw RenderingFailedException::becauseATemplateWasNotSpecified();
+        }
+
+        $variablesEmpty = (is_object($variables) ? iterator_to_array($variables, false) : $variables) === []
+            || $variables === null;
+
+        if ($templateNameOrModel instanceof ModelInterface && ! $variablesEmpty) {
+            throw RenderingFailedException::becauseOfAmbiguousArgumentsToPhpRenderer();
         }
 
         $viewModel = $templateNameOrModel instanceof ModelInterface

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -12,8 +12,6 @@ use Laminas\View\Model\ViewModel;
 use Laminas\View\Resolver\ResolverInterface;
 
 use function assert;
-use function is_object;
-use function iterator_to_array;
 
 final class PhpRenderer implements RendererInterface
 {
@@ -52,10 +50,7 @@ final class PhpRenderer implements RendererInterface
             throw RenderingFailedException::becauseATemplateWasNotSpecified();
         }
 
-        $variablesEmpty = (is_object($variables) ? iterator_to_array($variables, false) : $variables) === []
-            || $variables === null;
-
-        if ($templateNameOrModel instanceof ModelInterface && ! $variablesEmpty) {
+        if ($templateNameOrModel instanceof ModelInterface && $variables !== null) {
             throw RenderingFailedException::becauseOfAmbiguousArgumentsToPhpRenderer();
         }
 

--- a/test/Renderer/PhpRendererTest.php
+++ b/test/Renderer/PhpRendererTest.php
@@ -281,12 +281,14 @@ final class PhpRendererTest extends TestCase
         ), $caught->getMessage());
     }
 
-    /** @return list<array{0: iterable<non-empty-string, mixed>}> */
+    /** @return array<string, array{0: iterable<non-empty-string, mixed>}> */
     public static function emptyVariablesArgumentsForAmbiguity(): array
     {
         return [
-            [['message' => 'Whatever']],
-            [new ArrayObject(['message' => 'Whatever'])],
+            'Non-empty array'    => [['message' => 'Whatever']],
+            'Non-empty iterable' => [new ArrayObject(['message' => 'Whatever'])],
+            'Empty array'        => [[]],
+            'Empty iterable'     => [new ArrayObject([])],
         ];
     }
 

--- a/test/Renderer/PhpRendererTest.php
+++ b/test/Renderer/PhpRendererTest.php
@@ -300,7 +300,7 @@ final class PhpRendererTest extends TestCase
 
         $this->expectException(RenderingFailedException::class);
         $this->expectExceptionMessage(
-            'Passing both view model view variables to render is ambiguous. '
+            'Passing both view model and view variables to render is ambiguous. '
             . 'Either provide just the model, or, a template name and the variables with '
             . 'which to create the model.',
         );

--- a/test/Renderer/PhpRendererTest.php
+++ b/test/Renderer/PhpRendererTest.php
@@ -281,15 +281,28 @@ final class PhpRendererTest extends TestCase
         ), $caught->getMessage());
     }
 
-    public function testVariablesArgumentIsIgnoredWhenAViewModelIsGiven(): void
+    /** @return list<array{0: iterable<non-empty-string, mixed>}> */
+    public static function emptyVariablesArgumentsForAmbiguity(): array
     {
-        $model = new ViewModel(['message' => 'View Model Variable']);
-        $model->setTemplate('variable-as-property');
+        return [
+            [['message' => 'Whatever']],
+            [new ArrayObject(['message' => 'Whatever'])],
+        ];
+    }
 
-        self::assertStringContainsString(
-            '<p>View Model Variable</p>',
-            $this->renderer->render($model, ['message' => 'Variable from arguments']),
+    /** @param iterable<non-empty-string, mixed> $variables */
+    #[DataProvider('emptyVariablesArgumentsForAmbiguity')]
+    public function testVariablesArgumentIsExceptionalWhenAViewModelIsGiven(iterable $variables): void
+    {
+        $model = new ViewModel(['message' => 'View Model Variable'], 'variable-as-property');
+
+        $this->expectException(RenderingFailedException::class);
+        $this->expectExceptionMessage(
+            'Passing both view model view variables to render is ambiguous. '
+            . 'Either provide just the model, or, a template name and the variables with '
+            . 'which to create the model.',
         );
+        $this->renderer->render($model, $variables);
     }
 
     public function testSharedInstanceHelper(): void


### PR DESCRIPTION
`PhpRenderer::render` should be called with `(ViewModel)` or `(string, iterable)`.

When called with `(ViewModel, iterable)`, an exception will now be thrown instead of silently ignoring the `iterable` representing the view variables.

This will be useful signalling to users because in previous versions, the view model and the given variables would have been merged.

