### PR TITLE
Ensure that all factories can handle iterables for the `config` service

### DIFF
--- a/src/Factory/Configuration.php
+++ b/src/Factory/Configuration.php
@@ -7,9 +7,10 @@ namespace Laminas\View\Factory;
 use Laminas\View\ConfigProvider;
 use Psr\Container\ContainerInterface;
 
-use function is_array;
 use function is_bool;
+use function is_iterable;
 use function is_string;
+use function iterator_to_array;
 
 /**
  * Provides consistent retrieval of configuration and individual values based on historic conventions
@@ -36,7 +37,7 @@ final readonly class Configuration
             ? $container->get('config')
             : [];
 
-        return is_array($config) ? $config : [];
+        return is_iterable($config) ? iterator_to_array($config) : [];
     }
 
     /**

--- a/src/Helper/Service/AssetFactory.php
+++ b/src/Helper/Service/AssetFactory.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Laminas\View\Helper\Service;
 
 use Laminas\View\Exception\RuntimeException;
+use Laminas\View\Factory\Configuration;
 use Laminas\View\Helper\Asset;
 use Psr\Container\ContainerInterface;
-use Traversable;
 
 use function gettype;
 use function is_array;
-use function iterator_to_array;
 use function sprintf;
 
 /**
@@ -27,11 +26,7 @@ final readonly class AssetFactory
      */
     public function __invoke(ContainerInterface $container): Asset
     {
-        /** @psalm-var mixed $config */
-        $config = $container->get('config');
-        /** @psalm-var mixed $config */
-        $config = $config instanceof Traversable ? iterator_to_array($config, true) : $config;
-        $config = is_array($config) ? $config : [];
+        $config = Configuration::get($container);
 
         $helperConfig = $this->assertArray('view_helper_config', $config);
         $helperConfig = $this->assertArray('asset', $helperConfig);

--- a/src/Helper/Service/HeadTitleFactory.php
+++ b/src/Helper/Service/HeadTitleFactory.php
@@ -6,10 +6,10 @@ namespace Laminas\View\Helper\Service;
 
 use Laminas\Escaper\Escaper;
 use Laminas\Escaper\EscaperInterface;
+use Laminas\View\Factory\Configuration;
 use Laminas\View\Helper\HeadTitle;
 use Psr\Container\ContainerInterface;
 
-use function assert;
 use function is_array;
 use function is_bool;
 use function is_string;
@@ -24,11 +24,7 @@ final readonly class HeadTitleFactory
 {
     public function __invoke(ContainerInterface $container): HeadTitle
     {
-        $config = $container->has('config')
-            ? $container->get('config')
-            : [];
-
-        assert(is_array($config));
+        $config = Configuration::get($container);
 
         $options = $this->resolveOptions($config);
 

--- a/test/Factory/ConfigurationTest.php
+++ b/test/Factory/ConfigurationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Factory;
 
+use ArrayObject;
 use Laminas\View\Factory\Configuration;
 use LaminasTest\View\TestAsset\InMemoryContainer;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +15,14 @@ final class ConfigurationTest extends TestCase
     {
         $container = new InMemoryContainer();
         $container->set('config', ['foo']);
+
+        self::assertSame(['foo'], Configuration::get($container));
+    }
+
+    public function testGetReturnsConfigWhenItIsAnObject(): void
+    {
+        $container = new InMemoryContainer();
+        $container->set('config', new ArrayObject(['foo']));
 
         self::assertSame(['foo'], Configuration::get($container));
     }

--- a/test/Helper/AssetTest.php
+++ b/test/Helper/AssetTest.php
@@ -76,6 +76,10 @@ final class AssetTest extends TestCase
     {
         $services = $this->createMock(ServiceManager::class);
         $services->expects(self::atLeast(1))
+            ->method('has')
+            ->with('config')
+            ->willReturn(true);
+        $services->expects(self::atLeast(1))
             ->method('get')
             ->with('config')
             ->willReturn($config);

--- a/test/Helper/Service/AssetFactoryTest.php
+++ b/test/Helper/Service/AssetFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Helper\Service;
 
+use ArrayObject;
 use Laminas\View\Exception\RuntimeException;
 use Laminas\View\Helper\Asset;
 use Laminas\View\Helper\Service\AssetFactory;
@@ -86,19 +87,32 @@ final class AssetFactoryTest extends TestCase
         ];
     }
 
-    /** @param array<string, mixed> $config */
+    /** @return iterable<string, array{0: ArrayObject<string, mixed>}> */
+    public static function validConfigAsArrayObjectProvider(): iterable
+    {
+        foreach (self::validConfigProvider() as $key => $args) {
+            yield $key . ' (ArrayObject)' => [new ArrayObject($args[0])];
+        }
+    }
+
+    /** @param iterable<string, mixed> $config */
     #[DataProvider('validConfigProvider')]
-    public function testThatAnExceptionWillNotBeThrownWhenGivenUnsetOrEmptyArrayConfiguration(array $config): void
+    #[DataProvider('validConfigAsArrayObjectProvider')]
+    public function testThatAnExceptionWillNotBeThrownWhenGivenUnsetOrEmptyArrayConfiguration(iterable $config): void
     {
         $container = $this->getServices($config);
         (new AssetFactory())($container);
         self::assertTrue(true);
     }
 
-    /** @param array<string, mixed> $config */
-    private function getServices(array $config = []): ContainerInterface
+    /** @param iterable<string, mixed> $config */
+    private function getServices(iterable $config = []): ContainerInterface
     {
         $services = $this->createMock(ContainerInterface::class);
+        $services->expects(self::once())
+            ->method('has')
+            ->with('config')
+            ->willReturn(true);
         $services->expects(self::once())
             ->method('get')
             ->with('config')

--- a/test/Helper/Service/HeadTitleFactoryTest.php
+++ b/test/Helper/Service/HeadTitleFactoryTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace LaminasTest\View\Helper\Service;
 
+use ArrayObject;
 use Laminas\View\Helper\Service\HeadTitleFactory;
 use LaminasTest\View\TestAsset\InMemoryContainer;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+
+use function is_array;
 
 final class HeadTitleFactoryTest extends TestCase
 {
@@ -69,12 +72,25 @@ final class HeadTitleFactoryTest extends TestCase
         ];
     }
 
+    /** @return iterable<string, array{0: ArrayObject<array-key, mixed>|null, 1: list<string>, 2: string}> */
+    public static function configScenariosAsArrayObjects(): iterable
+    {
+        foreach (self::configScenarios() as $key => $args) {
+            yield $key . ' (ArrayObject)' => [
+                is_array($args[0]) ? new ArrayObject($args[0]) : $args[0],
+                $args[1],
+                $args[2],
+            ];
+        }
+    }
+
     /**
-     * @param array<array-key, mixed>|null $config
+     * @param iterable<array-key, mixed>|null $config
      * @param list<string> $append
      */
     #[DataProvider('configScenarios')]
-    public function testFactory(array|null $config, array $append, string $expect): void
+    #[DataProvider('configScenariosAsArrayObjects')]
+    public function testFactory(iterable|null $config, array $append, string $expect): void
     {
         $container = new InMemoryContainer();
         if ($config !== null) {


### PR DESCRIPTION
Infrequently, the `config` service might be some kind of iterable such as an `ArrayObject`.

This patch ensures that all factories can still operate, and extract the correct configuration when this is the case
