### PR TITLE
Add support for `laminas-translator@2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "laminas/laminas-escaper": "^2.17.0",
         "laminas/laminas-servicemanager": "^4.4.0",
         "laminas/laminas-stdlib": "^3.10.1",
-        "laminas/laminas-translator": "^1.1",
+        "laminas/laminas-translator": "^1.1 || ^2.0",
         "psr/container": "^1 || ^2"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "13ee5bc560a6ed64d14cb4b97b3f6859",
+    "content-hash": "8aff93455a4009f19fad42009e02a5e7",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -262,16 +262,16 @@
         },
         {
             "name": "laminas/laminas-translator",
-            "version": "1.3.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-translator.git",
-                "reference": "1d6bf7d857c3fc310a30f5ea028731b9bf8be9db"
+                "reference": "0169180f44f3d3273bd9a7b00e23ad6b0b870f17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/1d6bf7d857c3fc310a30f5ea028731b9bf8be9db",
-                "reference": "1d6bf7d857c3fc310a30f5ea028731b9bf8be9db",
+                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/0169180f44f3d3273bd9a7b00e23ad6b0b870f17",
+                "reference": "0169180f44f3d3273bd9a7b00e23ad6b0b870f17",
                 "shasum": ""
             },
             "require": {
@@ -279,8 +279,8 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~3.1.0",
-                "phpunit/phpunit": "^11.5.46",
-                "vimeo/psalm": "^6.14.3"
+                "phpunit/phpunit": "^11.5.55",
+                "vimeo/psalm": "^6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -312,7 +312,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-12-30T14:26:45+00:00"
+            "time": "2026-06-02T11:36:39+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/test/Helper/HeadTitleTest.php
+++ b/test/Helper/HeadTitleTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\View\Helper;
 
 use Laminas\Translator\TranslatorInterface;
 use Laminas\View\Helper\HeadTitle;
+use LaminasTest\View\TestAsset\TranslatorStubFactory;
 use PHPUnit\Framework\TestCase;
 
 final class HeadTitleTest extends TestCase
@@ -128,24 +129,13 @@ final class HeadTitleTest extends TestCase
 
     private function getTranslator(): TranslatorInterface
     {
-        return new class implements TranslatorInterface
-        {
-            /** @inheritDoc */
-            public function translate($message, $textDomain = 'default', $locale = null)
-            {
-                return match ($message) {
-                    'Foo' => 'Kermit',
-                    'Bar' => 'Fozzy Bear',
-                    default => 'Gonzo',
-                };
-            }
-
-            /** @inheritDoc */
-            public function translatePlural($singular, $plural, $number, $textDomain = 'default', $locale = null)
-            {
-                return 'Unused Method';
-            }
+        $matcher = fn (string $message): string => match ($message) {
+            'Foo' => 'Kermit',
+            'Bar' => 'Fozzy Bear',
+            default => 'Gonzo',
         };
+
+        return (new TranslatorStubFactory())->getTranslator($matcher);
     }
 
     public function testCanTranslateTitle(): void

--- a/test/Helper/Service/FetchTranslatorFromContainerTest.php
+++ b/test/Helper/Service/FetchTranslatorFromContainerTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\View\Helper\Service;
 use Laminas\Translator\TranslatorInterface;
 use Laminas\View\Helper\Service\FetchTranslatorFromContainer;
 use LaminasTest\View\TestAsset\InMemoryContainer;
+use LaminasTest\View\TestAsset\TranslatorStubFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -17,18 +18,7 @@ final class FetchTranslatorFromContainerTest extends TestCase
 {
     private static function makeTranslator(): TranslatorInterface
     {
-        return new class implements TranslatorInterface
-        {
-            public function translate($message, $textDomain = 'default', $locale = null) // phpcs:ignore
-            {
-                return $message;
-            }
-
-            public function translatePlural($singular, $plural, $number, $textDomain = 'default', $locale = null) // phpcs:ignore
-            {
-                return $singular;
-            }
-        };
+        return (new TranslatorStubFactory())->getTranslator();
     }
 
     /** @return iterable<string, array{0: array<string, object>, 1: TranslatorInterface|null}> */

--- a/test/TestAsset/TranslatorStubFactory.php
+++ b/test/TestAsset/TranslatorStubFactory.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\View\TestAsset;
+
+use Closure;
+use Laminas\Translator\TranslatorInterface;
+use ReflectionClass;
+use ReflectionParameter;
+
+use function assert;
+
+final readonly class TranslatorStubFactory
+{
+    /** @param (Closure(string):string)|null $messageMatcher */
+    public function getTranslator(Closure|null $messageMatcher = null): TranslatorInterface
+    {
+        $messageMatcher ??= fn (string $message): string => $message;
+        $reflection       = new ReflectionClass(TranslatorInterface::class);
+        $method           = $reflection->getMethod('translate');
+        $parameter        = $method->getParameters()[0] ?? null;
+        assert($parameter instanceof ReflectionParameter);
+
+        if (! $parameter->hasType()) {
+            return $this->v1Stub($messageMatcher);
+        }
+
+        return $this->v2Stub($messageMatcher);
+    }
+
+    /** @param Closure(string):string $messageMatcher */
+    private function v1Stub(Closure $messageMatcher): TranslatorInterface
+    {
+        /** @psalm-suppress MissingParamType,MixedArgument,MethodSignatureMismatch,UnusedPsalmSuppress */
+        return new class ($messageMatcher) implements TranslatorInterface
+        {
+            /** @param Closure(string):string $messageMatcher */
+            public function __construct(private readonly Closure $messageMatcher)
+            {
+            }
+
+            /**
+             * @inheritDoc
+             * @psalm-suppress MethodSignatureMismatch
+             */
+            public function translate($message, $textDomain = 'default', $locale = null)
+            {
+                return ($this->messageMatcher)($message);
+            }
+
+            /**
+             * @inheritDoc
+             * @psalm-suppress MethodSignatureMismatch
+             */
+            public function translatePlural($singular, $plural, $number, $textDomain = 'default', $locale = null)
+            {
+                return ($this->messageMatcher)($singular);
+            }
+        };
+    }
+
+    /** @param Closure(string):string $messageMatcher */
+    private function v2Stub(Closure $messageMatcher): TranslatorInterface
+    {
+        return new class ($messageMatcher) implements TranslatorInterface
+        {
+            /** @param Closure(string):string $messageMatcher */
+            public function __construct(private readonly Closure $messageMatcher)
+            {
+            }
+
+            /** @inheritDoc */
+            public function translate(
+                string $message,
+                string $textDomain = 'default',
+                string|null $locale = null,
+            ): string {
+                return ($this->messageMatcher)($message);
+            }
+
+            /** @inheritDoc */
+            public function translatePlural(
+                string $singular,
+                string $plural,
+                int $number,
+                string $textDomain = 'default',
+                string|null $locale = null,
+            ): string {
+                return ($this->messageMatcher)($singular);
+            }
+        };
+    }
+}

--- a/tools/infection/composer.json
+++ b/tools/infection/composer.json
@@ -13,7 +13,7 @@
         "laminas/laminas-escaper": "^2.18.0",
         "laminas/laminas-servicemanager": "^4.5.1",
         "laminas/laminas-stdlib": "^3.21.0",
-        "laminas/laminas-translator": "^1.3",
+        "laminas/laminas-translator": "^1.3 || ^2.0",
         "psr/container": "^1 || ^2.0.2"
     },
     "require-dev": {

--- a/tools/infection/composer.lock
+++ b/tools/infection/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "530d43a961798a243292ea4d1bd65cff",
+    "content-hash": "0a91659f08580ecb663d359ab05c50eb",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -262,16 +262,16 @@
         },
         {
             "name": "laminas/laminas-translator",
-            "version": "1.3.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-translator.git",
-                "reference": "1d6bf7d857c3fc310a30f5ea028731b9bf8be9db"
+                "reference": "0169180f44f3d3273bd9a7b00e23ad6b0b870f17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/1d6bf7d857c3fc310a30f5ea028731b9bf8be9db",
-                "reference": "1d6bf7d857c3fc310a30f5ea028731b9bf8be9db",
+                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/0169180f44f3d3273bd9a7b00e23ad6b0b870f17",
+                "reference": "0169180f44f3d3273bd9a7b00e23ad6b0b870f17",
                 "shasum": ""
             },
             "require": {
@@ -279,8 +279,8 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~3.1.0",
-                "phpunit/phpunit": "^11.5.46",
-                "vimeo/psalm": "^6.14.3"
+                "phpunit/phpunit": "^11.5.55",
+                "vimeo/psalm": "^6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -312,7 +312,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-12-30T14:26:45+00:00"
+            "time": "2026-06-02T11:36:39+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/tools/rector/rector.php
+++ b/tools/rector/rector.php
@@ -13,6 +13,7 @@ return RectorConfig::configure()
         __DIR__ . '/../../src',
         __DIR__ . '/../../test',
     ])
+    ->withSkipPath(__DIR__ . '/../../test/TestAsset/TranslatorStubFactory.php')
     ->withPreparedSets(
         typeDeclarations: true,
     )->withSkip([


### PR DESCRIPTION
Adds a factory for tests to produce a v1 or v2 stub by inspecting the method signature of the installed interface. It's kinda messy, but means we can continue to test using both versions.