### PR TITLE
Fix (docs) argument order in view render method

### DIFF
--- a/docs/book/v3/quick-start.md
+++ b/docs/book/v3/quick-start.md
@@ -127,7 +127,7 @@ final class ExamplePageHandler implements RequestHandlerInterface
             'greeting' => 'Hello',
             'name' => 'World',
         ];
-        $markup = $this->view->render($variables, 'pages/greeting');
+        $markup = $this->view->render('pages/greeting', $variables);
         
         return new HtmlResponse($markup);
     }


### PR DESCRIPTION
Quick start documentation error.

Reference:

https://github.com/laminas/laminas-view/blob/c7f8af6e20a46306fe577cf730474a337ce4d1fd/src/View.php#L48-L52
