### PR TITLE
Deprecate the `RenderChildModel` Helper

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3835,6 +3835,10 @@
     </DeprecatedMethod>
   </file>
   <file src="test/Helper/RenderChildModelTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[RenderChildModel]]></code>
+      <code><![CDATA[RenderChildModel::class]]></code>
+    </DeprecatedClass>
     <DeprecatedMethod>
       <code><![CDATA[plugin]]></code>
       <code><![CDATA[plugin]]></code>

--- a/src/Helper/RenderChildModel.php
+++ b/src/Helper/RenderChildModel.php
@@ -16,6 +16,9 @@ use function sprintf;
  * Finds children matching "capture-to" values, and renders them using the
  * composed view instance.
  *
+ * @deprecated Since 2.44.0. This helper will be removed in 3.0.0. Its functionality will be a default feature of nested
+ *             view rendering in 3.0.0 and is therefore no longer useful.
+ *
  * @final
  */
 class RenderChildModel extends AbstractHelper


### PR DESCRIPTION
Closes #386

