### PR TITLE
Introduce `ViewInterface`

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -174,6 +174,7 @@ final readonly class ConfigProvider
                 HelperPluginManagerInterface::class => HelperPluginManager::class,
                 Renderer\RendererInterface::class   => Renderer\PhpRenderer::class,
                 Resolver\ResolverInterface::class   => Resolver\AggregateResolver::class,
+                ViewInterface::class                => View::class,
             ],
         ];
     }

--- a/src/View.php
+++ b/src/View.php
@@ -13,7 +13,7 @@ use Laminas\View\Renderer\RendererInterface;
 
 use function is_string;
 
-final class View
+final class View implements ViewInterface
 {
     private readonly ViewModelHelper $viewModelHelper;
 
@@ -34,14 +34,7 @@ final class View
         $this->preRenderHandlers = [];
     }
 
-    /**
-     * Render a configured top-level layout view model
-     *
-     * It is expected that the given model will have a non-empty template configured and all necessary variables and
-     * child models set.
-     *
-     * @throws RenderingFailedException When any exception occurs during render.
-     */
+    /** @inheritDoc */
     public function renderLayout(ModelInterface $layout): string
     {
         $this->viewModelHelper->setRoot($layout);
@@ -51,11 +44,7 @@ final class View
         return $content;
     }
 
-    /**
-     * @param non-empty-string|ModelInterface $modelOrTemplate
-     * @param iterable<non-empty-string, mixed>|null|ModelInterface $variables
-     * @throws RenderingFailedException When any exception occurs during render.
-     */
+    /** @inheritDoc */
     public function render(
         string|ModelInterface $modelOrTemplate,
         iterable|ModelInterface|null $variables = null,

--- a/src/ViewInterface.php
+++ b/src/ViewInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\View;
+
+use Laminas\View\Exception\RenderingFailedException;
+use Laminas\View\Model\ModelInterface;
+
+interface ViewInterface
+{
+    /**
+     * Render a template
+     *
+     * Unless layout is disabled, the template will be "wrapped" in the configured layout
+     *
+     * @param non-empty-string|ModelInterface $modelOrTemplate
+     * @param iterable<non-empty-string, mixed>|null|ModelInterface $variables
+     * @throws RenderingFailedException When any exception occurs during render.
+     */
+    public function render(
+        string|ModelInterface $modelOrTemplate,
+        iterable|ModelInterface|null $variables = null,
+        bool $enableLayout = true,
+    ): string;
+
+    /**
+     * Render a configured top-level layout view model
+     *
+     * It is expected that the given model will have a non-empty template configured and all necessary variables and
+     * child models set.
+     *
+     * @throws RenderingFailedException When any exception occurs during render.
+     */
+    public function renderLayout(ModelInterface $layout): string;
+}


### PR DESCRIPTION
Because `View` is final, we should ship `ViewInterface` so it can be replaced with user-defined implementations and more easily mocked in tests.

Hopefully, this is one of the final patches before releasing 3.0