### PR TITLE
Add defensive check for empty strings to `ViewModel::setCaptureTo()`

### DIFF
--- a/src/Model/ViewModel.php
+++ b/src/Model/ViewModel.php
@@ -217,7 +217,7 @@ final class ViewModel implements ModelInterface, ClearableModelInterface, Retrie
     {
         /** @psalm-suppress TypeDoesNotContainType Adding a defensive check here regardless of documented types */
         if ($capture === '') {
-            throw new InvalidArgumentException('The `capture` name cannot be an empty string');
+            throw new InvalidArgumentException('The `capture` target cannot be an empty string');
         }
 
         $this->captureTo = $capture;

--- a/src/Model/ViewModel.php
+++ b/src/Model/ViewModel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\View\Model;
 
 use ArrayIterator;
+use Laminas\View\Exception\InvalidArgumentException;
 use Traversable;
 
 use function array_key_exists;
@@ -214,6 +215,11 @@ final class ViewModel implements ModelInterface, ClearableModelInterface, Retrie
 
     public function setCaptureTo(string $capture): static
     {
+        /** @psalm-suppress TypeDoesNotContainType Adding a defensive check here regardless of documented types */
+        if ($capture === '') {
+            throw new InvalidArgumentException('The `capture` name cannot be an empty string');
+        }
+
         $this->captureTo = $capture;
         return $this;
     }

--- a/test/Model/ViewModelTest.php
+++ b/test/Model/ViewModelTest.php
@@ -408,7 +408,7 @@ final class ViewModelTest extends TestCase
     {
         $model = new ViewModel();
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The `capture` name cannot be an empty string');
+        $this->expectExceptionMessage('The `capture` target cannot be an empty string');
         /** @psalm-suppress InvalidArgument */
         $model->setCaptureTo('');
     }

--- a/test/Model/ViewModelTest.php
+++ b/test/Model/ViewModelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\View\Model;
 
 use ArrayObject;
+use Laminas\View\Exception\InvalidArgumentException;
 use Laminas\View\Model\ViewModel;
 use LaminasTest\View\Model\TestAsset\Variable;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -401,5 +402,14 @@ final class ViewModelTest extends TestCase
         self::assertSame([$child1, $child2], iterator_to_array($model, false));
         self::assertSame('apples', $child1->captureTo());
         self::assertSame('oranges', $child2->captureTo());
+    }
+
+    public function testCaptureToCannotBeSetToAnEmptyString(): void
+    {
+        $model = new ViewModel();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The `capture` name cannot be an empty string');
+        /** @psalm-suppress InvalidArgument */
+        $model->setCaptureTo('');
     }
 }


### PR DESCRIPTION
Closes #384
